### PR TITLE
add by hyb for issues-646

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -116,6 +116,9 @@ type BlockChain struct {
 	blockSynInterVal time.Duration
 	DefCacheSize     int64
 	failed           int32
+
+	blockOnChain   *BlockOnChain
+	onChainTimeout int64
 }
 
 //New new
@@ -157,6 +160,8 @@ func New(cfg *types.BlockChain) *BlockChain {
 		MaxFetchBlockNum:    128 * 6, //一次最多申请获取block个数
 		TimeoutSeconds:      2,
 		isFastDownloadSync:  true,
+		blockOnChain:        &BlockOnChain{},
+		onChainTimeout:      0,
 	}
 	blockchain.initConfig(cfg)
 	return blockchain
@@ -179,6 +184,11 @@ func (chain *BlockChain) initConfig(cfg *types.BlockChain) {
 	chain.isRecordBlockSequence = cfg.IsRecordBlockSequence
 	chain.isParaChain = cfg.IsParaChain
 	types.S("quickIndex", cfg.EnableTxQuickIndex)
+
+	if cfg.OnChainTimeout > 0 {
+		chain.onChainTimeout = cfg.OnChainTimeout
+	}
+	chain.initOnChainTimeout()
 }
 
 //Close 关闭区块链

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1294,7 +1294,7 @@ func TestOnChainTimeout(t *testing.T) {
 	chainlog.Info("TestOnChainTimeout begin --------------------")
 
 	cfg, sub := testnode.GetDefaultConfig()
-	cfg.BlockChain.OnChainTimeout = 2
+	cfg.BlockChain.OnChainTimeout = 1
 	mock33 := testnode.NewWithConfig(cfg, sub, nil)
 
 	defer mock33.Close()
@@ -1309,8 +1309,8 @@ func TestOnChainTimeout(t *testing.T) {
 	isTimeOut := blockchain.OnChainTimeout(curheight)
 	assert.Equal(t, isTimeOut, false)
 
-	//5秒后超时
-	time.Sleep(5 * time.Second)
+	//2秒后超时
+	time.Sleep(2 * time.Second)
 	lastheight := blockchain.GetBlockHeight()
 	isTimeOut = blockchain.OnChainTimeout(lastheight)
 	println("curheight:", curheight)
@@ -1319,7 +1319,7 @@ func TestOnChainTimeout(t *testing.T) {
 		isTimeOut = blockchain.OnChainTimeout(lastheight)
 		assert.Equal(t, isTimeOut, true)
 	} else {
-		time.Sleep(5 * time.Second)
+		time.Sleep(2 * time.Second)
 		isTimeOut = blockchain.OnChainTimeout(lastheight)
 		assert.Equal(t, isTimeOut, true)
 	}

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -148,6 +148,8 @@ type BlockChain struct {
 	RollbackBlock int64 `protobuf:"varint,15,opt,name=rollbackBlock" json:"rollbackBlock,omitempty"`
 	// 回退是否保存区块
 	RollbackSave bool `protobuf:"varint,16,opt,name=rollbackSave" json:"rollbackSave,omitempty"`
+	// 最新区块上链超时时间，单位秒。
+	OnChainTimeout int64 `protobuf:"varint,16,opt,name=onChainTimeout" json:"onChainTimeout,omitempty"`
 }
 
 // P2P 配置


### PR DESCRIPTION

问题描述：
    目前联盟链节点可能会出现区块不能广播到其他节点导致整个网络的共识卡主。
修改方案：
    增加一个节点区块高度长时间不增涨的超时处理。
如果节点区块高度长时间不增涨，超过预设置的超时时间，并且本节点和最高节点只差一个区块时，
本节点向最高节点主动请求最新的区块

使用说明：
    配置文件blockchain模块增加一个区块上链超时时间的设置onChainTimeout，单位是秒。系统默认是0，不开启这个超时检测的处理。联盟链可以根据各自的情况设置这个超时时间

close 33cn/plugin#646
