### PR TITLE
adapting wallet in parachain

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -250,6 +250,11 @@ func (r *RPC) Listen() (port1 int, port2 int) {
 	return port1, port2
 }
 
+// GetJRpcAPI get json rpc api
+func (r *RPC) GetJRpcAPI() *Chain33 {
+	return r.japi.jrpc
+}
+
 // GetQueueClient get queue client
 func (r *RPC) GetQueueClient() queue.Client {
 	return r.c

--- a/types/jsonpb/jsonpb_test_proto/test_objects.proto
+++ b/types/jsonpb/jsonpb_test_proto/test_objects.proto
@@ -161,9 +161,9 @@ message MsgWithRequired {
 }
 
 message MsgWithIndirectRequired {
-    optional MsgWithRequired     subm      = 1;
+    optional MsgWithRequired subm = 1;
     map<string, MsgWithRequired> map_field = 2;
-    repeated MsgWithRequired slice_field   = 3;
+    repeated MsgWithRequired slice_field = 3;
 }
 
 message MsgWithRequiredBytes {

--- a/types/jsonpb/jsonpb_test_proto/test_objects.proto
+++ b/types/jsonpb/jsonpb_test_proto/test_objects.proto
@@ -161,9 +161,9 @@ message MsgWithRequired {
 }
 
 message MsgWithIndirectRequired {
-    optional MsgWithRequired subm = 1;
+    optional MsgWithRequired     subm      = 1;
     map<string, MsgWithRequired> map_field = 2;
-    repeated MsgWithRequired slice_field = 3;
+    repeated MsgWithRequired slice_field   = 3;
 }
 
 message MsgWithRequiredBytes {

--- a/util/cli/chain33.go
+++ b/util/cli/chain33.go
@@ -171,6 +171,7 @@ func RunChain33(name string) {
 	log.Info("loading wallet module")
 	walletm := wallet.New(cfg.Wallet, sub.Wallet)
 	walletm.SetQueueClient(q.Client())
+	walletm.SetChain33RPC(rpcapi)
 
 	health := util.NewHealthCheckServer(q.Client())
 	health.Start(cfg.Health)

--- a/wallet/common/walletoperate.go
+++ b/wallet/common/walletoperate.go
@@ -73,4 +73,5 @@ type WalletOperate interface {
 	WaitTxs(hashes [][]byte) (ret []*types.TransactionDetail)
 	SendTransaction(payload types.Message, execer []byte, priv crypto.PrivKey, to string) (hash []byte, err error)
 	SendToAddress(priv crypto.PrivKey, addrto string, amount int64, note string, Istoken bool, tokenSymbol string) (*types.ReplyHash, error)
+	SendTx(tx *types.Transaction) (*types.Reply, error)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/33cn/chain33/rpc"
+
 	"github.com/33cn/chain33/account"
 	"github.com/33cn/chain33/client"
 	"github.com/33cn/chain33/common"
@@ -57,6 +59,7 @@ type Wallet struct {
 	client queue.Client
 	// 模块间通信的操作接口,建议用api代替client调用
 	api                client.QueueProtocolAPI
+	rpc                *rpc.RPC
 	mtx                sync.Mutex
 	timeout            *time.Timer
 	mineStatusReporter wcom.MineStatusReport
@@ -142,6 +145,11 @@ func (wallet *Wallet) GetConfig() *types.Wallet {
 // GetAPI 获取操作API
 func (wallet *Wallet) GetAPI() client.QueueProtocolAPI {
 	return wallet.api
+}
+
+// SetChain33RPC 设置chain33 rpc
+func (wallet *Wallet) SetChain33RPC(rpc *rpc.RPC) {
+	wallet.rpc = rpc
 }
 
 // GetMutex 获取钱包互斥量

--- a/wallet/wallet_proc.go
+++ b/wallet/wallet_proc.go
@@ -95,7 +95,7 @@ func (wallet *Wallet) ProcSignRawTx(unsigned *types.ReqSignRawTx) (string, error
 		return "", err
 	}
 	tx.SetExpire(time.Duration(expire))
-	if policy, ok := wcom.PolicyContainer[string(tx.Execer)]; ok {
+	if policy, ok := wcom.PolicyContainer[string(types.GetParaExec(tx.Execer))]; ok {
 		// 尝试让策略自己去完成签名
 		needSysSign, signtx, err := policy.SignTransaction(key, unsigned)
 		if !needSysSign {
@@ -909,7 +909,7 @@ func (wallet *Wallet) ProcWalletAddBlock(block *types.BlockDetail) {
 	newbatch := wallet.walletStore.NewBatch(true)
 	for index := 0; index < txlen; index++ {
 		tx := block.Block.Txs[index]
-		execer := string(tx.Execer)
+		execer := string(types.GetParaExec(tx.Execer))
 		// 执行钱包业务逻辑策略
 		if policy, ok := wcom.PolicyContainer[execer]; ok {
 			wtxdetail := policy.OnAddBlockTx(block, tx, int32(index), newbatch)
@@ -1031,7 +1031,7 @@ func (wallet *Wallet) ProcWalletDelBlock(block *types.BlockDetail) {
 		heightstr := fmt.Sprintf("%018d", blockheight)
 		tx := block.Block.Txs[index]
 
-		execer := string(tx.Execer)
+		execer := string(types.GetParaExec(tx.Execer))
 		// 执行钱包业务逻辑策略
 		if policy, ok := wcom.PolicyContainer[execer]; ok {
 			wtxdetail := policy.OnDeleteBlockTx(block, tx, int32(index), newbatch)


### PR DESCRIPTION
适配平行链下钱包模块：
1. wallet增加chain33 rpc接口访问，解决隐私合约需要将交易转发到主链问题
1. wallet 处理block消息时，分发del/add block任务时，通过执行器名称获取注册容器时需要区分平行链和主链合约