### PR TITLE
Update p2p broadcast filter

### DIFF
--- a/p2p/blockcache.go
+++ b/p2p/blockcache.go
@@ -10,7 +10,7 @@ var (
 	//发送交易短哈希广播,在本地暂时缓存一些区块数据, 限制最大大小
 	totalBlockCache = newSpaceLimitCache(BlockCacheNum, MaxBlockCacheByteSize)
 	//接收到短哈希区块数据,只构建出区块部分交易,需要缓存, 并继续向对端节点请求剩余数据
-	ltBlockCache    = newSpaceLimitCache(BlockCacheNum/2, MaxBlockCacheByteSize/2)
+	ltBlockCache = newSpaceLimitCache(BlockCacheNum/2, MaxBlockCacheByteSize/2)
 )
 
 // lru缓存封装, 控制占用空间大小

--- a/p2p/blockcache.go
+++ b/p2p/blockcache.go
@@ -7,7 +7,9 @@ import (
 )
 
 var (
+	//发送交易短哈希广播,在本地暂时缓存一些区块数据, 限制最大大小
 	totalBlockCache = newSpaceLimitCache(BlockCacheNum, MaxBlockCacheByteSize)
+	//接收到短哈希区块数据,只构建出区块部分交易,需要缓存, 并继续向对端节点请求剩余数据
 	ltBlockCache    = newSpaceLimitCache(BlockCacheNum/2, MaxBlockCacheByteSize/2)
 )
 

