### PR TITLE
增加多线程计算merkle tree 的功能

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -36,6 +36,7 @@ type DB struct {
 	execAccountKeyPerfix []byte
 	execer               string
 	symbol               string
+	accountKeyBuffer     []byte
 }
 
 // NewCoinsAccount 新建账户
@@ -63,6 +64,8 @@ func NewAccountDB(execer string, symbol string, db dbm.KV) (*DB, error) {
 func newAccountDB(prefix string) *DB {
 	acc := &DB{}
 	acc.accountKeyPerfix = []byte(prefix)
+	acc.accountKeyBuffer = make([]byte, 0, len(acc.accountKeyPerfix)+64)
+	acc.accountKeyBuffer = append(acc.accountKeyBuffer, acc.accountKeyPerfix...)
 	acc.execAccountKeyPerfix = append([]byte(prefix), []byte("exec-")...)
 	//alog.Warn("NewAccountDB", "prefix", prefix, "key1", string(acc.accountKeyPerfix), "key2", string(acc.execAccountKeyPerfix))
 	return acc
@@ -74,9 +77,15 @@ func (acc *DB) SetDB(db dbm.KV) *DB {
 	return acc
 }
 
+func (acc *DB) accountReadKey(addr string) []byte {
+	acc.accountKeyBuffer = acc.accountKeyBuffer[0:len(acc.accountKeyPerfix)]
+	acc.accountKeyBuffer = append(acc.accountKeyBuffer, []byte(addr)...)
+	return acc.accountKeyBuffer
+}
+
 // LoadAccount 根据地址载入账户
 func (acc *DB) LoadAccount(addr string) *types.Account {
-	value, err := acc.db.Get(acc.AccountKey(addr))
+	value, err := acc.db.Get(acc.accountReadKey(addr))
 	if err != nil {
 		return &types.Account{Addr: addr}
 	}
@@ -126,10 +135,11 @@ func (acc *DB) Transfer(from, to string, amount int64) (*types.Receipt, error) {
 			Prev:    &copyto,
 			Current: accTo,
 		}
-
-		acc.SaveAccount(accFrom)
-		acc.SaveAccount(accTo)
-		return acc.transferReceipt(accFrom, accTo, receiptBalanceFrom, receiptBalanceTo), nil
+		fromkv := acc.GetKVSet(accFrom)
+		tokv := acc.GetKVSet(accTo)
+		acc.SaveKVSet(fromkv)
+		acc.SaveKVSet(tokv)
+		return acc.transferReceipt(fromkv, tokv, receiptBalanceFrom, receiptBalanceTo), nil
 	}
 
 	return nil, types.ErrNoBalance
@@ -146,12 +156,12 @@ func (acc *DB) depositBalance(execaddr string, amount int64) (*types.Receipt, er
 		Prev:    &copyacc,
 		Current: acc1,
 	}
-	acc.SaveAccount(acc1)
+	kv := acc.GetKVSet(acc1)
+	acc.SaveKVSet(kv)
 	log1 := &types.ReceiptLog{
 		Ty:  int32(types.TyLogDeposit),
 		Log: types.Encode(receiptBalance),
 	}
-	kv := acc.GetKVSet(acc1)
 	return &types.Receipt{
 		Ty:   types.ExecOk,
 		KV:   kv,
@@ -159,7 +169,7 @@ func (acc *DB) depositBalance(execaddr string, amount int64) (*types.Receipt, er
 	}, nil
 }
 
-func (acc *DB) transferReceipt(accFrom, accTo *types.Account, receiptFrom, receiptTo proto.Message) *types.Receipt {
+func (acc *DB) transferReceipt(fromkv, tokv []*types.KeyValue, receiptFrom, receiptTo proto.Message) *types.Receipt {
 	ty := int32(types.TyLogTransfer)
 	log1 := &types.ReceiptLog{
 		Ty:  ty,
@@ -169,8 +179,9 @@ func (acc *DB) transferReceipt(accFrom, accTo *types.Account, receiptFrom, recei
 		Ty:  ty,
 		Log: types.Encode(receiptTo),
 	}
-	kv := acc.GetKVSet(accFrom)
-	kv = append(kv, acc.GetKVSet(accTo)...)
+	kv := make([]*types.KeyValue, 0, len(fromkv)+len(tokv))
+	kv = append(kv, fromkv...)
+	kv = append(kv, tokv...)
 	return &types.Receipt{
 		Ty:   types.ExecOk,
 		KV:   kv,
@@ -186,13 +197,21 @@ func (acc *DB) SaveAccount(acc1 *types.Account) {
 	}
 }
 
+//SaveKVSet 保存Key Value set
+func (acc *DB) SaveKVSet(set []*types.KeyValue) {
+	for i := 0; i < len(set); i++ {
+		acc.db.Set(set[i].GetKey(), set[i].Value)
+	}
+}
+
 // GetKVSet 将账户数据转为数据库存储kv
 func (acc *DB) GetKVSet(acc1 *types.Account) (kvset []*types.KeyValue) {
 	value := types.Encode(acc1)
-	kvset = append(kvset, &types.KeyValue{
+	kvset = make([]*types.KeyValue, 1)
+	kvset[0] = &types.KeyValue{
 		Key:   acc.AccountKey(acc1.Addr),
 		Value: value,
-	})
+	}
 	return kvset
 }
 
@@ -217,6 +236,7 @@ func (acc *DB) LoadAccountsDB(addrs []string) (accs []*types.Account, err error)
 
 // AccountKey return the key of address in DB
 func (acc *DB) AccountKey(address string) (key []byte) {
+	key = make([]byte, 0, len(acc.accountKeyPerfix)+len(address))
 	key = append(key, acc.accountKeyPerfix...)
 	key = append(key, []byte(address)...)
 	return key

--- a/account/execaccount.go
+++ b/account/execaccount.go
@@ -52,6 +52,7 @@ func (acc *DB) GetExecKVSet(execaddr string, acc1 *types.Account) (kvset []*type
 }
 
 func (acc *DB) execAccountKey(address, execaddr string) (key []byte) {
+	key = make([]byte, 0, len(acc.execAccountKeyPerfix)+len(execaddr)+len(address)+1)
 	key = append(key, acc.execAccountKeyPerfix...)
 	key = append(key, []byte(execaddr)...)
 	key = append(key, []byte(":")...)

--- a/common/hash.go
+++ b/common/hash.go
@@ -105,21 +105,12 @@ func Sha3(b []byte) []byte {
 	return data[:]
 }
 
-func sha2Hash(b []byte, out []byte) {
-	s := sha256.New()
-	s.Write(b[:])
-	tmp := s.Sum(nil)
-	s.Reset()
-	s.Write(tmp)
-	copy(out[:], s.Sum(nil))
-}
-
 // Sha2Sum Returns hash: SHA256( SHA256( data ) )
 // Where possible, using ShaHash() should be a bit faster
 func Sha2Sum(b []byte) []byte {
-	out := make([]byte, 32)
-	sha2Hash(b, out[:])
-	return out[:]
+	tmp := sha256.Sum256(b)
+	tmp = sha256.Sum256(tmp[:])
+	return tmp[:]
 }
 
 func rimpHash(in []byte, out []byte) {

--- a/common/merkle/merkle.go
+++ b/common/merkle/merkle.go
@@ -7,8 +7,8 @@ package merkle
 
 import (
 	"bytes"
-	"crypto/sha256"
 
+	"github.com/33cn/chain33/common"
 	"github.com/33cn/chain33/types"
 )
 
@@ -48,6 +48,100 @@ known ways of changing the transactions without affecting the merkle
 root.
 */
 
+/*GetMerkleRoot This implements a constant-space merkle root/path calculator, limited to 2^32 leaves. */
+//flage =1 只计算roothash  flage =2 只计算branch  flage =3 计算roothash 和 branch
+func getMerkleRoot(hashes [][]byte) []byte {
+	cache := make([]byte, 64)
+	level := 0
+	for len(hashes) > 1 {
+		if len(hashes)&1 != 0 { //奇数
+			hashes = append(hashes, hashes[len(hashes)-1])
+		}
+		index := 0
+		for i := 0; i < len(hashes); i += 2 {
+			hashes[index] = GetHashFromTwoHash(cache, hashes[i], hashes[i+1])
+			index++
+		}
+		level++
+		hashes = hashes[0:index]
+	}
+	if len(hashes) == 0 {
+		return nil
+	}
+	return hashes[0]
+}
+
+func log2(data int) int {
+	level := 1
+	if data == 0 {
+		return 0
+	}
+	for {
+		data = data / 2
+		if data <= 1 {
+			return level
+		}
+		level++
+	}
+}
+
+func getMerkleRootPad(hashes [][]byte, step int) []byte {
+	level1 := log2(len(hashes))
+	level2 := log2(step)
+	root := getMerkleRoot(hashes)
+	cache := make([]byte, 64)
+	for i := 0; i < level2-level1; i++ {
+		root = GetHashFromTwoHash(cache, root, root)
+	}
+	return root
+}
+
+type childstate struct {
+	hash  []byte
+	index int
+}
+
+var step = 256
+
+//GetMerkleRoot 256构成一个组，进行计算
+func GetMerkleRoot(hashes [][]byte) []byte {
+	if len(hashes) < 2*step {
+		return getMerkleRoot(hashes)
+	}
+	ch := make(chan *childstate, 10)
+	//pad to step
+	rem := len(hashes) % step
+	l := len(hashes) / step
+	if rem != 0 {
+		l++
+	}
+	for i := 0; i < l; i++ {
+		end := (i + 1) * step
+		if end > len(hashes) {
+			end = len(hashes)
+		}
+		child := hashes[i*step : end]
+		go func(index int, h [][]byte) {
+			var subhash []byte
+			if len(h) != step {
+				subhash = getMerkleRootPad(h, step)
+			} else {
+				subhash = getMerkleRoot(h)
+			}
+			ch <- &childstate{
+				hash:  subhash,
+				index: index,
+			}
+		}(i, child)
+	}
+	childlist := make([][]byte, l)
+	for i := 0; i < l; i++ {
+		sub := <-ch
+		childlist[sub.index] = sub.hash
+	}
+	return getMerkleRoot(childlist)
+}
+
 /*Computation This implements a constant-space merkle root/path calculator, limited to 2^32 leaves. */
 //flage =1 只计算roothash  flage =2 只计算branch  flage =3 计算roothash 和 branch
 func Computation(leaves [][]byte, flage int, branchpos uint32) (roothash []byte, mutated bool, pbranch [][]byte) {
@@ -66,6 +160,7 @@ func Computation(leaves [][]byte, flage int, branchpos uint32) (roothash []byte,
 	var matchlevel uint32 = 0xff
 	mutated = false
 	var matchh bool
+	cache := make([]byte, 64)
 	for count, h = range leaves {
 
 		if (uint32(count) == branchpos) && (flage&2) != 0 {
@@ -89,7 +184,7 @@ func Computation(leaves [][]byte, flage int, branchpos uint32) (roothash []byte,
 				mutated = true
 			}
 			//计算inner[level] + h 的hash值
-			h = GetHashFromTwoHash(inner[level], h)
+			h = GetHashFromTwoHash(cache, inner[level], h)
 		}
 		inner[level] = h
 		if matchh {
@@ -105,7 +200,7 @@ func Computation(leaves [][]byte, flage int, branchpos uint32) (roothash []byte,
 		if (flage&2) != 0 && matchh {
 			branch = append(branch, h)
 		}
-		h = GetHashFromTwoHash(h, h)
+		h = GetHashFromTwoHash(cache, h, h)
 		count += (1 << level)
 		level++
 		// And propagate the result upwards accordingly.
@@ -118,7 +213,7 @@ func Computation(leaves [][]byte, flage int, branchpos uint32) (roothash []byte,
 					matchh = true
 				}
 			}
-			h = GetHashFromTwoHash(inner[level], h)
+			h = GetHashFromTwoHash(cache, inner[level], h)
 			level++
 		}
 	}
@@ -126,29 +221,13 @@ func Computation(leaves [][]byte, flage int, branchpos uint32) (roothash []byte,
 }
 
 //GetHashFromTwoHash 计算左右节点hash的父hash
-func GetHashFromTwoHash(left []byte, right []byte) []byte {
+func GetHashFromTwoHash(parent []byte, left []byte, right []byte) []byte {
 	if left == nil || right == nil {
 		return nil
 	}
-	leftlen := len(left)
-	rightlen := len(right)
-
-	parent := make([]byte, leftlen+rightlen)
-
 	copy(parent, left)
-	copy(parent[leftlen:], right)
-	hash := sha256.Sum256(parent)
-	parenthash := sha256.Sum256(hash[:])
-	return parenthash[:]
-}
-
-//GetMerkleRoot 获取merkle roothash
-func GetMerkleRoot(leaves [][]byte) (roothash []byte) {
-	if leaves == nil {
-		return nil
-	}
-	proothash, _, _ := Computation(leaves, 1, 0)
-	return proothash
+	copy(parent[32:], right)
+	return common.Sha2Sum(parent)
 }
 
 //GetMerkleBranch 获取指定txindex的branch position 从0开始
@@ -160,11 +239,12 @@ func GetMerkleBranch(leaves [][]byte, position uint32) [][]byte {
 //GetMerkleRootFromBranch 通过branch 获取对应的roothash 用于指定txhash的proof证明
 func GetMerkleRootFromBranch(merkleBranch [][]byte, leaf []byte, Index uint32) []byte {
 	hash := leaf
+	hashcache := make([]byte, 64)
 	for _, branch := range merkleBranch {
 		if (Index & 1) != 0 {
-			hash = GetHashFromTwoHash(branch, hash)
+			hash = GetHashFromTwoHash(hashcache, branch, hash)
 		} else {
-			hash = GetHashFromTwoHash(hash, branch)
+			hash = GetHashFromTwoHash(hashcache, hash, branch)
 		}
 		Index >>= 1
 	}

--- a/common/merkle/merkle_test.go
+++ b/common/merkle/merkle_test.go
@@ -290,10 +290,13 @@ func getHashFromTwoHash(left []byte, right []byte) []byte {
 //优化办法:
 //1. 减少内存分配
 //2. 改进算法
+
+var benchlen = 100000
+
 func BenchmarkGetMerkelRoot(b *testing.B) {
 	b.ReportAllocs()
 	var hashlist [][]byte
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < benchlen; i++ {
 		key := common.GetRandBytes(32, 32)
 		hashlist = append(hashlist, key)
 	}
@@ -312,7 +315,7 @@ func BenchmarkGetMerkelRoot(b *testing.B) {
 func BenchmarkGetMerkelRoot2(b *testing.B) {
 	b.ReportAllocs()
 	var hashlist [][]byte
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < benchlen; i++ {
 		key := common.GetRandBytes(32, 32)
 		hashlist = append(hashlist, key)
 	}

--- a/common/merkle/merkle_test.go
+++ b/common/merkle/merkle_test.go
@@ -6,7 +6,10 @@ package merkle
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"testing"
+
+	"github.com/33cn/chain33/common"
 )
 
 //测试两个交易的roothash以及branch.获取bitcoin的99997 block作为验证
@@ -246,5 +249,57 @@ func Test_SixTxMerkle(t *testing.T) {
 			}
 			t.Logf("Test_SixTxMerkle bitroothash == brroothash :%d", txindex)
 		}
+	}
+}
+
+func BenchmarkHashTwo(b *testing.B) {
+	b.ReportAllocs()
+	left := common.GetRandBytes(32, 32)
+	right := common.GetRandBytes(32, 32)
+	for i := 0; i < b.N; i++ {
+		getHashFromTwoHash(left, right)
+	}
+}
+
+func BenchmarkHashTwo2(b *testing.B) {
+	b.ReportAllocs()
+	left := common.GetRandBytes(32, 32)
+	right := common.GetRandBytes(32, 32)
+	for i := 0; i < b.N; i++ {
+		GetHashFromTwoHash(left, right)
+	}
+}
+
+//原来的版本更快，这个方案只是做一个性能测试的对比
+func getHashFromTwoHash(left []byte, right []byte) []byte {
+	if left == nil || right == nil {
+		return nil
+	}
+	h := sha256.New()
+	h.Write(left)
+	h.Write(right)
+	hash1 := h.Sum(nil)
+	h.Reset()
+	h.Write(hash1)
+	return h.Sum(nil)
+}
+
+//优化办法:
+//1. 减少内存分配
+//2. 改进算法
+func BenchmarkGetMerkelRoot(b *testing.B) {
+	b.ReportAllocs()
+	var hashlist [][]byte
+	for i := 0; i < 10000; i++ {
+		key := common.GetRandBytes(32, 32)
+		hashlist = append(hashlist, key)
+	}
+	var prevroot []byte
+	for i := 0; i < b.N; i++ {
+		newroot := GetMerkleRoot(hashlist)
+		if prevroot != nil && !bytes.Equal(prevroot, newroot) {
+			b.Error("root is not the same")
+		}
+		prevroot = newroot
 	}
 }

--- a/executor/execenv.go
+++ b/executor/execenv.go
@@ -105,17 +105,18 @@ func (e *executor) processFee(tx *types.Transaction) (*types.Receipt, error) {
 		copyfrom := *accFrom
 		accFrom.Balance = accFrom.GetBalance() - tx.Fee
 		receiptBalance := &types.ReceiptAccountTransfer{Prev: &copyfrom, Current: accFrom}
-		e.coinsAccount.SaveAccount(accFrom)
-		return e.cutFeeReceipt(accFrom, receiptBalance), nil
+		set := e.coinsAccount.GetKVSet(accFrom)
+		e.coinsAccount.SaveKVSet(set)
+		return e.cutFeeReceipt(set, receiptBalance), nil
 	}
 	return nil, types.ErrNoBalance
 }
 
-func (e *executor) cutFeeReceipt(acc *types.Account, receiptBalance proto.Message) *types.Receipt {
+func (e *executor) cutFeeReceipt(kvset []*types.KeyValue, receiptBalance proto.Message) *types.Receipt {
 	feelog := &types.ReceiptLog{Ty: types.TyLogFee, Log: types.Encode(receiptBalance)}
 	return &types.Receipt{
 		Ty:   types.ExecPack,
-		KV:   e.coinsAccount.GetKVSet(acc),
+		KV:   kvset,
 		Logs: append([]*types.ReceiptLog{}, feelog),
 	}
 }

--- a/util/exec.go
+++ b/util/exec.go
@@ -212,27 +212,3 @@ func DelDupKey(kvs []*types.KeyValue) []*types.KeyValue {
 	}
 	return kvs[0:index]
 }
-
-func delDupKey(kvs []*types.KeyValue) []*types.KeyValue {
-	dupindex := make(map[string]int)
-	hasdup := false
-	for i, kv := range kvs {
-		if _, ok := dupindex[string(kv.Key)]; ok {
-			hasdup = true
-		}
-		dupindex[string(kv.Key)] = i
-	}
-	//没有重复的情况下，不需要重新处理
-	if !hasdup {
-		return kvs
-	}
-	index := 0
-	for i, kv := range kvs {
-		lastindex := dupindex[string(kv.Key)]
-		if i == lastindex {
-			kvs[index] = kv
-			index++
-		}
-	}
-	return kvs[0:index]
-}

--- a/util/exec.go
+++ b/util/exec.go
@@ -192,6 +192,31 @@ func DelDupKey(kvs []*types.KeyValue) []*types.KeyValue {
 	dupindex := make(map[string]int)
 	hasdup := false
 	for i, kv := range kvs {
+		skey := string(kv.Key)
+		if index, ok := dupindex[skey]; ok {
+			hasdup = true
+			kvs[index] = nil
+		}
+		dupindex[skey] = i
+	}
+	//没有重复的情况下，不需要重新处理
+	if !hasdup {
+		return kvs
+	}
+	index := 0
+	for _, kv := range kvs {
+		if kv != nil {
+			kvs[index] = kv
+			index++
+		}
+	}
+	return kvs[0:index]
+}
+
+func delDupKey(kvs []*types.KeyValue) []*types.KeyValue {
+	dupindex := make(map[string]int)
+	hasdup := false
+	for i, kv := range kvs {
 		if _, ok := dupindex[string(kv.Key)]; ok {
 			hasdup = true
 		}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -7,6 +7,7 @@ package util
 import (
 	"testing"
 
+	"github.com/33cn/chain33/common"
 	"github.com/33cn/chain33/common/address"
 	"github.com/33cn/chain33/queue"
 	"github.com/33cn/chain33/types"
@@ -155,6 +156,26 @@ func TestDelDupKey(t *testing.T) {
 	}
 	kvs = DelDupKey(kvs)
 	assert.Equal(t, kvs, result)
+}
+
+func BenchmarkDelDupKey(b *testing.B) {
+	var kvs []*types.KeyValue
+	for i := 0; i < 1000; i++ {
+		key := common.GetRandBytes(20, 40)
+		value := common.GetRandBytes(40, 60)
+		kvs = append(kvs, &types.KeyValue{Key: key, Value: value})
+		if i%10 == 0 {
+			kvs = append(kvs, &types.KeyValue{Key: key, Value: value})
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		testkv := make([]*types.KeyValue, len(kvs))
+		copy(testkv, kvs)
+		newkvs := DelDupKey(testkv)
+		if newkvs[len(newkvs)-1] == nil {
+			assert.NotNil(b, newkvs[len(newkvs)-1])
+		}
+	}
 }
 
 func TestDelDupTx(t *testing.T) {


### PR DESCRIPTION
增加多线程计算merkle tree 的功能
在mac pro 测试，10万个 merkle tree ，从 79ms 降低为 25ms

大幅度减少 内存分配的数量 （account 模块中）

目前 ExecBlock 测试的结果为：

    10	 188000355 ns/op	71508354 B/op	 1211029 allocs/op
