### PR TITLE
add by hyb for fast download timeout proc

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1088,6 +1088,7 @@ func testReadBlockToExec(t *testing.T, chain *blockchain.BlockChain) {
 	chainlog.Info("testReadBlockToExec begin ---------------------")
 	curheight := chain.GetBlockHeight()
 	chain.ReadBlockToExec(curheight+1, false)
+	chain.DownLoadTimeOutProc(curheight - 1)
 	chainlog.Info("testReadBlockToExec end ---------------------")
 }
 func testWriteBlockToDbTemp(t *testing.T, chain *blockchain.BlockChain) {

--- a/blockchain/download.go
+++ b/blockchain/download.go
@@ -331,3 +331,22 @@ func (chain *BlockChain) ReqDownLoadBlocks() {
 		}
 	}
 }
+
+//DownLoadTimeOutProc 快速下载模式下载区块超时的处理函数
+func (chain *BlockChain) DownLoadTimeOutProc(height int64) {
+	info := chain.GetDownLoadInfo()
+	synlog.Info("DownLoadTimeOutProc", "timeoutheight", height, "StartHeight", info.StartHeight, "EndHeight", info.EndHeight)
+
+	if info.StartHeight != -1 && info.EndHeight != -1 && info.Pids != nil {
+		//从超时的高度继续下载区块
+		if info.StartHeight > height {
+			chain.UpdateDownLoadStartHeight(height)
+			info.StartHeight = height
+		}
+		synlog.Info("DownLoadTimeOutProc:FetchBlock", "StartHeight", info.StartHeight, "EndHeight", info.EndHeight, "pids", len(info.Pids))
+		err := chain.FetchBlock(info.StartHeight, info.EndHeight, info.Pids, true)
+		if err != nil {
+			synlog.Error("DownLoadTimeOutProc:FetchBlock", "err", err)
+		}
+	}
+}

--- a/blockchain/task_test.go
+++ b/blockchain/task_test.go
@@ -61,3 +61,35 @@ func TestTasks(t *testing.T) {
 		}
 	}
 }
+
+func TestTaskTimeOut(t *testing.T) {
+	task := newTask(time.Millisecond * 10)
+	if task.InProgress() {
+		task.Cancel()
+		t.Log("task not start")
+		return
+	}
+	timeoutcb := func(height int64) {
+		timeOutProc(height)
+	}
+	task.Start(1, 10, nil, timeoutcb)
+	perm := rand.Perm(10)
+	for i := 0; i < len(perm); i++ {
+		time.Sleep(time.Millisecond * 10)
+		task.Done(int64(perm[i]) + 1)
+		if i < len(perm)-1 && !task.InProgress() {
+			task.Cancel()
+			t.Log("task not done, but InProgress is false")
+			return
+		}
+		if i == len(perm)-1 && task.InProgress() {
+			task.Cancel()
+			t.Log("task is done, but InProgress is true")
+			return
+		}
+	}
+}
+
+func timeOutProc(height int64) {
+	chainlog.Info("timeOutProc", "height", height)
+}

--- a/blockchain/task_test.go
+++ b/blockchain/task_test.go
@@ -17,7 +17,7 @@ func TestTask(t *testing.T) {
 		t.Log("task not start")
 		return
 	}
-	task.Start(1, 10, nil)
+	task.Start(1, 10, nil, nil)
 	perm := rand.Perm(10)
 	for i := 0; i < len(perm); i++ {
 		time.Sleep(time.Millisecond * 5)
@@ -43,7 +43,7 @@ func TestTasks(t *testing.T) {
 			t.Log("task not start")
 			return
 		}
-		task.Start(1, 10, nil)
+		task.Start(1, 10, nil, nil)
 		perm := rand.Perm(10)
 		for i := 0; i < len(perm); i++ {
 			time.Sleep(time.Millisecond / 10)


### PR DESCRIPTION
解决issues566问题：
在task任务模块增加一个超时回调处理接口。

当在快速同步模式时，挂接下载超时调用接口DownLoadTimeOutProc从而再次触发从超时的高度继续同步数据

普通下载模式是通过定时器触发的，所以普通下载模式不需要挂接超时的处理函数。

目前下载区块主要分三种情况：
a，节点启动后的快速同步；
b，定时触发的普通同步 ；
c，检测到分叉之后的回滚数据的下载处理；

限制条件：
1，在普通同步模式时，如果检测到有分叉需要回滚处理，此时需要暂停普通同步的任务，等分叉处理之后再开启普通同步。
,2，当正在处理分叉回滚时，不允许触发定时的普通同步数据，直到分叉回滚处理结束后再触发普通同步