### PR TITLE
issue115 Fix amount

### DIFF
--- a/system/dapp/commands/types/utils.go
+++ b/system/dapp/commands/types/utils.go
@@ -80,6 +80,10 @@ func CreateRawTx(cmd *cobra.Command, to string, amount float64, note string, isW
 	if amount < 0 {
 		return "", types.ErrAmount
 	}
+	if float64(types.MaxCoin/types.Coin) < amount {
+		return "", types.ErrAmount
+	}
+
 	paraName, _ := cmd.Flags().GetString("paraName")
 	amountInt64 := int64(math.Trunc((amount+0.0000001)*1e4)) * 1e4
 	initExecName := execName

--- a/types/config.go
+++ b/types/config.go
@@ -33,7 +33,7 @@ var (
 // coin conversation
 const (
 	Coin            int64 = 1e8
-	MaxCoin         int64 = 1e17
+	MaxCoin         int64 = 9e18
 	MaxTxSize             = 100000 //100K
 	MaxTxGroupSize  int32 = 20
 	MaxBlockSize          = 20000000 //20M


### PR DESCRIPTION
fix #115 。
coin 上限为 9e18， 即 int64 的上限。
在客户端检查输出的amount