### PR TITLE
修复平行链上面token资产查询，存在前缀混乱的bug

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -277,7 +277,7 @@ func (acc *DB) loadAccountsHistory(api client.QueueProtocolAPI, addrs []string, 
 // GetBalance 获取某个状态下账户余额
 func (acc *DB) GetBalance(api client.QueueProtocolAPI, in *types.ReqBalance) ([]*types.Account, error) {
 	// load account
-	if in.AssetExec == types.GetParaExec(in.Execer) || "" == in.Execer {
+	if in.AssetExec == string(types.GetParaExec([]byte(in.Execer))) || "" == in.Execer {
 		addrs := in.GetAddresses()
 		var exaddrs []string
 		for _, addr := range addrs {

--- a/account/account.go
+++ b/account/account.go
@@ -277,7 +277,7 @@ func (acc *DB) loadAccountsHistory(api client.QueueProtocolAPI, addrs []string, 
 // GetBalance 获取某个状态下账户余额
 func (acc *DB) GetBalance(api client.QueueProtocolAPI, in *types.ReqBalance) ([]*types.Account, error) {
 	// load account
-	if in.AssetExec == in.Execer || "" == in.Execer || types.GetTitle()+in.AssetExec == in.Execer {
+	if in.AssetExec == types.GetParaExec(in.Execer) || "" == in.Execer {
 		addrs := in.GetAddresses()
 		var exaddrs []string
 		for _, addr := range addrs {

--- a/account/account.go
+++ b/account/account.go
@@ -277,7 +277,7 @@ func (acc *DB) loadAccountsHistory(api client.QueueProtocolAPI, addrs []string, 
 // GetBalance 获取某个状态下账户余额
 func (acc *DB) GetBalance(api client.QueueProtocolAPI, in *types.ReqBalance) ([]*types.Account, error) {
 	// load account
-	if in.AssetExec == in.Execer || "" == in.Execer {
+	if in.AssetExec == in.Execer || "" == in.Execer || types.GetTitle()+in.AssetExec == in.Execer {
 		addrs := in.GetAddresses()
 		var exaddrs []string
 		for _, addr := range addrs {


### PR DESCRIPTION
平行链上面token资产查询，存在前缀混乱的情况 

close 33cn/plugin#227 