### PR TITLE
query transaction when bytes string is utf8, encode to string, not hex

### DIFF
--- a/rpc/types/code.go
+++ b/rpc/types/code.go
@@ -103,7 +103,7 @@ func DecodeTx(tx *types.Transaction) (*Transaction, error) {
 	}
 	var pljson json.RawMessage
 	if pl != nil {
-		pljson, _ = types.PBToJSON(pl)
+		pljson, _ = types.PBToJSONUTF8(pl)
 	}
 	result := &Transaction{
 		Execer:     string(tx.Execer),

--- a/types/executor.go
+++ b/types/executor.go
@@ -447,6 +447,20 @@ func getTo(payload interface{}) (string, bool) {
 	return "", false
 }
 
+//IsAssetsTransfer 是否是资产转移相关的交易
+func IsAssetsTransfer(payload interface{}) bool {
+	if _, ok := payload.(*AssetsTransfer); ok {
+		return true
+	}
+	if _, ok := payload.(*AssetsWithdraw); ok {
+		return true
+	}
+	if _, ok := payload.(*AssetsTransferToExec); ok {
+		return true
+	}
+	return false
+}
+
 //Amounter 转账金额
 type Amounter interface {
 	GetAmount() int64

--- a/types/executor_test.go
+++ b/types/executor_test.go
@@ -133,3 +133,10 @@ func TestCallCreateTx(t *testing.T) {
 	fee, _ = tx.GetRealFee(GInt("MinFee"))
 	assert.Equal(t, tx.Fee, fee)
 }
+
+func TestIsAssetsTransfer(t *testing.T) {
+	assert.Equal(t, true, IsAssetsTransfer(&AssetsTransfer{}))
+	assert.Equal(t, true, IsAssetsTransfer(&AssetsWithdraw{}))
+	assert.Equal(t, true, IsAssetsTransfer(&AssetsTransferToExec{}))
+	assert.Equal(t, false, IsAssetsTransfer(&Transaction{}))
+}

--- a/types/types.go
+++ b/types/types.go
@@ -214,6 +214,12 @@ func JSONToPB(data []byte, msg proto.Message) error {
 	return jsonpb.Unmarshal(bytes.NewReader(data), msg)
 }
 
+//JSONToPBUTF8 默认解码utf8的字符串成bytes
+func JSONToPBUTF8(data []byte, msg proto.Message) error {
+	decode := &jsonpb.Unmarshaler{EnableUTF8BytesToString: true}
+	return decode.Unmarshal(bytes.NewReader(data), msg)
+}
+
 //Hash  计算叶子节点的hash
 func (leafnode *LeafNode) Hash() []byte {
 	data, err := proto.Marshal(leafnode)
@@ -423,6 +429,16 @@ type ParaCrossTx interface {
 // PBToJSON 消息类型转换
 func PBToJSON(r Message) ([]byte, error) {
 	encode := &jsonpb.Marshaler{EmitDefaults: true}
+	var buf bytes.Buffer
+	if err := encode.Marshal(&buf, r); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// PBToJSONUTF8 消息类型转换
+func PBToJSONUTF8(r Message) ([]byte, error) {
+	encode := &jsonpb.Marshaler{EmitDefaults: true, EnableUTF8BytesToString: true}
 	var buf bytes.Buffer
 	if err := encode.Marshal(&buf, r); err != nil {
 		return nil, err

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -153,6 +153,30 @@ func TestProtoToJson(t *testing.T) {
 	assert.Equal(t, dr.Msg, []byte{})
 }
 
+func TestJsonpbUTF8(t *testing.T) {
+	r := &Reply{Msg: []byte("OK")}
+	b, err := PBToJSONUTF8(r)
+	assert.Nil(t, err)
+	assert.Equal(t, b, []byte(`{"isOk":false,"msg":"OK"}`))
+
+	var newreply Reply
+	err = JSONToPBUTF8(b, &newreply)
+	assert.Nil(t, err)
+	assert.Equal(t, r, &newreply)
+}
+
+func TestJsonpb(t *testing.T) {
+	r := &Reply{Msg: []byte("OK")}
+	b, err := PBToJSON(r)
+	assert.Nil(t, err)
+	assert.Equal(t, b, []byte(`{"isOk":false,"msg":"0x4f4b"}`))
+
+	var newreply Reply
+	err = JSONToPB(b, &newreply)
+	assert.Nil(t, err)
+	assert.Equal(t, r, &newreply)
+}
+
 func TestHex(t *testing.T) {
 	s := "0x4f4b"
 	b, err := common.FromHex(s)


### PR DESCRIPTION
fixed #297