### PR TITLE
修复系统框架中没有默认处理钱包功能导致钱包测试用例过不了的BUG

### DIFF
--- a/types/reflect.go
+++ b/types/reflect.go
@@ -7,6 +7,7 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -231,7 +232,7 @@ func NewQueryData(prefix string) *QueryData {
 
 func (q *QueryData) Register(key string, obj interface{}) {
 	if _, existed := q.funcMap[key]; existed {
-		panic("QueryData reg dup")
+		panic(fmt.Sprintf("QueryData Register dup for key=%s", key))
 	}
 	q.funcMap[key], q.typeMap[key] = BuildQueryType(q.prefix, ListMethod(obj))
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -146,7 +146,6 @@ func SaveAccountTomavl(client queue.Client, prevStateRoot []byte, accs []*types.
 }
 
 func TestWallet(t *testing.T) {
-	t.Skip()
 	wallet, store, q := initEnv()
 	defer wallet.Close()
 	defer store.Close()
@@ -648,7 +647,7 @@ func testProcWalletLock(t *testing.T, wallet *Wallet) {
 	wallet.client.Send(msg, true)
 	resp, _ = wallet.client.Wait(msg)
 	status = resp.GetData().(*types.WalletStatus)
-	if !status.IsHasSeed || status.IsAutoMining || !status.IsWalletLock || status.IsTicketLock {
+	if !status.IsHasSeed || status.IsAutoMining || !status.IsWalletLock {
 		t.Error("testGetWalletStatus failed")
 	}
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -636,7 +636,7 @@ func testProcWalletLock(t *testing.T, wallet *Wallet) {
 	wallet.client.Send(msg, true)
 	resp, _ = wallet.client.Wait(msg)
 	status := resp.GetData().(*types.WalletStatus)
-	if !status.IsHasSeed || status.IsAutoMining || !status.IsWalletLock {
+	if !status.IsHasSeed || status.IsAutoMining || !status.IsWalletLock || (walletUnLock.GetWalletOrTicket() && status.IsTicketLock) {
 		t.Error("testGetWalletStatus failed")
 	}
 

--- a/wallet/walletbizpolicy.go
+++ b/wallet/walletbizpolicy.go
@@ -1,0 +1,156 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"sync"
+
+	"github.com/33cn/chain33/common/crypto"
+	"github.com/33cn/chain33/common/db"
+	"github.com/33cn/chain33/types"
+	wcom "github.com/33cn/chain33/wallet/common"
+)
+
+const (
+	walletBizPolicyX = "walletBizPolicy"
+)
+
+func init() {
+	wcom.RegisterPolicy(walletBizPolicyX, newPolicy())
+}
+
+func newPolicy() wcom.WalletBizPolicy {
+	ret := &walletBizPlicy{
+		mtx: &sync.Mutex{},
+	}
+	return ret
+}
+
+// 默认的钱包业务实现
+type walletBizPlicy struct {
+	mtx           *sync.Mutex
+	walletOperate wcom.WalletOperate
+}
+
+func (this *walletBizPlicy) Init(walletBiz wcom.WalletOperate, sub []byte) {
+	this.setWalletOperate(walletBiz)
+}
+
+func (this *walletBizPlicy) setWalletOperate(walletBiz wcom.WalletOperate) {
+	this.mtx.Lock()
+	defer this.mtx.Unlock()
+	this.walletOperate = walletBiz
+}
+
+func (this *walletBizPlicy) getWalletOperate() wcom.WalletOperate {
+	this.mtx.Lock()
+	defer this.mtx.Unlock()
+	return this.walletOperate
+}
+
+func (this *walletBizPlicy) OnAddBlockTx(block *types.BlockDetail, tx *types.Transaction, index int32, dbbatch db.Batch) *types.WalletTxDetail {
+	return nil
+}
+
+func (this *walletBizPlicy) OnDeleteBlockTx(block *types.BlockDetail, tx *types.Transaction, index int32, dbbatch db.Batch) *types.WalletTxDetail {
+	return nil
+}
+
+func (this *walletBizPlicy) SignTransaction(key crypto.PrivKey, req *types.ReqSignRawTx) (needSysSign bool, signtx string, err error) {
+	needSysSign = true
+	return
+}
+
+func (this *walletBizPlicy) OnCreateNewAccount(acc *types.Account) {
+	wg := this.getWalletOperate().GetWaitGroup()
+	wg.Add(1)
+	go this.rescanReqTxDetailByAddr(acc.Addr, wg)
+}
+
+func (this *walletBizPlicy) OnImportPrivateKey(acc *types.Account) {
+	wg := this.getWalletOperate().GetWaitGroup()
+	wg.Add(1)
+	go this.rescanReqTxDetailByAddr(acc.Addr, wg)
+}
+
+func (this *walletBizPlicy) OnWalletLocked() {
+}
+
+func (this *walletBizPlicy) OnWalletUnlocked(WalletUnLock *types.WalletUnLock) {
+}
+
+func (this *walletBizPlicy) OnAddBlockFinish(block *types.BlockDetail) {
+}
+
+func (this *walletBizPlicy) OnDeleteBlockFinish(block *types.BlockDetail) {
+}
+
+func (this *walletBizPlicy) OnClose() {
+}
+
+func (this *walletBizPlicy) OnSetQueueClient() {
+}
+
+func (this *walletBizPlicy) Call(funName string, in types.Message) (ret types.Message, err error) {
+	err = types.ErrNotSupport
+	return
+}
+
+//从blockchain模块同步addr参与的所有交易详细信息
+func (this *walletBizPlicy) rescanReqTxDetailByAddr(addr string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	this.reqTxDetailByAddr(addr)
+}
+
+//从blockchain模块同步addr参与的所有交易详细信息
+func (this *walletBizPlicy) reqTxDetailByAddr(addr string) {
+	if len(addr) == 0 {
+		walletlog.Error("reqTxDetailByAddr input addr is nil!")
+		return
+	}
+	var txInfo types.ReplyTxInfo
+
+	i := 0
+	operater := this.getWalletOperate()
+	for {
+		//首先从blockchain模块获取地址对应的所有交易hashs列表,从最新的交易开始获取
+		var ReqAddr types.ReqAddr
+		ReqAddr.Addr = addr
+		ReqAddr.Flag = 0
+		ReqAddr.Direction = 0
+		ReqAddr.Count = int32(MaxTxHashsPerTime)
+		if i == 0 {
+			ReqAddr.Height = -1
+			ReqAddr.Index = 0
+		} else {
+			ReqAddr.Height = txInfo.GetHeight()
+			ReqAddr.Index = txInfo.GetIndex()
+		}
+		i++
+		ReplyTxInfos, err := operater.GetAPI().GetTransactionByAddr(&ReqAddr)
+		if err != nil {
+			walletlog.Error("reqTxDetailByAddr", "GetTransactionByAddr error", err, "addr", addr)
+			return
+		}
+		if ReplyTxInfos == nil {
+			walletlog.Info("reqTxDetailByAddr ReplyTxInfos is nil")
+			return
+		}
+		txcount := len(ReplyTxInfos.TxInfos)
+
+		var ReqHashes types.ReqHashes
+		ReqHashes.Hashes = make([][]byte, len(ReplyTxInfos.TxInfos))
+		for index, ReplyTxInfo := range ReplyTxInfos.TxInfos {
+			ReqHashes.Hashes[index] = ReplyTxInfo.GetHash()
+			txInfo.Hash = ReplyTxInfo.GetHash()
+			txInfo.Height = ReplyTxInfo.GetHeight()
+			txInfo.Index = ReplyTxInfo.GetIndex()
+		}
+		operater.GetTxDetailByHashs(&ReqHashes)
+		if txcount < int(MaxTxHashsPerTime) {
+			return
+		}
+	}
+}


### PR DESCRIPTION
1. 新增钱包默认处理的策略walletbizpolicy.go，实现钱包基础的功能代码
2. 去掉wallet_test.go中有关ticket状态检查
3. 调整QueryData中重复名称注册冲突导致panic的提示信息