### PR TITLE
fix rpc param check

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -76,17 +76,15 @@ func (j *JSONRPCServer) Listen() (int, error) {
 			}
 			//格式做一个检查
 			client, err := parseJSONRpcParams(data)
-			errstr := "nil"
 			if err != nil {
-				errstr = err.Error()
+				err = fmt.Errorf(`invalid json request err:%s`, err.Error())
+				log.Debug("JSONRPCServer", "request", string(data), "parseErr", err)
+				writeError(w, r, 0, err.Error())
+				return
 			}
 			funcName := strings.Split(client.Method, ".")[len(strings.Split(client.Method, "."))-1]
 			if !checkFilterPrintFuncBlacklist(funcName) {
-				log.Debug("JSONRPCServer", "request", string(data), "err", errstr)
-			}
-			if err != nil {
-				writeError(w, r, 0, fmt.Sprintf(`parse request err %s`, err.Error()))
-				return
+				log.Debug("JSONRPCServer", "request", string(data))
 			}
 			//Release local request
 			ipaddr := net.ParseIP(ip)


### PR DESCRIPTION
fix #534 
>rpc解析非法参数后，未处理空指针情况