### PR TITLE
add by hyb for issues217

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -406,7 +406,6 @@ func (chain *BlockChain) InitIndexAndBestView() {
 		if header == nil {
 			chainlog.Error("InitIndexAndBestView GetBlockHeaderByHeight", "height", height, "err", err)
 			panic("InitIndexAndBestView fail!")
-			return
 		}
 
 		newNode := newBlockNodeByHeader(false, header, "self", -1)

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -402,8 +402,10 @@ func (chain *BlockChain) InitIndexAndBestView() {
 		height = 0
 	}
 	for ; height <= curheight; height++ {
-		header, _ := chain.blockStore.GetBlockHeaderByHeight(height)
+		header, err := chain.blockStore.GetBlockHeaderByHeight(height)
 		if header == nil {
+			chainlog.Error("InitIndexAndBestView GetBlockHeaderByHeight", "height", height, "err", err)
+			panic("InitIndexAndBestView fail!")
 			return
 		}
 


### PR DESCRIPTION
最新版本存在这方面的隐患，目前的代码处理：就是启动blockchian时在InitIndexAndBestView函数中通过height获取blockheader 然后将blockheader信息加载到缓存中，如果此时从数据库获取blockheader失败，会直接退出此函数导致ChainView 和index没有被初始化。

修改方案：在InitIndexAndBestView函数中，通过height获取blockheader失败时直接panic掉。