### PR TITLE
Mempool levelfee

### DIFF
--- a/system/mempool/base.go
+++ b/system/mempool/base.go
@@ -285,7 +285,10 @@ func (mem *Mempool) RemoveTxsOfBlock(block *types.Block) bool {
 func (mem *Mempool) GetProperFeeRate() int64 {
 	baseFeeRate := mem.cache.GetProperFee()
 	if mem.cfg.IsLevelFee {
-		return mem.getLevelFeeRate(baseFeeRate)
+		levelFeeRate := mem.getLevelFeeRate(mem.cfg.MinTxFee)
+		if levelFeeRate > baseFeeRate {
+			return levelFeeRate
+		}
 	}
 	return baseFeeRate
 }

--- a/system/mempool/base.go
+++ b/system/mempool/base.go
@@ -296,11 +296,10 @@ func (mem *Mempool) getLevelFeeRate(baseFeeRate int64) int64 {
 	sumByte := mem.cache.TotalByte()
 	maxTxNumber := types.GetP(mem.Height()).MaxTxNumber
 	switch {
-	case (sumByte > int64(types.MaxBlockSize/100) && sumByte < int64(types.MaxBlockSize/20)) ||
-		(int64(mem.Size()) >= maxTxNumber/10 && int64(mem.Size()) < maxTxNumber/2):
-		feeRate = 10 * baseFeeRate
 	case sumByte >= int64(types.MaxBlockSize/20) || int64(mem.Size()) >= maxTxNumber/2:
 		feeRate = 100 * baseFeeRate
+	case sumByte >= int64(types.MaxBlockSize/100)|| int64(mem.Size()) >= maxTxNumber/10:
+		feeRate = 10 * baseFeeRate
 	default:
 		return baseFeeRate
 	}

--- a/system/mempool/base.go
+++ b/system/mempool/base.go
@@ -298,7 +298,7 @@ func (mem *Mempool) getLevelFeeRate(baseFeeRate int64) int64 {
 	switch {
 	case sumByte >= int64(types.MaxBlockSize/20) || int64(mem.Size()) >= maxTxNumber/2:
 		feeRate = 100 * baseFeeRate
-	case sumByte >= int64(types.MaxBlockSize/100)|| int64(mem.Size()) >= maxTxNumber/10:
+	case sumByte >= int64(types.MaxBlockSize/100) || int64(mem.Size()) >= maxTxNumber/10:
 		feeRate = 10 * baseFeeRate
 	default:
 		feeRate = baseFeeRate

--- a/system/mempool/base.go
+++ b/system/mempool/base.go
@@ -301,7 +301,7 @@ func (mem *Mempool) getLevelFeeRate(baseFeeRate int64) int64 {
 	case sumByte >= int64(types.MaxBlockSize/100)|| int64(mem.Size()) >= maxTxNumber/10:
 		feeRate = 10 * baseFeeRate
 	default:
-		return baseFeeRate
+		feeRate = baseFeeRate
 	}
 	if feeRate > 10000000 {
 		feeRate = 10000000

--- a/system/mempool/check.go
+++ b/system/mempool/check.go
@@ -124,7 +124,7 @@ func (mem *Mempool) checkTxs(msg *queue.Message) *queue.Message {
 // checkLevelFee 检查阶梯手续费
 func (mem *Mempool) checkLevelFee(tx *types.TransactionCache) error {
 	//获取mempool里所有交易手续费总和
-	feeRate := mem.GetProperFeeRate()
+	feeRate := mem.getLevelFeeRate(mem.cfg.MinTxFee)
 	totalfee, err := tx.GetTotalFee(feeRate)
 	if err != nil {
 		return err


### PR DESCRIPTION
配置文件里新增一个阶梯手续费的开关
当这个开关处于开启状态时候
mempool里的交易总字节数大于等于区块最大字节数二十分之一或者交易数量大于区块最大交易数的二分之一时，手续费率就会提升百倍
mempool里的交易总字节数大于等于区块最大字节数的百分之一或者交易数量大于等于区块最大交易数量的十分之一时，手续费率就会提升十倍
手续费率最高不会超过0.1
该合适的手续费率目前是通过排队方式的合适手续费率获得，默认排队方式是timeline，合适手续费率为配置里mempool的minTxFee，即最小手续费
修改了之前 https://github.com/33cn/chain33/pull/538 判断的逻辑