### PR TITLE
fix chain33_GetCoinSymbol 在平行链返回 symbol 为 配置值

### DIFF
--- a/build/system-test-rpc.sh
+++ b/build/system-test-rpc.sh
@@ -339,8 +339,12 @@ chain33_GetSeqCallBackLastNum() {
 }
 
 chain33_GetCoinSymbol() {
+    symbol="bty"
+    if [ "$IS_PARA" == true ]; then
+        symbol="paracoin"
+    fi
     r1=$(curl -ksd '{"method":"Chain33.GetCoinSymbol","params":[]}' ${MAIN_HTTP} | jq -r ".result.data")
-    [ "$r1" == "bty" ]
+    [ "$r1" == "$symbol" ]
     echo_rst "$FUNCNAME" "$?"
 }
 


### PR DESCRIPTION
fix chain33_GetCoinSymbol 在平行链返回 symbol 为 配置值, 不是bty