### PR TITLE
p2p:add manual cancel download grpc stream

### DIFF
--- a/p2p/downloadblocks.go
+++ b/p2p/downloadblocks.go
@@ -233,8 +233,11 @@ func (d *DownloadJob) syncDownloadBlock(peer *Peer, inv *pb.Inventory, bchan cha
 	var p2pdata pb.P2PGetData
 	p2pdata.Version = d.p2pcli.network.node.nodeInfo.channelVersion
 	p2pdata.Invs = []*pb.Inventory{inv}
+	ctx, cancel := context.WithCancel(context.Background())
+	//主动取消grpc流, 即时释放资源
+	defer cancel()
 	beg := pb.Now()
-	resp, err := peer.mconn.gcli.GetData(context.Background(), &p2pdata, grpc.FailFast(true))
+	resp, err := peer.mconn.gcli.GetData(ctx, &p2pdata, grpc.FailFast(true))
 	P2pComm.CollectPeerStat(err, peer)
 	if err != nil {
 		log.Error("syncDownloadBlock", "GetData err", err.Error())


### PR DESCRIPTION
目前p2p下载区块基于grpc 服务端流式调用，由于改成了接收到数据立即返回，没有等待Recv流io.EOF，grpc内部相关的gorouting没有释放，造成泄漏，需要完成调用后主动结束stream，即时释放资源 fixed 33cn/plugin#581