### PR TITLE
add by hyb for rollback-seq

### DIFF
--- a/blockchain/blockstore.go
+++ b/blockchain/blockstore.go
@@ -1267,25 +1267,12 @@ func (bs *BlockStore) CheckSequenceStatus(recordSequence bool) int {
 			storeLog.Error("CheckSequenceStatus", "lastHeight", lastHeight, "lastSequence", lastSequence)
 			return seqStatusNeedCreate
 		}
-		//通过lastSequence获取对应的blockhash ！= lastHeader.hash 报错
-		if lastSequence != -1 {
-			blockSequence, err := bs.GetBlockSequence(lastSequence)
-			if err != nil {
-				storeLog.Error("CheckSequenceStatus", "lastSequence", lastSequence, "GetBlockSequence err", err)
-				panic(err)
-			}
-			lastHeader := bs.LastHeader()
-			if !bytes.Equal(lastHeader.Hash, blockSequence.Hash) {
-				storeLog.Error("CheckSequenceStatus:", "lastHeight", lastHeight, "lastSequence", lastSequence, "lastHeader.Hash", common.ToHex(lastHeader.Hash), "blockSequence.Hash", common.ToHex(blockSequence.Hash))
-				return seqStatusNeedCreate
-			}
-		}
 		return seqStatusOk
 	}
 	//去使能isRecordBlockSequence时的检测
 	if lastSequence != -1 {
 		storeLog.Error("CheckSequenceStatus", "lastSequence", lastSequence)
-		return seqStatusNeedDelete
+		panic("can not disable isRecordBlockSequence")
 	}
 	return seqStatusOk
 }

--- a/blockchain/blockstore_test.go
+++ b/blockchain/blockstore_test.go
@@ -176,10 +176,4 @@ func TestSeqCreateAndDelete(t *testing.T) {
 	seq, err = blockStore.GetSequenceByHash([]byte("0"))
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), seq)
-
-	blockStore.saveSequence = false
-	blockStore.DeleteSequences(10)
-	seq, err = blockStore.LoadBlockLastSequence()
-	assert.NotNil(t, err)
-	assert.Equal(t, int64(-1), seq)
 }

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -248,8 +248,6 @@ func (chain *BlockChain) InitBlockChain() {
 	seqStatus := chain.blockStore.CheckSequenceStatus(chain.isRecordBlockSequence)
 	if seqStatus == seqStatusNeedCreate {
 		chain.blockStore.CreateSequences(100000)
-	} else if seqStatus == seqStatusNeedDelete {
-		chain.blockStore.DeleteSequences(100000)
 	}
 
 	//先缓存最新的128个block信息到cache中


### PR DESCRIPTION
1，在区块回滚的过程中lastblock和lastseq对应的block不是同一个区块，所以取消这个lastblock和lastseq对应block hash值的比较。
2，不允许用户关闭isRecordBlockSequence功能。