### PR TITLE
add by hyb for tx shorthash duplicate

### DIFF
--- a/blockchain/blockstore.go
+++ b/blockchain/blockstore.go
@@ -350,7 +350,9 @@ func (bs *BlockStore) HasTx(key []byte) (bool, error) {
 			}
 			return false, err
 		}
-		return true, nil
+		//通过短hash查询交易存在时，需要再通过全hash索引查询一下。
+		//避免短hash重复，而全hash不一样的情况
+		//return true, nil
 	}
 	if _, err := bs.db.Get(types.CalcTxKey(key)); err != nil {
 		if err == dbm.ErrNotFoundInDb {


### PR DESCRIPTION
在tx交易去重处理时，首先检测短hash是否重复，不重复直接返回，如果短hash有重复需要再校验一下tx交易的全hash是否有重复。从而避免那种全hash不一致，但是短hash一致时的交易