### PR TITLE
reply close error

### DIFF
--- a/queue/client.go
+++ b/queue/client.go
@@ -177,7 +177,7 @@ func (client *client) Close() {
 	atomic.StoreInt32(&client.isClosed, 1)
 	close(client.Recv())
 	for msg := range client.Recv() {
-		msg.ReplyErr("client.close", types.ErrChannelClosed)
+		msg.Reply(client.NewMessage(msg.Topic, msg.Ty, types.ErrChannelClosed))
 	}
 }
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -187,11 +187,17 @@ func TestClientClose(t *testing.T) {
 				}()
 				msg := client.NewMessage("mempool", types.EventTx, "hello")
 				err := client.Send(msg, true)
+				if err == types.ErrChannelClosed {
+					return
+				}
 				if err != nil { //chan is closed
 					t.Error(err)
 					return
 				}
 				_, err = client.Wait(msg)
+				if err == types.ErrChannelClosed {
+					return
+				}
 				if err != nil {
 					t.Error(err)
 					return
@@ -465,6 +471,9 @@ func TestChannelClose(t *testing.T) {
 			return
 		}
 		_, err = client.Wait(msg)
+		if err == types.ErrChannelClosed {
+			return
+		}
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
回复错误的时候，直接回复 error msg ，如果用 ReplyErr 会引起问题。

TODO: ReplyErr 需要重新命名，以防止出现类似的误解。