### PR TITLE
calculate real fee of wasm tx in different way

### DIFF
--- a/types/tx.go
+++ b/types/tx.go
@@ -546,6 +546,13 @@ func (tx *Transaction) GetRealFee(minFee int64) (int64, error) {
 	}
 	// 检查交易费是否小于最低值
 	realFee := int64(txSize/1000+1) * minFee
+	//wasm的交易统一收0.05个币的手续费
+	if bytes.Contains(tx.Execer, []byte("user.wasm.")) { //wasmtypes.UserWasmX
+		wasmFee := int64(5000000) //0.05个币 wasmtypes.MinWasmFee
+		if realFee < wasmFee {
+			realFee = wasmFee
+		}
+	}
 	return realFee, nil
 }
 


### PR DESCRIPTION
获取真实交易费时，对wasm的交易单独处理，暂定为一个定值，或者从payload里解析gas limit作为该笔交易的最小交易费