### PR TITLE
add by hyb for get wallet tx list from last or first

### DIFF
--- a/system/dapp/commands/wallet.go
+++ b/system/dapp/commands/wallet.go
@@ -171,14 +171,14 @@ func addWalletListTxsFlags(cmd *cobra.Command) {
 	cmd.Flags().Int32P("count", "c", 0, "number of transactions")
 	cmd.MarkFlagRequired("count")
 
-	cmd.Flags().Int32P("direction", "d", 1, "query direction (0: pre page, 1: next page)")
+	cmd.Flags().Int32P("direction", "d", 0, "query direction (0: pre page, 1: next page)")
 }
 
 func walletListTxs(cmd *cobra.Command, args []string) {
 	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
 	txHash, _ := cmd.Flags().GetString("from")
 	count, _ := cmd.Flags().GetInt32("count")
-	direction, _ := cmd.Flags().GetInt32("dir")
+	direction, _ := cmd.Flags().GetInt32("direction")
 	params := rpctypes.ReqWalletTransactionList{
 		FromTx:    txHash,
 		Count:     count,

--- a/wallet/common/store.go
+++ b/wallet/common/store.go
@@ -202,10 +202,16 @@ func (store *Store) GetTxDetailByIter(TxList *types.ReqWalletTransactionList) (*
 	}
 
 	var txbytes [][]byte
-	//FromTx是空字符串时。默认从最新的交易开始取count个
+	//FromTx是空字符串时，
+	//Direction == 0从最新的交易开始倒序取count个
+	//Direction == 1从最早的交易开始正序取count个
 	if len(TxList.FromTx) == 0 {
 		list := store.NewListHelper()
-		txbytes = list.IteratorScanFromLast(CalcTxKey(""), TxList.Count)
+		if TxList.Direction == 0 {
+			txbytes = list.IteratorScanFromLast(CalcTxKey(""), TxList.Count)
+		} else {
+			txbytes = list.IteratorScanFromFirst(CalcTxKey(""), TxList.Count)
+		}
 		if len(txbytes) == 0 {
 			storelog.Error("GetTxDetailByIter IteratorScanFromLast does not exist tx!")
 			return nil, types.ErrTxNotExist

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -415,9 +415,11 @@ func testProcImportPrivKey(t *testing.T, wallet *Wallet) {
 
 func testProcWalletTxList(t *testing.T, wallet *Wallet) {
 	println("TestProcWalletTxList begin")
+
+	//倒序获取最新的三笔交易
 	txList := &types.ReqWalletTransactionList{
 		Count:     3,
-		Direction: 1,
+		Direction: 0,
 		FromTx:    []byte(""),
 	}
 	msg := wallet.client.NewMessage("wallet", types.EventWalletTransactionList, txList)
@@ -427,13 +429,25 @@ func testProcWalletTxList(t *testing.T, wallet *Wallet) {
 	walletTxDetails := resp.GetData().(*types.WalletTxDetails)
 
 	var FromTxstr string
+	index := make([]int64, 3)
+
 	if len(walletTxDetails.TxDetails) != 3 {
 		t.Error("testProcWalletTxList failed")
 	}
 	println("TestProcWalletTxList dir last-------")
-	for _, walletTxDetail := range walletTxDetails.TxDetails {
+	for i, walletTxDetail := range walletTxDetails.TxDetails {
 		println("TestProcWalletTxList", "Direction", txList.Direction, "WalletTxDetail", walletTxDetail.String())
+		index[i] = walletTxDetail.GetHeight()*100000 + walletTxDetail.GetIndex()
 		FromTxstr = fmt.Sprintf("%018d", walletTxDetail.GetHeight()*100000+walletTxDetail.GetIndex())
+	}
+	//倒序index值的判断，index[0]>index[1]>index[2]
+	if index[0] <= index[1] {
+		println("TestProcWalletTxList", "index[0]", index[0], "index[1]", index[1])
+		t.Error("testProcWalletTxList:Reverse check fail!")
+	}
+	if index[1] <= index[2] {
+		println("TestProcWalletTxList", "index[1]", index[1], "index[2]", index[2])
+		t.Error("testProcWalletTxList:Reverse check fail!")
 	}
 
 	txList.Direction = 1
@@ -465,6 +479,34 @@ func testProcWalletTxList(t *testing.T, wallet *Wallet) {
 	}
 	for _, walletTxDetail := range walletTxDetails.TxDetails {
 		println("TestProcWalletTxList", "Direction", txList.Direction, "WalletTxDetail", walletTxDetail.String())
+	}
+
+	//正序获取最早的三笔交易
+	txList = &types.ReqWalletTransactionList{
+		Count:     3,
+		Direction: 1,
+		FromTx:    []byte(""),
+	}
+	msg = wallet.client.NewMessage("wallet", types.EventWalletTransactionList, txList)
+	wallet.client.Send(msg, true)
+	resp, err = wallet.client.Wait(msg)
+	require.NoError(t, err)
+	walletTxDetails = resp.GetData().(*types.WalletTxDetails)
+
+	if len(walletTxDetails.TxDetails) != 3 {
+		t.Error("testProcWalletTxList failed")
+	}
+	for i, walletTxDetail := range walletTxDetails.TxDetails {
+		index[i] = walletTxDetail.GetHeight()*100000 + walletTxDetail.GetIndex()
+	}
+	//正序index值的判断，index[0]<index[1]<index[2]
+	if index[0] >= index[1] {
+		println("TestProcWalletTxList", "index[0]", index[0], "index[1]", index[1])
+		t.Error("testProcWalletTxList:positive check fail!")
+	}
+	if index[1] >= index[2] {
+		println("TestProcWalletTxList", "index[1]", index[1], "index[2]", index[2])
+		t.Error("testProcWalletTxList:positive check fail!")
 	}
 	println("TestProcWalletTxList end")
 	println("--------------------------")


### PR DESCRIPTION
修改WalletTxList接口的实现：

现在代码实现：当调用此接口时传入fromTx为空时，默认从最新的交易开始获取，没有使用direction的值。所以现有代码只能从最新的交易开始获取，无法从最早的交易开始获取

新的代码实现：通过fromTx和direction一起组合使用。从最新/最早的交易开始获取
1，当fromTx == nil  && direction == 0，从最新的一笔交易开始获取
2，当fromTx == nil  && direction == 1，从最早的一笔交易开始获取

影响：
目前钱包项目获取最新的交易时传入的fromTx == nil ，direction的值可能是0或者1.
因为direction值没有被使用，所以direction的值填写0或者1都可以获取最新的交易。

如果钱包项目获取最新的交易时传入的direction值是1的话，
这次底层代码升级之后上层钱包项目需要同步升级。
按照新的规则传入参数来获取最新/最早的交易。
