### PR TITLE
fix for issue_63 

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -179,7 +179,7 @@ func (c *channelClient) GetAllExecBalance(in *types.ReqAddr) (*types.AllExecBala
 	addrs = append(addrs, addr)
 	allBalance := &types.AllExecBalance{Addr: addr}
 	for _, exec := range types.AllowUserExec {
-		execer := string(exec)
+		execer := types.ExecName(string(exec))
 		params := &types.ReqBalance{
 			Addresses: addrs,
 			Execer:    execer,


### PR DESCRIPTION
修改GetAllExecBalance的传参，使用执行器名称带上平行链前缀。 使其适配平行链上的查询。
 可以加上这个注释：
fixed #63 