### PR TITLE
在chain33 中 删除一些ticket 相关的接口

### DIFF
--- a/rpc/jrpchandler.go
+++ b/rpc/jrpchandler.go
@@ -924,58 +924,6 @@ func (c *Chain33) GetFatalFailure(in *types.ReqNil, result *interface{}) error {
 
 }
 
-// QueryTicketStat quert stat of ticket
-func (c *Chain33) QueryTicketStat(in *types.LocalDBGet, result *interface{}) error {
-	reply, err := c.cli.LocalGet(in)
-	if err != nil {
-		return err
-	}
-
-	var ticketStat types.TicketStatistic
-	err = types.Decode(reply.Values[0], &ticketStat)
-	if err != nil {
-		return err
-	}
-	*result = ticketStat
-	return nil
-}
-
-// QueryTicketInfo query ticket information
-func (c *Chain33) QueryTicketInfo(in *types.LocalDBGet, result *interface{}) error {
-	reply, err := c.cli.LocalGet(in)
-	if err != nil {
-		return err
-	}
-
-	var ticketInfo types.TicketMinerInfo
-	err = types.Decode(reply.Values[0], &ticketInfo)
-	if err != nil {
-		return err
-	}
-	*result = ticketInfo
-	return nil
-}
-
-// QueryTicketInfoList query ticket list information
-func (c *Chain33) QueryTicketInfoList(in *types.LocalDBList, result *interface{}) error {
-	reply, err := c.cli.LocalList(in)
-	if err != nil {
-		return err
-	}
-
-	var ticketInfo types.TicketMinerInfo
-	var ticketList []types.TicketMinerInfo
-	for _, v := range reply.Values {
-		err = types.Decode(v, &ticketInfo)
-		if err != nil {
-			return err
-		}
-		ticketList = append(ticketList, ticketInfo)
-	}
-	*result = ticketList
-	return nil
-}
-
 // DecodeRawTransaction decode rawtransaction
 func (c *Chain33) DecodeRawTransaction(in *types.ReqDecodeRawTransaction, result *interface{}) error {
 	reply, err := c.cli.DecodeRawTransaction(in)

--- a/rpc/jrpchandler.go
+++ b/rpc/jrpchandler.go
@@ -873,6 +873,9 @@ func (c *Chain33) IsNtpClockSync(in *types.ReqNil, result *interface{}) error {
 
 // QueryTotalFee query total fee
 func (c *Chain33) QueryTotalFee(in *types.LocalDBGet, result *interface{}) error {
+	if in == nil || len(in.Keys) > 1 {
+		return types.ErrInvalidParam
+	}
 	reply, err := c.cli.LocalGet(in)
 	if err != nil {
 		return err

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -104,11 +104,6 @@ func TestJSONClient_Call(t *testing.T) {
 	err = jsonClient.Call("Chain33.QueryTotalFee", &types.ReqSignRawTx{}, &fee)
 	assert.NotNil(t, err)
 
-	var ticket []types.TicketMinerInfo
-	api.On("LocalList", mock.Anything).Return(nil, errors.New("error value"))
-	err = jsonClient.Call("Chain33.QueryTicketInfoList", &types.ReqSignRawTx{}, &ticket)
-	assert.NotNil(t, err)
-
 	var retNtp bool
 	api.On("IsNtpClockSync", mock.Anything).Return(&types.Reply{IsOk: true, Msg: []byte("yes")}, nil)
 	err = jsonClient.Call("Chain33.IsNtpClockSync", &types.ReqNil{}, &retNtp)


### PR DESCRIPTION
fixed #311 

这几个接口是stat 相关的接口，目前，因为stat 相关的实现上存在错误，所以像删除这些接口。

同时，我们需要多 LocalList 和 LocalGet 两个接口做一个限制，需要限制分页的数目，以及读取的数目。

fixed #321