--- a/p2p/const.go
+++ b/p2p/const.go
@@ -68,9 +68,12 @@ const (
 
 // P2pCacheTxSize p2pcache size of transaction
 const (
-	PeerAddrCacheNum      = 1000
-	TxHashCacheNum        = 10240
-	BlockHashCacheNum     = 100
+	PeerAddrCacheNum = 1000
+	//接收的交易哈希过滤缓存设为mempool最大接收交易量
+	TxRecvFilterCacheNum = 10240
+	BlockFilterCacheNum  = 50
+	//交易从接收到处理完继续向外广播通常耗时较少, 维持较小的缓存个数即可
+	TxSendFilterCacheNum  = 100
 	BlockCacheNum         = 10
 	MaxBlockCacheByteSize = 100 * 1024 * 1024
 )

--- a/p2p/const.go
+++ b/p2p/const.go
@@ -72,8 +72,8 @@ const (
 	//接收的交易哈希过滤缓存设为mempool最大接收交易量
 	TxRecvFilterCacheNum = 10240
 	BlockFilterCacheNum  = 50
-	//交易从接收到处理完继续向外广播通常耗时较少, 维持较小的缓存个数即可
-	TxSendFilterCacheNum  = 100
+	//发送过滤主要用于发送时冗余检测, 发送完即可以被删除, 维护较小缓存数
+	TxSendFilterCacheNum  = 500
 	BlockCacheNum         = 10
 	MaxBlockCacheByteSize = 100 * 1024 * 1024
 )

--- a/p2p/filterrepeatdata.go
+++ b/p2p/filterrepeatdata.go
@@ -15,9 +15,14 @@ import (
 
 // Filter  a Filter object
 var (
-	peerAddrFilter  = NewFilter(PeerAddrCacheNum)
-	txHashFilter    = NewFilter(TxHashCacheNum)
-	blockHashFilter = NewFilter(BlockHashCacheNum)
+	peerAddrFilter = NewFilter(PeerAddrCacheNum)
+	//接收交易和区块过滤缓存, 避免重复提交到mempool或blockchain
+	txHashFilter    = NewFilter(TxRecvFilterCacheNum)
+	blockHashFilter = NewFilter(BlockFilterCacheNum)
+
+	//发送交易和区块时过滤缓存, 解决冗余广播发送
+	txSendFilter    = NewFilter(TxSendFilterCacheNum)
+	blockSendFilter = NewFilter(BlockFilterCacheNum)
 )
 
 // NewFilter produce a filter object
@@ -29,6 +34,11 @@ func NewFilter(num int) *Filterdata {
 		panic(err)
 	}
 	return filter
+}
+
+type sendFilterInfo struct {
+	//记录广播交易或区块时需要忽略的节点, 这些节点可能是交易的来源节点,也可能节点间维护了多条连接, 冗余发送
+	ignoreSendPeers map[string]bool
 }
 
 // Filterdata filter data attribute

--- a/p2p/p2pcli.go
+++ b/p2p/p2pcli.go
@@ -82,7 +82,7 @@ func (m *Cli) BroadCastTx(msg *queue.Message, taskindex int64) {
 		//是否已存在记录，不存在表示本节点发起的交易
 		if ttl, exist := txHashFilter.Get(txHash).(*pb.P2PRoute); exist {
 			route.TTL = ttl.TTL + 1
-		}else {
+		} else {
 			txHashFilter.RegRecvData(txHash)
 		}
 		m.network.node.pubsub.FIFOPub(&pb.P2PTx{Tx: tx, Route: route}, "tx")

--- a/p2p/p2pserver.go
+++ b/p2p/p2pserver.go
@@ -424,14 +424,14 @@ func (s *P2pserver) ServerStreamSend(in *pb.P2PPing, stream pb.P2Pgservice_Serve
 		time.Sleep(time.Second)
 	}
 	log.Debug("ServerStreamSend")
-	peername := hex.EncodeToString(in.GetSign().GetPubkey())
-	dataChain := s.addStreamHandler(peername)
-	defer s.deleteStream(peername, dataChain)
+	peerName := hex.EncodeToString(in.GetSign().GetPubkey())
+	dataChain := s.addStreamHandler(peerName)
+	defer s.deleteStream(peerName, dataChain)
 	for data := range dataChain {
 		if s.IsClose() {
 			return fmt.Errorf("node close")
 		}
-		sendData, doSend := s.node.processSendP2P(data, peerInfo.p2pversion, peerInfo.addr)
+		sendData, doSend := s.node.processSendP2P(data, peerInfo.p2pversion, peerName, peerInfo.addr)
 		if !doSend {
 			continue
 		}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -254,7 +254,7 @@ func (p *Peer) sendStream() {
 					log.Error("sendStream peer connect closed", "peerName", p.GetPeerName())
 					return
 				}
-				sendData, doSend := p.node.processSendP2P(task, p.version.GetVersion(), p.Addr())
+				sendData, doSend := p.node.processSendP2P(task, p.version.GetVersion(), peername, p.Addr())
 				if !doSend {
 					continue
 				}

--- a/p2p/process.go
+++ b/p2p/process.go
@@ -99,7 +99,9 @@ func (n *Node) sendBlock(block *types.P2PBlock, p2pData *types.BroadCastData, pe
 		}
 
 		// cache block
-		totalBlockCache.add(blockHash, block.Block, ltBlock.Size)
+		if !totalBlockCache.contains(blockHash) {
+			totalBlockCache.add(blockHash, block.Block, ltBlock.Size)
+		}
 
 		p2pData.Value = &types.BroadCastData_LtBlock{LtBlock: ltBlock}
 	} else {

--- a/p2p/process.go
+++ b/p2p/process.go
@@ -106,7 +106,6 @@ func (n *Node) sendBlock(block *types.P2PBlock, p2pData *types.BroadCastData, pe
 		p2pData.Value = &types.BroadCastData_Block{Block: block}
 	}
 
-	blockHashFilter.RegRecvData(blockHash)
 	return true
 }
 


### PR DESCRIPTION
fix 33cn/plugin#592
>问题是本地发出的交易未增加到接收重复过滤

同时增加了交易和区块发送重复过滤，有两种情况：
1. 节点间维护了两条连接（分别客户端服务端）时，只触发首次发送
2. 在交易发送前，可能接收到其他节点广播过来同一个交易，对这些节点不再发送

补充p2p广播处理流程日志