### PR TITLE
Issues277

### DIFF
--- a/blockchain/blockstore.go
+++ b/blockchain/blockstore.go
@@ -1061,8 +1061,6 @@ func (bs *BlockStore) SetUpgradeMeta(meta *types.UpgradeMeta) error {
 
 //isRecordBlockSequence配置的合法性检测
 func (bs *BlockStore) isRecordBlockSequenceValid() {
-	storeLog.Error("isRecordBlockSequenceValid")
-
 	lastHeight := bs.Height()
 	lastSequence, err := bs.LoadBlockLastSequence()
 	if err != nil {

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -502,7 +502,7 @@ func testGetBlocksMsg(t *testing.T, blockchain *blockchain.BlockChain) {
 	if err == nil && blocks != nil {
 		for _, block := range blocks.Items {
 			if checkheight != block.Block.Height || block.Receipts == nil {
-				t.Log("TestGetBlocksMsg", "checkheight", checkheight, "block", block)
+				t.Error("TestGetBlocksMsg", "checkheight", checkheight, "block", block)
 			}
 			checkheight++
 		}

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -119,6 +119,7 @@ func TestBlockChain(t *testing.T) {
 	testProcGetBlockBySeqMsg(t, mock33, blockchain)
 	testProcBlockChainFork(t, blockchain)
 	testDelBlock(t, blockchain, curBlock)
+	testIsRecordFaultErr(t)
 
 }
 
@@ -501,7 +502,7 @@ func testGetBlocksMsg(t *testing.T, blockchain *blockchain.BlockChain) {
 	if err == nil && blocks != nil {
 		for _, block := range blocks.Items {
 			if checkheight != block.Block.Height || block.Receipts == nil {
-				t.Error("testGetBlocksMsg Block Height or Receipts check error")
+				t.Log("TestGetBlocksMsg", "checkheight", checkheight, "block", block)
 			}
 			checkheight++
 		}
@@ -954,4 +955,12 @@ func testAddBlockSeqCB(t *testing.T, blockchain *blockchain.BlockChain) {
 		t.Error("testAddBlockSeqCB  getSeqCBLastNum", "num", num, "name", cb.Name)
 	}
 	chainlog.Info("testAddBlockSeqCB end -------------------------")
+}
+func testIsRecordFaultErr(t *testing.T) {
+	chainlog.Info("testIsRecordFaultErr begin ---------------------")
+	isok := blockchain.IsRecordFaultErr(types.ErrFutureBlock)
+	if isok {
+		t.Error("testIsRecordFaultErr  IsRecordFaultErr", "isok", isok)
+	}
+	chainlog.Info("testIsRecordFaultErr begin ---------------------")
 }

--- a/blockchain/proc.go
+++ b/blockchain/proc.go
@@ -230,8 +230,7 @@ func (chain *BlockChain) getLastHeader(msg queue.Message) {
 func (chain *BlockChain) addBlockDetail(msg queue.Message) {
 	blockDetail := msg.Data.(*types.BlockDetail)
 	Height := blockDetail.Block.Height
-	chainlog.Info("EventAddBlockDetail", "height", blockDetail.Block.Height, "parent", common.ToHex(blockDetail.Block.ParentHash))
-	//首先判断共识过来的block的parenthash是否是当前bestchain链的tip区块，如果不是就直接返回错误给共识模块
+	chainlog.Info("EventAddBlockDetail", "height", blockDetail.Block.Height, "blockhash", common.ToHex(blockDetail.Block.Hash()), "parent", common.ToHex(blockDetail.Block.ParentHash))
 	blockDetail, err := chain.ProcAddBlockMsg(true, blockDetail, "self")
 	if err != nil {
 		chainlog.Error("addBlockDetail", "err", err.Error())
@@ -244,7 +243,6 @@ func (chain *BlockChain) addBlockDetail(msg queue.Message) {
 		msg.Reply(chain.client.NewMessage("consensus", types.EventAddBlockDetail, err))
 		return
 	}
-	//获取此高度区块执行后的区块详情blockdetail返回给共识模块
 	chainlog.Debug("addBlockDetail success ", "Height", Height, "hash", common.HashHex(blockDetail.Block.Hash()))
 	msg.Reply(chain.client.NewMessage("consensus", types.EventAddBlockDetail, blockDetail))
 }

--- a/blockchain/proc.go
+++ b/blockchain/proc.go
@@ -230,7 +230,7 @@ func (chain *BlockChain) getLastHeader(msg queue.Message) {
 func (chain *BlockChain) addBlockDetail(msg queue.Message) {
 	blockDetail := msg.Data.(*types.BlockDetail)
 	Height := blockDetail.Block.Height
-	chainlog.Info("EventAddBlockDetail", "height", blockDetail.Block.Height, "blockhash", common.ToHex(blockDetail.Block.Hash()), "parent", common.ToHex(blockDetail.Block.ParentHash))
+	chainlog.Info("EventAddBlockDetail", "height", blockDetail.Block.Height, "parent", common.ToHex(blockDetail.Block.ParentHash))
 	blockDetail, err := chain.ProcAddBlockMsg(true, blockDetail, "self")
 	if err != nil {
 		chainlog.Error("addBlockDetail", "err", err.Error())


### PR DESCRIPTION
1，关于testGetBlocksMsg测试偶尔报错的问题，在本地测试很多次都是ok的。需要增加日志输出查看具体的错误信息。
2，区块执行失败时，如下几种错误需要做特殊处理：
 types.ErrFutureBlock && !api.IsGrpcError(err) && !api.IsQueueError(err)这三种错误时不需要记录到故障节点中。
 a）本节点产生的block区块执行失败时需要删除本地index中对应的记录，返回错误信息给共识模块，由共识模块触发尝试发起再次执行。主要考虑平行链，通过测试看，区块执行失败后，平行链的para共识会再次发送此block给blockchain模块执行。
b）从别的节点同步过来的区块执行失败，由同步过来的下一个区块触发尝试再次执行，

close #277 