### PR TITLE
fix coins withdraw command

### DIFF
--- a/system/dapp/commands/bty.go
+++ b/system/dapp/commands/bty.go
@@ -107,12 +107,14 @@ func createWithdraw(cmd *cobra.Command, args []string) {
 	exec, _ := cmd.Flags().GetString("exec")
 	amount, _ := cmd.Flags().GetFloat64("amount")
 	note, _ := cmd.Flags().GetString("note")
-	execAddr, err := commandtypes.GetExecAddr(exec)
+	paraName, _ := cmd.Flags().GetString("paraName")
+	realExec := getRealExecName(paraName, exec)
+	execAddr, err := commandtypes.GetExecAddr(realExec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
-	txHex, err := commandtypes.CreateRawTx(cmd, execAddr, amount, note, true, "", exec)
+	txHex, err := commandtypes.CreateRawTx(cmd, execAddr, amount, note, true, "", realExec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
@@ -145,12 +147,14 @@ func sendToExec(cmd *cobra.Command, args []string) {
 	exec, _ := cmd.Flags().GetString("exec")
 	amount, _ := cmd.Flags().GetFloat64("amount")
 	note, _ := cmd.Flags().GetString("note")
-	execAddr, err := commandtypes.GetExecAddr(exec)
+	paraName, _ := cmd.Flags().GetString("paraName")
+	realExec := getRealExecName(paraName, exec)
+	execAddr, err := commandtypes.GetExecAddr(realExec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
-	txHex, err := commandtypes.CreateRawTx(cmd, execAddr, amount, note, false, "", exec)
+	txHex, err := commandtypes.CreateRawTx(cmd, execAddr, amount, note, false, "", realExec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return

--- a/system/dapp/commands/types/utils.go
+++ b/system/dapp/commands/types/utils.go
@@ -90,15 +90,13 @@ func CreateRawTx(cmd *cobra.Command, to string, amount float64, note string, isW
 
 	paraName, _ := cmd.Flags().GetString("paraName")
 	amountInt64 := int64(math.Trunc((amount+0.0000001)*1e4)) * 1e4
-	initExecName := execName
-	execName = getRealExecName(paraName, execName)
 	if execName != "" && !types.IsAllowExecName([]byte(execName), []byte(execName)) {
 		return "", types.ErrExecNameNotMatch
 	}
 	var tx *types.Transaction
 	transfer := &cty.CoinsAction{}
 	if !isWithdraw {
-		if initExecName != "" {
+		if execName != "" {
 			v := &cty.CoinsAction_TransferToExec{TransferToExec: &types.AssetsTransferToExec{Amount: amountInt64, Note: []byte(note), ExecName: execName, To: to}}
 			transfer.Value = v
 			transfer.Ty = cty.CoinsActionTransferToExec


### PR DESCRIPTION
解决平行链命令行进行coins withdraw操作时，合约地址不正确
```
chain33-para send bty withdraw -e paracross -a 1 -k addr
```
采用如上命令，to地址是paracross而不是平行链下的paracross地址