### PR TITLE
配置文件里mempool的用户交易数最大限制无效

### DIFF
--- a/cmd/chain33/chain33.test.toml
+++ b/cmd/chain33/chain33.test.toml
@@ -67,20 +67,19 @@ keyFile="key.pem"
 name="timeline"
 poolCacheSize=10240
 minTxFee=100000
-maxTxNumPerAccount=10000
+maxTxNumPerAccount=100
 
 [mempool.sub.timeline]
 poolCacheSize=10240
-minTxFee=100000
-maxTxNumPerAccount=10000
 
-[mempool.sub.trade]
+[mempool.sub.score]
 poolCacheSize=10240
-minTxFee=100000
-maxTxNumPerAccount=10000
 timeParam=1      #时间占价格比例
-priceConstant=1  #一个合适的常量
-pricePower=0     #手续费占常量比例
+priceConstant=1544  #手续费相对于时间的一个合适的常量,取当前unxi时间戳前四位数,排序时手续费高1e-5~=快1s
+pricePower=1     #常量比例
+
+[mempool.sub.price]
+poolCacheSize=10240
 
 [consensus]
 name="solo"

--- a/cmd/chain33/chain33.toml
+++ b/cmd/chain33/chain33.toml
@@ -67,20 +67,19 @@ keyFile="key.pem"
 name="timeline"
 poolCacheSize=10240
 minTxFee=100000
-maxTxNumPerAccount=10000
+maxTxNumPerAccount=100
 
 [mempool.sub.timeline]
 poolCacheSize=10240
-minTxFee=100000
-maxTxNumPerAccount=10000
 
-[mempool.sub.trade]
+[mempool.sub.score]
 poolCacheSize=10240
-minTxFee=100000
-maxTxNumPerAccount=10000
 timeParam=1      #时间占价格比例
-priceConstant=1  #一个合适的常量
-pricePower=0     #手续费占常量比例
+priceConstant=1544  #手续费相对于时间的一个合适的常量,取当前unxi时间戳前四位数,排序时手续费高1e-5~=快1s
+pricePower=1     #常量比例
+
+[mempool.sub.price]
+poolCacheSize=10240
 
 [consensus]
 name="solo"

--- a/system/mempool/check.go
+++ b/system/mempool/check.go
@@ -63,7 +63,7 @@ func (mem *Mempool) checkTx(msg *queue.Message) *queue.Message {
 	}
 	// 检查交易账户在mempool中是否存在过多交易
 	from := tx.From()
-	if mem.TxNumOfAccount(from) >= maxTxNumPerAccount {
+	if mem.TxNumOfAccount(from) >= mem.cfg.MaxTxNumPerAccount {
 		msg.Data = types.ErrManyTx
 		return msg
 	}

--- a/system/mempool/mempool_test.go
+++ b/system/mempool/mempool_test.go
@@ -451,7 +451,7 @@ func TestAddMoreTxThanMaxAccountTx(t *testing.T) {
 		return
 	}
 	if mem.Size() != 2 {
-		t.Error("TestAddMaxAccountTx failed", "size", mem.Size())
+		t.Error("TestAddMoreTxThanMaxAccountTx failed", "size", mem.Size())
 	}
 }
 

--- a/system/mempool/mempool_test.go
+++ b/system/mempool/mempool_test.go
@@ -439,6 +439,22 @@ func TestAddMoreTxThanPoolSize(t *testing.T) {
 	}
 }
 
+func TestAddMoreTxThanMaxAccountTx(t *testing.T) {
+	q, mem := initEnv(4)
+	mem.cfg.MaxTxNumPerAccount = 2
+	defer q.Close()
+	defer mem.Close()
+
+	err := add4Tx(mem.client)
+	if err != nil {
+		t.Error("add tx error", err.Error())
+		return
+	}
+	if mem.Size() != 2 {
+		t.Error("TestAddMaxAccountTx failed", "size", mem.Size())
+	}
+}
+
 func TestRemoveTxOfBlock(t *testing.T) {
 	q, mem := initEnv(0)
 	defer q.Close()


### PR DESCRIPTION
检查交易的判断条件里用到的判断依据由const里的maxTxNumPerAccount改成了cfg里的MaxTxNumPerAccoun，删除了timeline中冗余的配置参数