### PR TITLE
add height set

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -151,6 +151,7 @@ func (exec *Executor) procExecQuery(msg queue.Message) {
 	driver.SetStateDB(db)
 	driver.SetAPI(exec.qclient)
 	driver.SetExecutorAPI(exec.qclient, exec.grpccli)
+	driver.SetEnv(header.GetHeight(), 0, 0)
 	//查询的情况下下，执行器不做严格校验，allow，尽可能的加载执行器，并且做查询
 
 	ret, err := driver.Query(data.FuncName, data.Param)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -151,7 +151,7 @@ func (exec *Executor) procExecQuery(msg queue.Message) {
 	driver.SetStateDB(db)
 	driver.SetAPI(exec.qclient)
 	driver.SetExecutorAPI(exec.qclient, exec.grpccli)
-	driver.SetEnv(header.GetHeight(), 0, 0)
+	driver.SetEnv(header.GetHeight(), header.GetBlockTime(), uint64(header.GetDifficulty()))
 	//查询的情况下下，执行器不做严格校验，allow，尽可能的加载执行器，并且做查询
 
 	ret, err := driver.Query(data.FuncName, data.Param)


### PR DESCRIPTION
EVM合约在查询数据时比较特殊，通过ABI查询和合约交易查询调用都可以查询数据，走的是同样的流程innerExec，在这个方法里面存在高度判断