### PR TITLE
add keepalive for grpc client

### DIFF
--- a/rpc/grpcclient/client.go
+++ b/rpc/grpcclient/client.go
@@ -2,9 +2,11 @@ package grpcclient
 
 import (
 	"sync"
+	"time"
 
 	"github.com/33cn/chain33/types"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 // paraChainGrpcRecSize 平行链receive最大100M
@@ -28,9 +30,14 @@ func NewMainChainClient(grpcaddr string) (types.Chain33Client, error) {
 	if paraRemoteGrpcClient == "" {
 		paraRemoteGrpcClient = "127.0.0.1:8802"
 	}
-
+	kp := keepalive.ClientParameters{
+		Time:                time.Second * 5,
+		Timeout:             time.Second * 20,
+		PermitWithoutStream: false,
+	}
 	conn, err := grpc.Dial(NewMultipleURL(paraRemoteGrpcClient), grpc.WithInsecure(),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(paraChainGrpcRecSize)))
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(paraChainGrpcRecSize)),
+		grpc.WithKeepaliveParams(kp))
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/grpcclient/client.go
+++ b/rpc/grpcclient/client.go
@@ -33,7 +33,7 @@ func NewMainChainClient(grpcaddr string) (types.Chain33Client, error) {
 	kp := keepalive.ClientParameters{
 		Time:                time.Second * 5,
 		Timeout:             time.Second * 20,
-		PermitWithoutStream: false,
+		PermitWithoutStream: true,
 	}
 	conn, err := grpc.Dial(NewMultipleURL(paraRemoteGrpcClient), grpc.WithInsecure(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(paraChainGrpcRecSize)),


### PR DESCRIPTION
给grpc 的客户端加上 keepalive， 防止tcp链接异常导致请求卡住。
