### PR TITLE
fix lint warning

### DIFF
--- a/executor/execenv.go
+++ b/executor/execenv.go
@@ -136,7 +136,7 @@ func (e *executor) setEnv(exec drivers.Driver) {
 	exec.SetStateDB(e.stateDB)
 	exec.SetLocalDB(e.localDB)
 	exec.SetEnv(e.height, e.blocktime, e.difficulty)
-	exec.SetApi(e.api)
+	exec.SetAPI(e.api)
 	exec.SetTxs(e.txs)
 	exec.SetReceipt(e.receipts)
 }

--- a/p2p/addrbook.go
+++ b/p2p/addrbook.go
@@ -34,7 +34,7 @@ func (a *AddrBook) Close() {
 type AddrBook struct {
 	mtx      sync.Mutex
 	ourAddrs map[string]*NetAddress
-	addrPeer map[string]*knownAddress
+	addrPeer map[string]*KnownAddress
 	cfg      *types.P2P
 	keymtx   sync.Mutex
 	privkey  string
@@ -42,8 +42,8 @@ type AddrBook struct {
 	bookDb   db.DB
 	Quit     chan struct{}
 }
-
-type knownAddress struct {
+// KnownAddress defines known address type
+type KnownAddress struct {
 	kmtx        sync.Mutex
 	Addr        *NetAddress `json:"addr"`
 	Attempts    uint        `json:"attempts"`
@@ -52,7 +52,7 @@ type knownAddress struct {
 }
 
 // GetPeerStat get peer stat
-func (a *AddrBook) GetPeerStat(addr string) *knownAddress {
+func (a *AddrBook) GetPeerStat(addr string) *KnownAddress {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 	if peer, ok := a.addrPeer[addr]; ok {
@@ -62,7 +62,7 @@ func (a *AddrBook) GetPeerStat(addr string) *knownAddress {
 
 }
 
-func (a *AddrBook) setAddrStat(addr string, run bool) (*knownAddress, bool) {
+func (a *AddrBook) setAddrStat(addr string, run bool) (*KnownAddress, bool) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 	if peer, ok := a.addrPeer[addr]; ok {
@@ -82,7 +82,7 @@ func NewAddrBook(cfg *types.P2P) *AddrBook {
 	a := &AddrBook{
 
 		ourAddrs: make(map[string]*NetAddress),
-		addrPeer: make(map[string]*knownAddress),
+		addrPeer: make(map[string]*KnownAddress),
 		cfg:      cfg,
 		Quit:     make(chan struct{}, 1),
 	}
@@ -90,8 +90,8 @@ func NewAddrBook(cfg *types.P2P) *AddrBook {
 	return a
 }
 
-func newKnownAddress(addr *NetAddress) *knownAddress {
-	return &knownAddress{
+func newKnownAddress(addr *NetAddress) *KnownAddress {
+	return &KnownAddress{
 		kmtx:        sync.Mutex{},
 		Addr:        addr,
 		Attempts:    0,
@@ -99,7 +99,7 @@ func newKnownAddress(addr *NetAddress) *knownAddress {
 	}
 }
 
-func (ka *knownAddress) markGood() {
+func (ka *KnownAddress) markGood() {
 	ka.kmtx.Lock()
 	defer ka.kmtx.Unlock()
 	now := types.Now()
@@ -109,10 +109,10 @@ func (ka *knownAddress) markGood() {
 }
 
 // Copy a KnownAddress
-func (ka *knownAddress) Copy() *knownAddress {
+func (ka *KnownAddress) Copy() *KnownAddress {
 	ka.kmtx.Lock()
 
-	ret := knownAddress{
+	ret := KnownAddress{
 		Addr:        ka.Addr.Copy(),
 		Attempts:    ka.Attempts,
 		LastAttempt: ka.LastAttempt,
@@ -122,7 +122,7 @@ func (ka *knownAddress) Copy() *knownAddress {
 	return &ret
 }
 
-func (ka *knownAddress) markAttempt() {
+func (ka *KnownAddress) markAttempt() {
 	ka.kmtx.Lock()
 	defer ka.kmtx.Unlock()
 
@@ -133,7 +133,7 @@ func (ka *knownAddress) markAttempt() {
 }
 
 // GetAttempts return attempts
-func (ka *knownAddress) GetAttempts() uint {
+func (ka *KnownAddress) GetAttempts() uint {
 	ka.kmtx.Lock()
 	defer ka.kmtx.Unlock()
 	return ka.Attempts
@@ -176,13 +176,13 @@ func (a *AddrBook) Size() int {
 }
 
 type addrBookJSON struct {
-	Addrs []*knownAddress `json:"addrs"`
+	Addrs []*KnownAddress `json:"addrs"`
 }
 
 func (a *AddrBook) saveToDb() {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
-	addrs := []*knownAddress{}
+	addrs := []*KnownAddress{}
 
 	seeds := a.cfg.Seeds
 	seedsMap := make(map[string]int)
@@ -294,7 +294,7 @@ out:
 
 // AddAddress add a address for ours
 // NOTE: addr must not be nil
-func (a *AddrBook) AddAddress(addr *NetAddress, ka *knownAddress) {
+func (a *AddrBook) AddAddress(addr *NetAddress, ka *KnownAddress) {
 
 	a.mtx.Lock()
 	defer a.mtx.Unlock()

--- a/p2p/downloadblocks.go
+++ b/p2p/downloadblocks.go
@@ -15,8 +15,8 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
-
-type downloadJob struct {
+// DownloadJob defines download job type
+type DownloadJob struct {
 	wg            sync.WaitGroup
 	retryList     *list.List
 	p2pcli        *Cli
@@ -32,8 +32,8 @@ type peerJob struct {
 }
 
 // NewDownloadJob create a downloadjob object
-func NewDownloadJob(p2pcli *Cli, peers []*Peer) *downloadJob {
-	job := new(downloadJob)
+func NewDownloadJob(p2pcli *Cli, peers []*Peer) *DownloadJob {
+	job := new(DownloadJob)
 	job.retryList = list.New()
 	job.p2pcli = p2pcli
 	job.busyPeer = make(map[string]*peerJob)
@@ -41,7 +41,7 @@ func NewDownloadJob(p2pcli *Cli, peers []*Peer) *downloadJob {
 	return job
 }
 
-func (d *downloadJob) isBusyPeer(pid string) bool {
+func (d *DownloadJob) isBusyPeer(pid string) bool {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	if pjob, ok := d.busyPeer[pid]; ok {
@@ -50,7 +50,7 @@ func (d *downloadJob) isBusyPeer(pid string) bool {
 	return false
 }
 
-func (d *downloadJob) setBusyPeer(peer *pb.Peer) {
+func (d *DownloadJob) setBusyPeer(peer *pb.Peer) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	if pjob, ok := d.busyPeer[peer.GetName()]; ok {
@@ -62,7 +62,7 @@ func (d *downloadJob) setBusyPeer(peer *pb.Peer) {
 	d.busyPeer[peer.GetName()] = &peerJob{peer, 1}
 }
 
-func (d *downloadJob) setFreePeer(pid string) {
+func (d *DownloadJob) setFreePeer(pid string) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
@@ -76,7 +76,7 @@ func (d *downloadJob) setFreePeer(pid string) {
 }
 
 // GetFreePeer get free peer ,return peer
-func (d *downloadJob) GetFreePeer(joblimit int64) *Peer {
+func (d *DownloadJob) GetFreePeer(joblimit int64) *Peer {
 	_, infos := d.p2pcli.network.node.GetActivePeers()
 	for _, peer := range d.downloadPeers {
 		pbpeer, ok := infos[peer.Addr()]
@@ -99,16 +99,16 @@ func (d *downloadJob) GetFreePeer(joblimit int64) *Peer {
 }
 
 // CancelJob cancel the downloadjob object
-func (d *downloadJob) CancelJob() {
+func (d *DownloadJob) CancelJob() {
 	atomic.StoreInt32(&d.canceljob, 1)
 }
 
-func (d *downloadJob) isCancel() bool {
+func (d *DownloadJob) isCancel() bool {
 	return atomic.LoadInt32(&d.canceljob) == 1
 }
 
 // DownloadBlock download the block
-func (d *downloadJob) DownloadBlock(invs []*pb.Inventory,
+func (d *DownloadJob) DownloadBlock(invs []*pb.Inventory,
 	bchan chan *pb.BlockPid) []*pb.Inventory {
 	var errinvs []*pb.Inventory
 	if d.isCancel() {
@@ -140,7 +140,7 @@ func (d *downloadJob) DownloadBlock(invs []*pb.Inventory,
 	return d.restOfInvs(bchan)
 }
 
-func (d *downloadJob) restOfInvs(bchan chan *pb.BlockPid) []*pb.Inventory {
+func (d *DownloadJob) restOfInvs(bchan chan *pb.BlockPid) []*pb.Inventory {
 	var errinvs []*pb.Inventory
 	if d.isCancel() {
 		return errinvs
@@ -166,7 +166,7 @@ func (d *downloadJob) restOfInvs(bchan chan *pb.BlockPid) []*pb.Inventory {
 	return invs
 }
 
-func (d *downloadJob) syncDownloadBlock(peer *Peer, inv *pb.Inventory, bchan chan *pb.BlockPid) error {
+func (d *DownloadJob) syncDownloadBlock(peer *Peer, inv *pb.Inventory, bchan chan *pb.BlockPid) error {
 	//每次下载一个高度的数据，通过bchan返回上层
 	if peer == nil {
 		return fmt.Errorf("peer is not exist")

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -64,7 +64,7 @@ func (j *JSONRPCServer) Listen() (int, error) {
 			return
 		}
 
-		if !checkIpWhitelist(ip) {
+		if !checkIPWhitelist(ip) {
 			writeError(w, r, 0, fmt.Sprintf(`The %s Address is not authorized!`, ip))
 			return
 		}
@@ -75,7 +75,7 @@ func (j *JSONRPCServer) Listen() (int, error) {
 				return
 			}
 			//格式做一个检查
-			client, err := parseJsonRpcParams(data)
+			client, err := parseJSONRpcParams(data)
 			errstr := "nil"
 			if err != nil {
 				errstr = err.Error()
@@ -90,7 +90,7 @@ func (j *JSONRPCServer) Listen() (int, error) {
 			if !ipaddr.IsLoopback() {
 				funcName := strings.Split(client.Method, ".")[len(strings.Split(client.Method, "."))-1]
 				if checkJrpcFuncBlacklist(funcName) || !checkJrpcFuncWhitelist(funcName) {
-					writeError(w, r, client.Id, fmt.Sprintf(`The %s method is not authorized!`, funcName))
+					writeError(w, r, client.ID, fmt.Sprintf(`The %s method is not authorized!`, funcName))
 					return
 				}
 			}
@@ -114,7 +114,7 @@ func (j *JSONRPCServer) Listen() (int, error) {
 }
 
 type serverResponse struct {
-	Id     uint64      `json:"id"`
+	ID     uint64      `json:"id"`
 	Result interface{} `json:"result"`
 	Error  interface{} `json:"error"`
 }
@@ -161,7 +161,7 @@ func auth(ctx context.Context, info *grpc.UnaryServerInfo) error {
 			return fmt.Errorf("the %s Address is not authorized", ip)
 		}
 
-		if !checkIpWhitelist(ip) {
+		if !checkIPWhitelist(ip) {
 			return fmt.Errorf("the %s Address is not authorized", ip)
 		}
 
@@ -177,10 +177,10 @@ func auth(ctx context.Context, info *grpc.UnaryServerInfo) error {
 type clientRequest struct {
 	Method string         `json:"method"`
 	Params [1]interface{} `json:"params"`
-	Id     uint64         `json:"id"`
+	ID     uint64         `json:"id"`
 }
 
-func parseJsonRpcParams(data []byte) (*clientRequest, error) {
+func parseJSONRpcParams(data []byte) (*clientRequest, error) {
 	var req clientRequest
 	err := json.Unmarshal(data, &req)
 	if err != nil {

--- a/rpc/jrpchandler.go
+++ b/rpc/jrpchandler.go
@@ -422,7 +422,7 @@ func (c *Chain33) WalletTxList(in rpctypes.ReqWalletTransactionList, result *int
 	}
 	{
 		var txdetails rpctypes.WalletTxDetails
-		rpctypes.ConvertWalletTxDetailToJson(reply, &txdetails)
+		rpctypes.ConvertWalletTxDetailToJSON(reply, &txdetails)
 		*result = &txdetails
 	}
 	return nil

--- a/rpc/jsonclient/jsonclient.go
+++ b/rpc/jsonclient/jsonclient.go
@@ -42,11 +42,11 @@ func New(prefix, url string) (*JSONClient, error) {
 type clientRequest struct {
 	Method string         `json:"method"`
 	Params [1]interface{} `json:"params"`
-	Id     uint64         `json:"id"`
+	ID     uint64         `json:"id"`
 }
 
 type clientResponse struct {
-	Id     uint64           `json:"id"`
+	ID     uint64           `json:"id"`
 	Result *json.RawMessage `json:"result"`
 	Error  interface{}      `json:"error"`
 }

--- a/rpc/jsonclient/rpc_ctx.go
+++ b/rpc/jsonclient/rpc_ctx.go
@@ -10,9 +10,9 @@ import (
 	"os"
 )
 
-// RpcCtx rpc ctx interface
+// RPCCtx rpc ctx interface
 // TODO: SetPostRunCb()
-type RpcCtx struct {
+type RPCCtx struct {
 	Addr   string
 	Method string
 	Params interface{}
@@ -23,9 +23,9 @@ type RpcCtx struct {
 // Callback a callback function
 type Callback func(res interface{}) (interface{}, error)
 
-// NewRpcCtx produce a object of rpcctx
-func NewRpcCtx(laddr, method string, params, res interface{}) *RpcCtx {
-	return &RpcCtx{
+// NewRPCCtx produce a object of rpcctx
+func NewRPCCtx(laddr, method string, params, res interface{}) *RPCCtx {
+	return &RPCCtx{
 		Addr:   laddr,
 		Method: method,
 		Params: params,
@@ -34,12 +34,12 @@ func NewRpcCtx(laddr, method string, params, res interface{}) *RpcCtx {
 }
 
 // SetResultCb rpcctx callback
-func (c *RpcCtx) SetResultCb(cb Callback) {
+func (c *RPCCtx) SetResultCb(cb Callback) {
 	c.cb = cb
 }
 
 // RunResult  format rpc result
-func (c *RpcCtx) RunResult() (interface{}, error) {
+func (c *RPCCtx) RunResult() (interface{}, error) {
 	rpc, err := NewJSONClient(c.Addr)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (c *RpcCtx) RunResult() (interface{}, error) {
 }
 
 // Run rpcctx to runresult
-func (c *RpcCtx) Run() {
+func (c *RPCCtx) Run() {
 	result, err := c.RunResult()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -78,7 +78,7 @@ func (c *RpcCtx) Run() {
 }
 
 // RunWithoutMarshal return source result of string
-func (c *RpcCtx) RunWithoutMarshal() {
+func (c *RPCCtx) RunWithoutMarshal() {
 	var res string
 	rpc, err := NewJSONClient(c.Addr)
 	if err != nil {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	remoteIpWhitelist = make(map[string]bool)
+	remoteIPWhitelist = make(map[string]bool)
 	rpcCfg            *types.RPC
 	jrpcFuncWhitelist = make(map[string]bool)
 	grpcFuncWhitelist = make(map[string]bool)
@@ -67,7 +67,7 @@ func (s *JSONRPCServer) Close() {
 	}
 }
 
-func checkIpWhitelist(addr string) bool {
+func checkIPWhitelist(addr string) bool {
 	//回环网络直接允许
 	ip := net.ParseIP(addr)
 	if ip.IsLoopback() {
@@ -77,10 +77,10 @@ func checkIpWhitelist(addr string) bool {
 	if ipv4 != nil {
 		addr = ipv4.String()
 	}
-	if _, ok := remoteIpWhitelist["0.0.0.0"]; ok {
+	if _, ok := remoteIPWhitelist["0.0.0.0"]; ok {
 		return true
 	}
-	if _, ok := remoteIpWhitelist[addr]; ok {
+	if _, ok := remoteIPWhitelist[addr]; ok {
 		return true
 	}
 	return false
@@ -177,7 +177,7 @@ type RPC struct {
 // InitCfg  interfaces
 func InitCfg(cfg *types.RPC) {
 	rpcCfg = cfg
-	InitIpWhitelist(cfg)
+	InitIPWhitelist(cfg)
 	InitJrpcFuncWhitelist(cfg)
 	InitGrpcFuncWhitelist(cfg)
 	InitJrpcFuncBlacklist(cfg)
@@ -265,29 +265,29 @@ func (r *RPC) Close() {
 	}
 }
 
-// InitIpWhitelist init ip whitelist
-func InitIpWhitelist(cfg *types.RPC) {
+// InitIPWhitelist init ip whitelist
+func InitIPWhitelist(cfg *types.RPC) {
 	if len(cfg.Whitelist) == 0 && len(cfg.Whitlist) == 0 {
-		remoteIpWhitelist["127.0.0.1"] = true
+		remoteIPWhitelist["127.0.0.1"] = true
 		return
 	}
 	if len(cfg.Whitelist) == 1 && cfg.Whitelist[0] == "*" {
-		remoteIpWhitelist["0.0.0.0"] = true
+		remoteIPWhitelist["0.0.0.0"] = true
 		return
 	}
 	if len(cfg.Whitlist) == 1 && cfg.Whitlist[0] == "*" {
-		remoteIpWhitelist["0.0.0.0"] = true
+		remoteIPWhitelist["0.0.0.0"] = true
 		return
 	}
 	if len(cfg.Whitelist) != 0 {
 		for _, addr := range cfg.Whitelist {
-			remoteIpWhitelist[addr] = true
+			remoteIPWhitelist[addr] = true
 		}
 		return
 	}
 	if len(cfg.Whitlist) != 0 {
 		for _, addr := range cfg.Whitlist {
-			remoteIpWhitelist[addr] = true
+			remoteIPWhitelist[addr] = true
 		}
 		return
 	}

--- a/rpc/types/code.go
+++ b/rpc/types/code.go
@@ -47,8 +47,8 @@ func DecodeLog(execer []byte, rlog *ReceiptData) (*ReceiptDataResult, error) {
 	return rd, nil
 }
 
-// ConvertWalletTxDetailToJson conver the wallet tx detail to json
-func ConvertWalletTxDetailToJson(in *types.WalletTxDetails, out *WalletTxDetails) error {
+// ConvertWalletTxDetailToJSON conver the wallet tx detail to json
+func ConvertWalletTxDetailToJSON(in *types.WalletTxDetails, out *WalletTxDetails) error {
 	if in == nil || out == nil {
 		return types.ErrInvalidParam
 	}

--- a/system/dapp/coins/autotest/coins.go
+++ b/system/dapp/coins/autotest/coins.go
@@ -7,18 +7,18 @@ package autotest
 import (
 	"reflect"
 
-	. "github.com/33cn/chain33/cmd/autotest/types"
+	"github.com/33cn/chain33/cmd/autotest/types"
 )
 
 type coinsAutoTest struct {
-	SimpleCaseArr   []SimpleCase   `toml:"SimpleCase,omitempty"`
+	SimpleCaseArr   []types.SimpleCase   `toml:"SimpleCase,omitempty"`
 	TransferCaseArr []TransferCase `toml:"TransferCase,omitempty"`
 	WithdrawCaseArr []WithdrawCase `toml:"WithdrawCase,omitempty"`
 }
 
 func init() {
 
-	RegisterAutoTest(coinsAutoTest{})
+	types.RegisterAutoTest(coinsAutoTest{})
 
 }
 

--- a/system/dapp/coins/autotest/transferCase.go
+++ b/system/dapp/coins/autotest/transferCase.go
@@ -7,12 +7,12 @@ package autotest
 import (
 	"strconv"
 
-	. "github.com/33cn/chain33/cmd/autotest/types"
+	"github.com/33cn/chain33/cmd/autotest/types"
 )
 
 // TransferCase transfer case
 type TransferCase struct {
-	BaseCase
+	types.BaseCase
 	From   string `toml:"from"`
 	To     string `toml:"to"`
 	Amount string `toml:"amount"`
@@ -20,19 +20,19 @@ type TransferCase struct {
 
 // TransferPack transfer pack
 type TransferPack struct {
-	BaseCasePack
+	types.BaseCasePack
 }
 
 // SendCommand sed command
-func (testCase *TransferCase) SendCommand(packID string) (PackFunc, error) {
+func (testCase *TransferCase) SendCommand(packID string) (types.PackFunc, error) {
 
-	return DefaultSend(testCase, &TransferPack{}, packID)
+	return types.DefaultSend(testCase, &TransferPack{}, packID)
 }
 
 // GetCheckHandlerMap get check handle for map
 func (pack *TransferPack) GetCheckHandlerMap() interface{} {
 
-	funcMap := make(CheckHandlerMapDiscard, 2)
+	funcMap := make(types.CheckHandlerMapDiscard, 2)
 	funcMap["balance"] = pack.checkBalance
 
 	return funcMap
@@ -61,10 +61,10 @@ func (pack *TransferPack) checkBalance(txInfo map[string]interface{}) bool {
 	//transfer to contract, deposit
 	if len(logArr) == 4 {
 		logDeposit := logArr[3].(map[string]interface{})["log"].(map[string]interface{})
-		depositCheck = CheckBalanceDeltaWithAddr(logDeposit, interCase.From, Amount)
+		depositCheck = types.CheckBalanceDeltaWithAddr(logDeposit, interCase.From, Amount)
 	}
 
-	return CheckBalanceDeltaWithAddr(logFee, interCase.From, -fee) &&
-		CheckBalanceDeltaWithAddr(logSend, interCase.From, -Amount) &&
-		CheckBalanceDeltaWithAddr(logRecv, interCase.To, Amount) && depositCheck
+	return types.CheckBalanceDeltaWithAddr(logFee, interCase.From, -fee) &&
+		types.CheckBalanceDeltaWithAddr(logSend, interCase.From, -Amount) &&
+		types.CheckBalanceDeltaWithAddr(logRecv, interCase.To, Amount) && depositCheck
 }

--- a/system/dapp/coins/autotest/withdrawCase.go
+++ b/system/dapp/coins/autotest/withdrawCase.go
@@ -7,31 +7,31 @@ package autotest
 import (
 	"strconv"
 
-	. "github.com/33cn/chain33/cmd/autotest/types"
+	"github.com/33cn/chain33/cmd/autotest/types"
 )
 
 // WithdrawCase defines the withdraw case
 type WithdrawCase struct {
-	BaseCase
+	types.BaseCase
 	Addr   string `toml:"addr"`
 	Amount string `toml:"amount"`
 }
 
 // WithdrawPack defines the withdraw pack
 type WithdrawPack struct {
-	BaseCasePack
+	types.BaseCasePack
 }
 
 // SendCommand send command of withdrawcase
-func (testCase *WithdrawCase) SendCommand(packID string) (PackFunc, error) {
+func (testCase *WithdrawCase) SendCommand(packID string) (types.PackFunc, error) {
 
-	return DefaultSend(testCase, &WithdrawPack{}, packID)
+	return types.DefaultSend(testCase, &WithdrawPack{}, packID)
 }
 
 // GetCheckHandlerMap get check handler for map
 func (pack *WithdrawPack) GetCheckHandlerMap() interface{} {
 
-	funcMap := make(CheckHandlerMapDiscard, 1)
+	funcMap := make(types.CheckHandlerMapDiscard, 1)
 	funcMap["balance"] = pack.checkBalance
 
 	return funcMap
@@ -62,8 +62,8 @@ func (pack *WithdrawPack) checkBalance(txInfo map[string]interface{}) bool {
 		"ToPrev", logRecv["prev"].(map[string]interface{})["balance"].(string),
 		"ToCurr", logRecv["current"].(map[string]interface{})["balance"].(string))
 
-	return CheckBalanceDeltaWithAddr(logFee, interCase.Addr, -fee) &&
-		CheckBalanceDeltaWithAddr(logWithdraw, interCase.Addr, -Amount) &&
-		CheckBalanceDeltaWithAddr(logSend, withdrawFrom, -Amount) &&
-		CheckBalanceDeltaWithAddr(logRecv, interCase.Addr, Amount)
+	return types.CheckBalanceDeltaWithAddr(logFee, interCase.Addr, -fee) &&
+		types.CheckBalanceDeltaWithAddr(logWithdraw, interCase.Addr, -Amount) &&
+		types.CheckBalanceDeltaWithAddr(logSend, withdrawFrom, -Amount) &&
+		types.CheckBalanceDeltaWithAddr(logRecv, interCase.Addr, Amount)
 }

--- a/system/dapp/commands/block.go
+++ b/system/dapp/commands/block.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/33cn/chain33/rpc/jsonclient"
 	rpctypes "github.com/33cn/chain33/rpc/types"
-	. "github.com/33cn/chain33/system/dapp/commands/types"
+	commandtypes "github.com/33cn/chain33/system/dapp/commands/types"
 	"github.com/33cn/chain33/types"
 	"github.com/spf13/cobra"
 )
@@ -77,15 +77,15 @@ func blockBodyCmd(cmd *cobra.Command, args []string) {
 		Isdetail: detailBool,
 	}
 	var res rpctypes.BlockDetails
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetBlocks", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetBlocks", params, &res)
 	ctx.SetResultCb(parseBlockDetail)
 	ctx.Run()
 }
 
 func parseBlockDetail(res interface{}) (interface{}, error) {
-	var result BlockDetailsResult
+	var result commandtypes.BlockDetailsResult
 	for _, vItem := range res.(*rpctypes.BlockDetails).Items {
-		b := &BlockResult{
+		b := &commandtypes.BlockResult{
 			Version:    vItem.Block.Version,
 			ParentHash: vItem.Block.ParentHash,
 			TxHash:     vItem.Block.TxHash,
@@ -94,9 +94,9 @@ func parseBlockDetail(res interface{}) (interface{}, error) {
 			BlockTime:  vItem.Block.BlockTime,
 		}
 		for _, vTx := range vItem.Block.Txs {
-			b.Txs = append(b.Txs, DecodeTransaction(vTx))
+			b.Txs = append(b.Txs, commandtypes.DecodeTransaction(vTx))
 		}
-		bd := &BlockDetailResult{Block: b, Receipts: vItem.Receipts}
+		bd := &commandtypes.BlockDetailResult{Block: b, Receipts: vItem.Receipts}
 		result.Items = append(result.Items, bd)
 	}
 	return result, nil
@@ -125,7 +125,7 @@ func blockHeightHash(cmd *cobra.Command, args []string) {
 		Height: height,
 	}
 	var res rpctypes.ReplyHash
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetBlockHash", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetBlockHash", params, &res)
 	ctx.Run()
 }
 
@@ -152,7 +152,7 @@ func blockViewByHash(cmd *cobra.Command, args []string) {
 		Hash: blockHash,
 	}
 	var res rpctypes.BlockOverview
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetBlockOverview", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetBlockOverview", params, &res)
 	ctx.Run()
 }
 
@@ -193,7 +193,7 @@ func blockHeader(cmd *cobra.Command, args []string) {
 		IsDetail: detailBool,
 	}
 	var res rpctypes.Headers
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetHeaders", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetHeaders", params, &res)
 	ctx.Run()
 }
 
@@ -210,7 +210,7 @@ func GetLastHeaderCmd() *cobra.Command {
 func lastHeader(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.Header
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetLastHeader", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetLastHeader", nil, &res)
 	ctx.Run()
 }
 
@@ -227,7 +227,7 @@ func GetLastBlockSequenceCmd() *cobra.Command {
 func lastSequence(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res int64
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetLastBlockSequence", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetLastBlockSequence", nil, &res)
 	ctx.Run()
 }
 
@@ -253,7 +253,7 @@ func getsequences(cmd *cobra.Command, args []string) {
 		Isdetail: false,
 	}
 	var res rpctypes.ReplyBlkSeqs
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetBlockSequences", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetBlockSequences", params, &res)
 	//ctx.SetResultCb(parseBlockDetail)
 	ctx.Run()
 }
@@ -291,7 +291,7 @@ func getblockbyhashs(cmd *cobra.Command, args []string) {
 	}
 
 	var res types.BlockDetails
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetBlockByHashes", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetBlockByHashes", params, &res)
 	//ctx.SetResultCb(parseQueryTxsByHashesRes)
 	ctx.Run()
 }

--- a/system/dapp/commands/bty.go
+++ b/system/dapp/commands/bty.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/33cn/chain33/rpc/jsonclient"
-	. "github.com/33cn/chain33/system/dapp/commands/types"
+	commandtypes "github.com/33cn/chain33/system/dapp/commands/types"
 	"github.com/33cn/chain33/types"
 	"github.com/spf13/cobra"
 )
@@ -86,7 +86,7 @@ func createTransfer(cmd *cobra.Command, args []string) {
 	toAddr, _ := cmd.Flags().GetString("to")
 	amount, _ := cmd.Flags().GetFloat64("amount")
 	note, _ := cmd.Flags().GetString("note")
-	txHex, err := CreateRawTx(cmd, toAddr, amount, note, false, "", "")
+	txHex, err := commandtypes.CreateRawTx(cmd, toAddr, amount, note, false, "", "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
@@ -119,12 +119,12 @@ func createWithdraw(cmd *cobra.Command, args []string) {
 	exec, _ := cmd.Flags().GetString("exec")
 	amount, _ := cmd.Flags().GetFloat64("amount")
 	note, _ := cmd.Flags().GetString("note")
-	execAddr, err := GetExecAddr(exec)
+	execAddr, err := commandtypes.GetExecAddr(exec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
-	txHex, err := CreateRawTx(cmd, execAddr, amount, note, true, "", exec)
+	txHex, err := commandtypes.CreateRawTx(cmd, execAddr, amount, note, true, "", exec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
@@ -157,12 +157,12 @@ func sendToExec(cmd *cobra.Command, args []string) {
 	exec, _ := cmd.Flags().GetString("exec")
 	amount, _ := cmd.Flags().GetFloat64("amount")
 	note, _ := cmd.Flags().GetString("note")
-	execAddr, err := GetExecAddr(exec)
+	execAddr, err := commandtypes.GetExecAddr(exec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
-	txHex, err := CreateRawTx(cmd, execAddr, amount, note, false, "", exec)
+	txHex, err := commandtypes.CreateRawTx(cmd, execAddr, amount, note, false, "", exec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
@@ -201,7 +201,7 @@ func transfer(cmd *cobra.Command, args []string) {
 	amount, _ := cmd.Flags().GetFloat64("amount")
 	note, _ := cmd.Flags().GetString("note")
 	amountInt64 := int64(amount*types.InputPrecision) * types.Multiple1E4 //支持4位小数输入，多余的输入将被截断
-	SendToAddress(rpcLaddr, fromAddr, toAddr, amountInt64, note, false, "", false)
+	commandtypes.SendToAddress(rpcLaddr, fromAddr, toAddr, amountInt64, note, false, "", false)
 }
 
 // WithdrawFromExecCmd withdraw from executor
@@ -234,13 +234,13 @@ func withdraw(cmd *cobra.Command, args []string) {
 	exec, _ := cmd.Flags().GetString("exec")
 	amount, _ := cmd.Flags().GetFloat64("amount")
 	note, _ := cmd.Flags().GetString("note")
-	execAddr, err := GetExecAddr(exec)
+	execAddr, err := commandtypes.GetExecAddr(exec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 	amountInt64 := int64(amount*types.InputPrecision) * types.Multiple1E4 //支持4位小数输入，多余的输入将被截断
-	SendToAddress(rpcLaddr, addr, execAddr, amountInt64, note, false, "", true)
+	commandtypes.SendToAddress(rpcLaddr, addr, execAddr, amountInt64, note, false, "", true)
 }
 
 // CreateTxGroupCmd create tx group
@@ -348,7 +348,7 @@ func createPub2PrivTxFlags(cmd *cobra.Command) {
 func createPub2PrivTx(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	pubkeypair, _ := cmd.Flags().GetString("pubkeypair")
-	amount := GetAmountValue(cmd, "amount")
+	amount := commandtypes.GetAmountValue(cmd, "amount")
 	tokenname, _ := cmd.Flags().GetString("tokenname")
 	note, _ := cmd.Flags().GetString("note")
 	expire, _ := cmd.Flags().GetInt64("expire")
@@ -375,7 +375,7 @@ func createPub2PrivTx(cmd *cobra.Command, args []string) {
 		Pubkeypair: pubkeypair,
 		Expire:     expire,
 	}
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "privacy.CreateRawTransaction", params, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "privacy.CreateRawTransaction", params, nil)
 	ctx.RunWithoutMarshal()
 }
 
@@ -407,7 +407,7 @@ func createPriv2PrivTxFlags(cmd *cobra.Command) {
 func createPriv2PrivTx(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	pubkeypair, _ := cmd.Flags().GetString("pubkeypair")
-	amount := GetAmountValue(cmd, "amount")
+	amount := commandtypes.GetAmountValue(cmd, "amount")
 	tokenname, _ := cmd.Flags().GetString("tokenname")
 	note, _ := cmd.Flags().GetString("note")
 	sender, _ := cmd.Flags().GetString("sender")
@@ -437,7 +437,7 @@ func createPriv2PrivTx(cmd *cobra.Command, args []string) {
 		Mixcount:   defaultPrivacyMixCount,
 		Expire:     expire,
 	}
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "privacy.CreateRawTransaction", params, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "privacy.CreateRawTransaction", params, nil)
 	ctx.RunWithoutMarshal()
 }
 
@@ -468,7 +468,7 @@ func createPriv2PubTxFlags(cmd *cobra.Command) {
 
 func createPriv2PubTx(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
-	amount := GetAmountValue(cmd, "amount")
+	amount := commandtypes.GetAmountValue(cmd, "amount")
 	tokenname, _ := cmd.Flags().GetString("tokenname")
 	from, _ := cmd.Flags().GetString("from")
 	to, _ := cmd.Flags().GetString("to")
@@ -499,6 +499,6 @@ func createPriv2PubTx(cmd *cobra.Command, args []string) {
 		Mixcount:  defaultPrivacyMixCount,
 		Expire:    expire,
 	}
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "privacy.CreateRawTransaction", params, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "privacy.CreateRawTransaction", params, nil)
 	ctx.RunWithoutMarshal()
 }

--- a/system/dapp/commands/mempool.go
+++ b/system/dapp/commands/mempool.go
@@ -7,7 +7,7 @@ package commands
 import (
 	"github.com/33cn/chain33/rpc/jsonclient"
 	rpctypes "github.com/33cn/chain33/rpc/types"
-	. "github.com/33cn/chain33/system/dapp/commands/types"
+	"github.com/33cn/chain33/system/dapp/commands/types"
 	"github.com/spf13/cobra"
 )
 
@@ -40,16 +40,16 @@ func GetMempoolCmd() *cobra.Command {
 func listMempoolTxs(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.ReplyTxList
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetMempool", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetMempool", nil, &res)
 	ctx.SetResultCb(parseListMempoolTxsRes)
 	ctx.Run()
 }
 
 func parseListMempoolTxsRes(arg interface{}) (interface{}, error) {
 	res := arg.(*rpctypes.ReplyTxList)
-	var result TxListResult
+	var result types.TxListResult
 	for _, v := range res.Txs {
-		result.Txs = append(result.Txs, DecodeTransaction(v))
+		result.Txs = append(result.Txs, types.DecodeTransaction(v))
 	}
 	return result, nil
 }
@@ -67,16 +67,16 @@ func GetLastMempoolCmd() *cobra.Command {
 func lastMempoolTxs(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.ReplyTxList
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetLastMemPool", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetLastMemPool", nil, &res)
 	ctx.SetResultCb(parselastMempoolTxsRes)
 	ctx.Run()
 }
 
 func parselastMempoolTxsRes(arg interface{}) (interface{}, error) {
 	res := arg.(*rpctypes.ReplyTxList)
-	var result TxListResult
+	var result types.TxListResult
 	for _, v := range res.Txs {
-		result.Txs = append(result.Txs, DecodeTransaction(v))
+		result.Txs = append(result.Txs, types.DecodeTransaction(v))
 	}
 	return result, nil
 }

--- a/system/dapp/commands/net.go
+++ b/system/dapp/commands/net.go
@@ -44,7 +44,7 @@ func GetPeerInfoCmd() *cobra.Command {
 func peerInfo(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.PeerList
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetPeerInfo", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetPeerInfo", nil, &res)
 	ctx.Run()
 }
 
@@ -61,7 +61,7 @@ func IsClockSyncCmd() *cobra.Command {
 func isClockSync(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res bool
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.IsNtpClockSync", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.IsNtpClockSync", nil, &res)
 	ctx.Run()
 }
 
@@ -78,7 +78,7 @@ func IsSyncCmd() *cobra.Command {
 func isSync(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res bool
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.IsSync", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.IsSync", nil, &res)
 	ctx.Run()
 }
 
@@ -95,7 +95,7 @@ func GetNetInfoCmd() *cobra.Command {
 func netInfo(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.NodeNetinfo
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetNetInfo", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetNetInfo", nil, &res)
 	ctx.Run()
 }
 
@@ -112,7 +112,7 @@ func GetFatalFailureCmd() *cobra.Command {
 func fatalFailure(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res int64
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetFatalFailure", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetFatalFailure", nil, &res)
 	ctx.Run()
 }
 
@@ -129,6 +129,6 @@ func GetTimeStausCmd() *cobra.Command {
 func timestatus(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.TimeStatus
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetTimeStatus", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetTimeStatus", nil, &res)
 	ctx.Run()
 }

--- a/system/dapp/commands/seed.go
+++ b/system/dapp/commands/seed.go
@@ -51,7 +51,7 @@ func genSeed(cmd *cobra.Command, args []string) {
 		Lang: lang,
 	}
 	var res types.ReplySeed
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GenSeed", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GenSeed", params, &res)
 	ctx.Run()
 }
 
@@ -78,7 +78,7 @@ func getSeed(cmd *cobra.Command, args []string) {
 		Passwd: pwd,
 	}
 	var res types.ReplySeed
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetSeed", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetSeed", params, &res)
 	ctx.Run()
 }
 
@@ -110,6 +110,6 @@ func saveSeed(cmd *cobra.Command, args []string) {
 		Passwd: pwd,
 	}
 	var res rpctypes.Reply
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.SaveSeed", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SaveSeed", params, &res)
 	ctx.Run()
 }

--- a/system/dapp/commands/stat.go
+++ b/system/dapp/commands/stat.go
@@ -19,7 +19,7 @@ import (
 	"github.com/33cn/chain33/common"
 	"github.com/33cn/chain33/common/difficulty"
 	rpctypes "github.com/33cn/chain33/rpc/types"
-	. "github.com/33cn/chain33/system/dapp/commands/types"
+	commandtypes "github.com/33cn/chain33/system/dapp/commands/types"
 	"github.com/33cn/chain33/types"
 	"github.com/spf13/cobra"
 )
@@ -111,7 +111,7 @@ func totalCoins(cmd *cobra.Command, args []string) {
 
 	// 查询高度哈希对应数据
 	var totalAmount int64
-	resp := GetTotalCoinsResult{}
+	resp := commandtypes.GetTotalCoinsResult{}
 
 	if symbol == "bty" {
 		//查询高度blockhash
@@ -249,7 +249,7 @@ func ticketStat(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	var resp GetTicketStatisticResult
+	var resp commandtypes.GetTicketStatisticResult
 	resp.CurrentOpenCount = res.CurrentOpenCount
 	resp.TotalMinerCount = res.TotalMinerCount
 	resp.TotalCloseCount = res.TotalCancleCount
@@ -281,7 +281,7 @@ func addTicketInfoCmdFlags(cmd *cobra.Command) {
 
 func ticketInfo(cmd *cobra.Command, args []string) {
 	rpcAddr, _ := cmd.Flags().GetString("rpc_laddr")
-	ticketId, _ := cmd.Flags().GetString("ticket_id")
+	ticketID, _ := cmd.Flags().GetString("ticket_id")
 
 	rpc, err := jsonclient.NewJSONClient(rpcAddr)
 	if err != nil {
@@ -289,7 +289,7 @@ func ticketInfo(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	key := []byte("Statistics:TicketInfo:TicketId:" + ticketId)
+	key := []byte("Statistics:TicketInfo:TicketId:" + ticketID)
 	fmt.Println(string(key))
 	params := types.LocalDBGet{Keys: [][]byte{key}}
 	var res types.TicketMinerInfo
@@ -299,8 +299,8 @@ func ticketInfo(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	var resp GetTicketMinerInfoResult
-	resp.TicketId = res.TicketId
+	var resp commandtypes.GetTicketMinerInfoResult
+	resp.TicketID = res.TicketId
 	switch res.Status {
 	case 1:
 		resp.Status = "openTicket"
@@ -360,7 +360,7 @@ func ticketInfoList(cmd *cobra.Command, args []string) {
 	count, _ := cmd.Flags().GetInt32("count")
 	direction, _ := cmd.Flags().GetInt32("direction")
 	createTime, _ := cmd.Flags().GetString("create_time")
-	ticketId, _ := cmd.Flags().GetString("ticket_id")
+	ticketID, _ := cmd.Flags().GetString("ticket_id")
 
 	if count <= 0 {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("input err, count:%v", count))
@@ -375,8 +375,8 @@ func ticketInfoList(cmd *cobra.Command, args []string) {
 
 	var key []byte
 	prefix := []byte("Statistics:TicketInfoOrder:Addr:" + addr)
-	if ticketId != "" && createTime != "" {
-		key = []byte("Statistics:TicketInfoOrder:Addr:" + addr + ":CreateTime:" + createTime + ":TicketId:" + ticketId)
+	if ticketID != "" && createTime != "" {
+		key = []byte("Statistics:TicketInfoOrder:Addr:" + addr + ":CreateTime:" + createTime + ":TicketId:" + ticketID)
 	}
 	fmt.Println(string(prefix))
 	fmt.Println(string(key))
@@ -388,10 +388,10 @@ func ticketInfoList(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	var resp []GetTicketMinerInfoResult
+	var resp []commandtypes.GetTicketMinerInfoResult
 	for _, v := range res {
-		var ticket GetTicketMinerInfoResult
-		ticket.TicketId = v.TicketId
+		var ticket commandtypes.GetTicketMinerInfoResult
+		ticket.TicketID = v.TicketId
 
 		switch v.Status {
 		case 1:
@@ -714,7 +714,7 @@ func execBalance(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	resp := GetExecBalanceResult{}
+	resp := commandtypes.GetExecBalanceResult{}
 
 	if symbol == "bty" {
 		exec = "coins"
@@ -787,13 +787,13 @@ func execBalance(cmd *cobra.Command, args []string) {
 	fmt.Println(string(data))
 }
 
-func convertReplyToResult(reply *types.ReplyGetExecBalance, result *GetExecBalanceResult, precision int64) {
+func convertReplyToResult(reply *types.ReplyGetExecBalance, result *commandtypes.GetExecBalanceResult, precision int64) {
 	result.Amount = strconv.FormatFloat(float64(reply.Amount)/float64(precision), 'f', 4, 64)
 	result.AmountFrozen = strconv.FormatFloat(float64(reply.AmountFrozen)/float64(precision), 'f', 4, 64)
 	result.AmountActive = strconv.FormatFloat(float64(reply.AmountActive)/float64(precision), 'f', 4, 64)
 
 	for i := 0; i < len(reply.Items); i++ {
-		item := &ExecBalance{}
+		item := &commandtypes.ExecBalance{}
 		item.ExecAddr = string(reply.Items[i].ExecAddr)
 		item.Frozen = strconv.FormatFloat(float64(reply.Items[i].Frozen)/float64(precision), 'f', 4, 64)
 		item.Active = strconv.FormatFloat(float64(reply.Items[i].Active)/float64(precision), 'f', 4, 64)

--- a/system/dapp/commands/tx.go
+++ b/system/dapp/commands/tx.go
@@ -15,7 +15,7 @@ import (
 	"github.com/33cn/chain33/common"
 	"github.com/33cn/chain33/rpc/jsonclient"
 	rpctypes "github.com/33cn/chain33/rpc/types"
-	. "github.com/33cn/chain33/system/dapp/commands/types"
+	commandtypes "github.com/33cn/chain33/system/dapp/commands/types"
 	"github.com/33cn/chain33/types"
 	"github.com/spf13/cobra"
 )
@@ -79,7 +79,7 @@ func queryTxByAddr(cmd *cobra.Command, args []string) {
 		Index:     index,
 	}
 	var res rpctypes.ReplyTxInfos
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetTxByAddr", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetTxByAddr", params, &res)
 	ctx.Run()
 }
 
@@ -110,7 +110,7 @@ func queryTx(cmd *cobra.Command, args []string) {
 		Hash: hash,
 	}
 	var res rpctypes.TransactionDetail
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.QueryTransaction", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.QueryTransaction", params, &res)
 	ctx.SetResultCb(parseQueryTxRes)
 	ctx.Run()
 }
@@ -118,8 +118,8 @@ func queryTx(cmd *cobra.Command, args []string) {
 func parseQueryTxRes(arg interface{}) (interface{}, error) {
 	res := arg.(*rpctypes.TransactionDetail)
 	amountResult := strconv.FormatFloat(float64(res.Amount)/float64(types.Coin), 'f', 4, 64)
-	result := TxDetailResult{
-		Tx:         DecodeTransaction(res.Tx),
+	result := commandtypes.TxDetailResult{
+		Tx:         commandtypes.DecodeTransaction(res.Tx),
 		Receipt:    res.Receipt,
 		Proofs:     res.Proofs,
 		Height:     res.Height,
@@ -158,21 +158,21 @@ func getTxsByHashes(cmd *cobra.Command, args []string) {
 	}
 
 	var res rpctypes.TransactionDetails
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetTxByHashes", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetTxByHashes", params, &res)
 	ctx.SetResultCb(parseQueryTxsByHashesRes)
 	ctx.Run()
 }
 
 func parseQueryTxsByHashesRes(arg interface{}) (interface{}, error) {
-	var result TxDetailsResult
+	var result commandtypes.TxDetailsResult
 	for _, v := range arg.(*rpctypes.TransactionDetails).Txs {
 		if v == nil {
 			result.Txs = append(result.Txs, nil)
 			continue
 		}
 		amountResult := strconv.FormatFloat(float64(v.Amount)/float64(types.Coin), 'f', 4, 64)
-		td := TxDetailResult{
-			Tx:         DecodeTransaction(v.Tx),
+		td := commandtypes.TxDetailResult{
+			Tx:         commandtypes.DecodeTransaction(v.Tx),
 			Receipt:    v.Receipt,
 			Proofs:     v.Proofs,
 			Height:     v.Height,
@@ -211,7 +211,7 @@ func getTxHexByHash(cmd *cobra.Command, args []string) {
 		Hash: txHash,
 	}
 
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetHexTxByHash", params, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetHexTxByHash", params, nil)
 	ctx.RunWithoutMarshal()
 }
 
@@ -252,7 +252,7 @@ func decodeTx(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	txResult := DecodeTransaction(res)
+	txResult := commandtypes.DecodeTransaction(res)
 
 	result, err := json.MarshalIndent(txResult, "", "    ")
 	if err != nil {
@@ -287,7 +287,7 @@ func viewAddress(cmd *cobra.Command, args []string) {
 	}
 
 	var res types.AddrOverview
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetAddrOverview", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetAddrOverview", params, &res)
 	ctx.SetResultCb(parseAddrOverview)
 	ctx.Run()
 }
@@ -296,7 +296,7 @@ func parseAddrOverview(view interface{}) (interface{}, error) {
 	res := view.(*types.AddrOverview)
 	balance := strconv.FormatFloat(float64(res.GetBalance())/float64(types.Coin), 'f', 4, 64)
 	receiver := strconv.FormatFloat(float64(res.GetReciver())/float64(types.Coin), 'f', 4, 64)
-	addrOverview := &AddrOverviewResult{
+	addrOverview := &commandtypes.AddrOverviewResult{
 		Balance:  balance,
 		Receiver: receiver,
 		TxCount:  res.GetTxCount(),

--- a/system/dapp/commands/types/types.go
+++ b/system/dapp/commands/types/types.go
@@ -156,7 +156,7 @@ type GetTicketStatisticResult struct {
 
 // GetTicketMinerInfoResult defines ticker minerinformation result rpc command
 type GetTicketMinerInfoResult struct {
-	TicketId     string `json:"ticketId"`
+	TicketID     string `json:"ticketId"`
 	Status       string `json:"status"`
 	PrevStatus   string `json:"prevStatus"`
 	IsGenesis    bool   `json:"isGenesis"`
@@ -256,7 +256,7 @@ type HashlockLockCLI struct {
 type TicketMinerCLI struct {
 	Bits     uint32 `json:"bits,omitempty"`
 	Reward   string `json:"reward,omitempty"`
-	TicketId string `json:"ticketId,omitempty"`
+	TicketID string `json:"ticketId,omitempty"`
 	Modify   []byte `json:"modify,omitempty"`
 }
 

--- a/system/dapp/commands/types/utils.go
+++ b/system/dapp/commands/types/utils.go
@@ -71,7 +71,7 @@ func SendToAddress(rpcAddr string, from string, to string, amount int64, note st
 	}
 
 	var res rpctypes.ReplyHash
-	ctx := jsonclient.NewRpcCtx(rpcAddr, "Chain33.SendToAddress", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcAddr, "Chain33.SendToAddress", params, &res)
 	ctx.Run()
 }
 

--- a/system/dapp/commands/version.go
+++ b/system/dapp/commands/version.go
@@ -23,6 +23,6 @@ func VersionCmd() *cobra.Command {
 func version(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.Version", nil, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.Version", nil, nil)
 	ctx.RunWithoutMarshal()
 }

--- a/system/dapp/commands/wallet.go
+++ b/system/dapp/commands/wallet.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/33cn/chain33/rpc/jsonclient"
 	rpctypes "github.com/33cn/chain33/rpc/types"
-	. "github.com/33cn/chain33/system/dapp/commands/types"
+	commandtypes "github.com/33cn/chain33/system/dapp/commands/types"
 	"github.com/33cn/chain33/types"
 	"github.com/spf13/cobra"
 )
@@ -57,7 +57,7 @@ func LockCmd() *cobra.Command {
 func lock(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.Reply
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.Lock", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.Lock", nil, &res)
 	ctx.Run()
 }
 
@@ -102,7 +102,7 @@ func unLock(cmd *cobra.Command, args []string) {
 		WalletOrTicket: walletOrTicket,
 	}
 	var res rpctypes.Reply
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.UnLock", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.UnLock", params, &res)
 	ctx.Run()
 }
 
@@ -119,7 +119,7 @@ func WalletStatusCmd() *cobra.Command {
 func walletStatus(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	var res rpctypes.WalletStatus
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.GetWalletStatus", nil, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.GetWalletStatus", nil, &res)
 	ctx.Run()
 }
 
@@ -151,7 +151,7 @@ func setPwd(cmd *cobra.Command, args []string) {
 		NewPass: newPwd,
 	}
 	var res rpctypes.Reply
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.SetPasswd", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SetPasswd", params, &res)
 	ctx.Run()
 }
 
@@ -187,18 +187,18 @@ func walletListTxs(cmd *cobra.Command, args []string) {
 		Direction: direction,
 	}
 	var res rpctypes.WalletTxDetails
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.WalletTxList", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.WalletTxList", params, &res)
 	ctx.SetResultCb(parseWalletTxListRes)
 	ctx.Run()
 }
 
 func parseWalletTxListRes(arg interface{}) (interface{}, error) {
 	res := arg.(*rpctypes.WalletTxDetails)
-	var result WalletTxDetailsResult
+	var result commandtypes.WalletTxDetailsResult
 	for _, v := range res.TxDetails {
 		amountResult := strconv.FormatFloat(float64(v.Amount)/float64(types.Coin), 'f', 4, 64)
-		wtxd := &WalletTxDetailResult{
-			Tx:         DecodeTransaction(v.Tx),
+		wtxd := &commandtypes.WalletTxDetailResult{
+			Tx:         commandtypes.DecodeTransaction(v.Tx),
 			Receipt:    v.Receipt,
 			Height:     v.Height,
 			Index:      v.Index,
@@ -236,7 +236,7 @@ func mergeBalance(cmd *cobra.Command, args []string) {
 		To: toAddr,
 	}
 	var res rpctypes.ReplyHashes
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.MergeBalance", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.MergeBalance", params, &res)
 	ctx.Run()
 }
 
@@ -269,7 +269,7 @@ func autoMine(cmd *cobra.Command, args []string) {
 		Flag: flag,
 	}
 	var res rpctypes.Reply
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "ticket.SetAutoMining", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "ticket.SetAutoMining", params, &res)
 	ctx.Run()
 }
 
@@ -338,7 +338,7 @@ func noBalanceTx(cmd *cobra.Command, args []string) {
 		Expire:  expire,
 		Privkey: privkey,
 	}
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.CreateNoBalanceTransaction", params, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.CreateNoBalanceTransaction", params, nil)
 	ctx.RunWithoutMarshal()
 }
 
@@ -414,7 +414,7 @@ func signRawTx(cmd *cobra.Command, args []string) {
 		Expire:  expire,
 		Index:   index,
 	}
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.SignRawTx", params, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SignRawTx", params, nil)
 	ctx.RunWithoutMarshal()
 }
 
@@ -442,7 +442,7 @@ func setFee(cmd *cobra.Command, args []string) {
 		Amount: amountInt64 * 1e4,
 	}
 	var res rpctypes.Reply
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.SetTxFee", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SetTxFee", params, &res)
 	ctx.Run()
 }
 
@@ -473,6 +473,6 @@ func sendTx(cmd *cobra.Command, args []string) {
 		Data:  data,
 	}
 
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.SendTransaction", params, nil)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SendTransaction", params, nil)
 	ctx.RunWithoutMarshal()
 }

--- a/system/dapp/driver.go
+++ b/system/dapp/driver.go
@@ -53,7 +53,7 @@ type Driver interface {
 	ExecDelLocal(tx *types.Transaction, receipt *types.ReceiptData, index int) (*types.LocalDBSet, error)
 	Query(funcName string, params []byte) (types.Message, error)
 	IsFree() bool
-	SetApi(client.QueueProtocolAPI)
+	SetAPI(client.QueueProtocolAPI)
 	SetTxs(txs []*types.Transaction)
 	SetReceipt(receipts []*types.ReceiptData)
 
@@ -105,13 +105,13 @@ func (d *DriverBase) GetFuncMap() map[string]reflect.Method {
 	return d.ety.GetExecFuncMap()
 }
 
-// SetApi set queue protocol api
-func (d *DriverBase) SetApi(api client.QueueProtocolAPI) {
+// SetAPI set queue protocol api
+func (d *DriverBase) SetAPI(api client.QueueProtocolAPI) {
 	d.api = api
 }
 
-// GetApi return queue protocol api
-func (d *DriverBase) GetApi() client.QueueProtocolAPI {
+// GetAPI return queue protocol api
+func (d *DriverBase) GetAPI() client.QueueProtocolAPI {
 	return d.api
 }
 

--- a/system/dapp/manage/commands/config.go
+++ b/system/dapp/manage/commands/config.go
@@ -107,6 +107,6 @@ func queryConfig(cmd *cobra.Command, args []string) {
 	params.Payload = req
 
 	var res types.ReplyConfig
-	ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.Query", params, &res)
+	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.Query", params, &res)
 	ctx.Run()
 }

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -36,7 +36,7 @@ var closeCmd = &cobra.Command{
 		//		rpc, _ := jsonrpc.NewJSONClient(rpcLaddr)
 		//		rpc.Call("Chain33.CloseQueue", nil, nil)
 		var res rpctypes.Reply
-		ctx := jsonclient.NewRpcCtx(rpcLaddr, "Chain33.CloseQueue", nil, &res)
+		ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.CloseQueue", nil, &res)
 		ctx.Run()
 	},
 }


### PR DESCRIPTION
函数名的修改，一些特殊字符使用大写
导入的包不能使用“.”， 修改