### PR TITLE
exec allow add height

### DIFF
--- a/system/dapp/register.go
+++ b/system/dapp/register.go
@@ -64,6 +64,7 @@ func LoadDriver(name string, height int64) (driver Driver, err error) {
 func LoadDriverAllow(tx *types.Transaction, index int, height int64) (driver Driver) {
 	exec, err := LoadDriver(string(tx.Execer), height)
 	if err == nil {
+		exec.SetEnv(height, 0, 0)
 		err = exec.Allow(tx, index)
 	}
 	if err != nil {


### PR DESCRIPTION
Allow 函数 能访问到区块高度，用于分叉处理。