### PR TITLE
add by hyb for issues493 getrealtoaddr

### DIFF
--- a/wallet/wallet_proc.go
+++ b/wallet/wallet_proc.go
@@ -977,8 +977,8 @@ func (wallet *Wallet) ProcWalletAddBlock(block *types.BlockDetail) {
 				walletlog.Debug("ProcWalletAddBlock", "fromaddress", fromaddress)
 				continue
 			}
-			//toaddr
-			toaddr := tx.GetTo()
+			//toaddr获取交易中真实的接收地址，主要是针对para
+			toaddr := tx.GetRealToAddr()
 			if len(toaddr) != 0 && wallet.AddrInWallet(toaddr) {
 				param.sendRecvFlag = recvTx
 				wallet.buildAndStoreWalletTxDetail(param)

--- a/wallet/wallet_proc.go
+++ b/wallet/wallet_proc.go
@@ -1082,7 +1082,7 @@ func (wallet *Wallet) ProcWalletDelBlock(block *types.BlockDetail) {
 				continue
 			}
 			//toaddr
-			toaddr := tx.GetTo()
+			toaddr := tx.GetRealToAddr()
 			if len(toaddr) != 0 && wallet.AddrInWallet(toaddr) {
 				newbatch.Delete(wcom.CalcTxKey(heightstr))
 			}


### PR DESCRIPTION
修改钱包按照实际的to地址存储交易信息，主要是平行链交易tx.GetTo()获取的是平行链的合约地址，不是真实的接受地址，获取真实的接受地址需要通过tx.GetRealToAddr（）来获取