### PR TITLE
add by hyb for issues646

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -23,7 +23,7 @@ var (
 //GetLocalDBKeyList 获取本地key列表
 func GetLocalDBKeyList() [][]byte {
 	return [][]byte{
-		WalletVerKey, BlockChainVerKey, LocalDBMeta, MavlTreeVerKey,
+		WalletVerKey, BlockChainVerKey, LocalDBMeta, StoreDBMeta, MavlTreeVerKey,
 	}
 }
 


### PR DESCRIPTION
1，新的代码不支持PrefixCount查询地址交易计数，在 executor/localdb.go PrefixCount  导致升级上来的数据库使用PrefixCount方式查询地址交易计数失败

解决方案：
    而现有的节点都已经升级了localdb到1.0.0版本，也就是都支持通过GetAddrTxsCount来获取地址交易 计数。所以ProcGetAddrOverview接口的实现统一修改成通过GetAddrTxsCount来获取地址交易计数


2，在升级localdb时，在删除tx相关的key值，没有过滤记录storedb版本信息的key值StoreDBMeta。导致每次升级完localdb之后都会升级storedb。

解决方案：将记录storedb版本信息的key值 ，添加version.GetLocalDBKeyList()中。这样在调用BlockStore.delAllKeys()时，可以过滤出不需要删除的key值

close #646 
