### PR TITLE
add by hyb for goroutine

### DIFF
--- a/blockchain/blocksyn.go
+++ b/blockchain/blocksyn.go
@@ -121,9 +121,10 @@ func (chain *BlockChain) SynRoutine() {
 	//2分钟尝试检测一次最优链，确保本节点在最优链
 	checkBestChainTicker := time.NewTicker(120 * time.Second)
 
-	//节点启动后首先尝试开启快速下载模式
-	chain.tickerwg.Add(1)
-	go chain.FastDownLoadBlocks()
+	//节点启动后首先尝试开启快速下载模式,目前默认开启
+	if GetDownloadSyncStatus() {
+		go chain.FastDownLoadBlocks()
+	}
 	for {
 		select {
 		case <-chain.quit:

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -507,7 +507,7 @@ func testGetBlocksMsg(t *testing.T, blockchain *blockchain.BlockChain) {
 	blocks, err := blockchain.ProcGetBlockDetailsMsg(&reqBlock)
 	if err == nil && blocks != nil {
 		for _, block := range blocks.Items {
-			if checkheight != block.Block.Height || block.Receipts == nil {
+			if checkheight != block.Block.Height {
 				t.Error("TestGetBlocksMsg", "checkheight", checkheight, "block", block)
 			}
 			checkheight++

--- a/blockchain/download.go
+++ b/blockchain/download.go
@@ -71,7 +71,6 @@ func UpdateDownloadSyncStatus(Sync bool) {
 
 //FastDownLoadBlocks 开启快速下载区块的模式
 func (chain *BlockChain) FastDownLoadBlocks() {
-	defer chain.tickerwg.Done()
 	curHeight := chain.GetBlockHeight()
 	lastTempHight := chain.GetLastTempBlockHeight()
 
@@ -222,7 +221,7 @@ func (chain *BlockChain) WriteBlockToDbTemp(block *types.Block) error {
 	defer func() {
 		chainlog.Debug("WriteBlockToDbTemp", "height", block.Height, "sync", sync, "cost", types.Since(beg))
 	}()
-	newbatch := chain.blockStore.NewBatch(false)
+	newbatch := chain.blockStore.NewBatch(sync)
 
 	blockByte, err := proto.Marshal(block)
 	if err != nil {

--- a/blockchain/proc.go
+++ b/blockchain/proc.go
@@ -162,15 +162,16 @@ func (chain *BlockChain) addBlock(msg *queue.Message) {
 	blockpid := msg.Data.(*types.BlockPid)
 	//chainlog.Error("addBlock", "height", blockpid.Block.Height, "pid", blockpid.Pid)
 	if GetDownloadSyncStatus() {
-		//downLoadTask 运行时设置对应的blockdone
-		if chain.downLoadTask.InProgress() {
-			chain.downLoadTask.Done(blockpid.Block.GetHeight())
-		}
+
 		err := chain.WriteBlockToDbTemp(blockpid.Block)
 		if err != nil {
 			chainlog.Error("WriteBlockToDbTemp", "height", blockpid.Block.Height, "err", err.Error())
 			reply.IsOk = false
 			reply.Msg = []byte(err.Error())
+		}
+		//downLoadTask 运行时设置对应的blockdone
+		if chain.downLoadTask.InProgress() {
+			chain.downLoadTask.Done(blockpid.Block.GetHeight())
 		}
 	} else {
 		_, err := chain.ProcAddBlockMsg(false, &types.BlockDetail{Block: blockpid.Block}, blockpid.Pid)


### PR DESCRIPTION
目前的处理是只要区块下载成功就通知下载任务继续下一个区间区块的下载，这样在机械硬盘的电脑写数据库比较慢的情况下，导致 blockchain这边积压很多需要写数据库的goroutine资源。

修改成在快速下载区块保存到数据库之后再通知下载任务继续下个区间的下载。这样可以减少goroutine资源的使用。

在节点启动后首先需要执行完上次已经下载并临时存贮在db中的blocks时，要允许close chain进程，所以取消go chain.FastDownLoadBlocks() 的WaitGroup等待处理