### PR TITLE
Skiplist 添加WalkS

### DIFF
--- a/common/skiplist/skiplist.go
+++ b/common/skiplist/skiplist.go
@@ -63,6 +63,23 @@ func (sli *Iterator) Last() *SkipValue {
 	return sli.node.Value
 }
 
+// Prev 获取迭代器的上一个节点
+func (sli *Iterator) Prev() *Iterator {
+	sli.node = sli.node.Prev()
+	return sli
+}
+
+// Next 获取迭代器的下一个节点
+func (sli *Iterator) Next() *Iterator {
+	sli.node = sli.node.Next()
+	return sli
+}
+
+// Value 获取迭代器当前的Value
+func (sli *Iterator) Value() *SkipValue {
+	return sli.node.Value
+}
+
 // Prev 获取上一个节点
 func (node *skipListNode) Prev() *skipListNode {
 	if node == nil || node.prev == nil {
@@ -260,13 +277,25 @@ func (sl *SkipList) Print() {
 	}
 }
 
-//Walk 遍历整个结构，如果cb 返回false 那么停止遍历
+//Walk 遍历整个结构中SkipValue的Value,如果cb 返回false 那么停止遍历
 func (sl *SkipList) Walk(cb func(value interface{}) bool) {
 	for e := sl.header.Next(); e != nil; e = e.Next() {
 		if cb == nil {
 			return
 		}
 		if !cb(e.Value.Value) {
+			return
+		}
+	}
+}
+
+//WalkS 遍历整个结构中的SkipValue,如果cb 返回false 那么停止遍历
+func (sl *SkipList) WalkS(cb func(value interface{}) bool) {
+	for e := sl.header.Next(); e != nil; e = e.Next() {
+		if cb == nil {
+			return
+		}
+		if !cb(e.Value) {
 			return
 		}
 	}

--- a/common/skiplist/skiplist_test.go
+++ b/common/skiplist/skiplist_test.go
@@ -78,3 +78,36 @@ func TestWalk(t *testing.T) {
 	l.Print()
 
 }
+
+func TestWalkS(t *testing.T) {
+	l := NewSkipList(nil)
+	l.Insert(s1)
+	l.Insert(s2)
+	var score [2]int64
+	var data [2]string
+	i := 0
+	l.WalkS(func(value interface{}) bool {
+		score[i] = value.(*SkipValue).Score
+		data[i] = value.(*SkipValue).Value.(string)
+		i++
+		return true
+	})
+	assert.Equal(t, data[0], "222")
+	assert.Equal(t, data[1], "111")
+	assert.Equal(t, int64(2), score[0])
+	assert.Equal(t, int64(1), score[1])
+
+	var score2 [2]int64
+	var data2 [2]string
+	i = 0
+	l.WalkS(func(value interface{}) bool {
+		score2[i] = value.(*SkipValue).Score
+		data2[i] = value.(*SkipValue).Value.(string)
+		i++
+		return false
+	})
+	assert.Equal(t, "222", data2[0])
+	assert.Equal(t, "", data2[1])
+	assert.Equal(t, int64(2), score2[0])
+	assert.Equal(t, int64(0), score2[1])
+}


### PR DESCRIPTION
跳跃表迭代器新增Prev()和Next()用于迭代下一个节点和上一个节点，WalkS用于迭代SkipValue，弥补Walk函数无法迭代获取Score