### PR TITLE
add by hyb for isRecordBlockSequenceValid

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -222,6 +222,10 @@ func (chain *BlockChain) GetOrphanPool() *OrphanPool {
 
 //InitBlockChain 区块链初始化
 func (chain *BlockChain) InitBlockChain() {
+	//isRecordBlockSequence配置的合法性检测
+	if !chain.cfg.IsParaChain {
+		chain.blockStore.isRecordBlockSequenceValid()
+	}
 	//先缓存最新的128个block信息到cache中
 	curheight := chain.GetBlockHeight()
 	if types.IsEnable("TxHeight") {

--- a/blockchain/sequences.go
+++ b/blockchain/sequences.go
@@ -93,6 +93,9 @@ func (chain *BlockChain) ProcAddBlockSeqCB(cb *types.BlockSeqCB) error {
 		return types.ErrInvalidParam
 	}
 
+	if !isRecordBlockSequence {
+		return types.ErrRecordBlockSequence
+	}
 	if chain.blockStore.seqCBNum() >= MaxSeqCB && !chain.blockStore.isSeqCBExist(cb.Name) {
 		return types.ErrTooManySeqCB
 	}

--- a/types/error.go
+++ b/types/error.go
@@ -175,6 +175,7 @@ var (
 	ErrCloneForkToExist   = errors.New("ErrCloneForkToExist")
 	ErrQueryThistIsNotSet = errors.New("ErrQueryThistIsNotSet")
 
-	ErrHeightLessZero = errors.New("ErrHeightLessZero")
-	ErrHeightOverflow = errors.New("ErrHeightOverflow")
+	ErrHeightLessZero      = errors.New("ErrHeightLessZero")
+	ErrHeightOverflow      = errors.New("ErrHeightOverflow")
+	ErrRecordBlockSequence = errors.New("ErrRecordBlockSequence")
 )

--- a/types/jsonpb/jsonpb_test_proto/test_objects.proto
+++ b/types/jsonpb/jsonpb_test_proto/test_objects.proto
@@ -161,9 +161,9 @@ message MsgWithRequired {
 }
 
 message MsgWithIndirectRequired {
-    optional MsgWithRequired     subm      = 1;
+    optional MsgWithRequired subm = 1;
     map<string, MsgWithRequired> map_field = 2;
-    repeated MsgWithRequired slice_field   = 3;
+    repeated MsgWithRequired slice_field = 3;
 }
 
 message MsgWithRequiredBytes {

--- a/types/proto/blockchain.proto
+++ b/types/proto/blockchain.proto
@@ -45,8 +45,8 @@ message Blocks {
 }
 
 message BlockSeqCB {
-    string name = 1;
-    string URL = 2;
+    string name   = 1;
+    string URL    = 2;
     string encode = 3;
 }
 
@@ -55,9 +55,9 @@ message BlockSeqCBs {
 }
 
 message BlockSeq {
-    int64 num = 1;
-    BlockSequence seq = 2;
-    BlockDetail detail = 3;
+    int64         num    = 1;
+    BlockSequence seq    = 2;
+    BlockDetail   detail = 3;
 }
 
 //节点ID以及对应的Block

--- a/types/proto/common.proto
+++ b/types/proto/common.proto
@@ -66,17 +66,17 @@ message ReqKey {
 }
 
 message ReqRandHash {
-	string execName = 1;
-	int64 height = 2;
-	int64 blockNum = 3;
+    string execName = 1;
+    int64  height   = 2;
+    int64  blockNum = 3;
 }
 
 /**
  *当前软件版本信息
  */
 message VersionInfo {
-    string title        = 1;
-    string app          = 2;
-    string chain33      = 3;
-    string localDb      = 4;
+    string title   = 1;
+    string app     = 2;
+    string chain33 = 3;
+    string localDb = 4;
 }

--- a/types/proto/rpc.proto
+++ b/types/proto/rpc.proto
@@ -125,7 +125,7 @@ service chain33 {
     //获取指定区间的block加载序列号信息
     rpc GetBlockSequences(ReqBlocks) returns (BlockSequences) {}
 
-    //get add block's sequence by hash
+    // get add block's sequence by hash
     rpc GetSequenceByHash(ReqHash) returns (Int64) {}
 
     //通过block hash 获取对应的blocks信息
@@ -139,7 +139,7 @@ service chain33 {
     rpc SignRawTx(ReqSignRawTx) returns (ReplySignRawTx) {}
 
     rpc CreateNoBalanceTransaction(NoBalanceTx) returns (ReplySignRawTx) {}
-    
-	// 获取随机HASH
-    rpc QueryRandNum(ReqRandHash) returns(ReplyHash) {}
+
+    // 获取随机HASH
+    rpc QueryRandNum(ReqRandHash) returns (ReplyHash) {}
 }

--- a/types/proto/statistic.proto
+++ b/types/proto/statistic.proto
@@ -73,8 +73,8 @@ message ReqGetExecBalance {
     bytes  addr      = 3;
     bytes  execAddr  = 4;
     string execer    = 5;
-    int64 count     = 6;
-    bytes nextKey   = 7;
+    int64  count     = 6;
+    bytes  nextKey   = 7;
 }
 
 message ExecBalanceItem {

--- a/types/rpc.pb.go
+++ b/types/rpc.pb.go
@@ -191,7 +191,7 @@ type Chain33Client interface {
 	GetLastBlockSequence(ctx context.Context, in *ReqNil, opts ...grpc.CallOption) (*Int64, error)
 	//获取指定区间的block加载序列号信息
 	GetBlockSequences(ctx context.Context, in *ReqBlocks, opts ...grpc.CallOption) (*BlockSequences, error)
-	//get add block's sequence by hash
+	// get add block's sequence by hash
 	GetSequenceByHash(ctx context.Context, in *ReqHash, opts ...grpc.CallOption) (*Int64, error)
 	//通过block hash 获取对应的blocks信息
 	GetBlockByHashes(ctx context.Context, in *ReqHashes, opts ...grpc.CallOption) (*BlockDetails, error)
@@ -760,7 +760,7 @@ type Chain33Server interface {
 	GetLastBlockSequence(context.Context, *ReqNil) (*Int64, error)
 	//获取指定区间的block加载序列号信息
 	GetBlockSequences(context.Context, *ReqBlocks) (*BlockSequences, error)
-	//get add block's sequence by hash
+	// get add block's sequence by hash
 	GetSequenceByHash(context.Context, *ReqHash) (*Int64, error)
 	//通过block hash 获取对应的blocks信息
 	GetBlockByHashes(context.Context, *ReqHashes) (*BlockDetails, error)


### PR DESCRIPTION
1，chain33启动之后增加isRecordBlockSequence配置的合法性检测
2，当isRecordBlockSequence没有被使能时不允许添加seq callback
3，在reindex时需要过滤掉seqCBPrefix和seqCBLastNumPrefix的key