### PR TITLE
add by hyb for wallet lock

### DIFF
--- a/wallet/seed.go
+++ b/wallet/seed.go
@@ -142,7 +142,7 @@ func GetSeed(db dbm.DB, password string) (string, error) {
 }
 
 //GetPrivkeyBySeed 通过seed生成子私钥十六进制字符串
-func GetPrivkeyBySeed(db dbm.DB, seed string, specificIndex uint32) (string, error) {
+func GetPrivkeyBySeed(db dbm.DB, seed string, specificIndex uint32, signType int) (string, error) {
 	var backupindex uint32
 	var Hexsubprivkey string
 	var err error
@@ -162,11 +162,11 @@ func GetPrivkeyBySeed(db dbm.DB, seed string, specificIndex uint32) (string, err
 	} else {
 		index = specificIndex
 	}
-	if SignType != 1 && SignType != 2 {
+	if signType != 1 && signType != 2 {
 		return "", types.ErrNotSupport
 	}
 	//secp256k1
-	if SignType == 1 {
+	if signType == 1 {
 
 		wallet, err := bipwallet.NewWalletFromMnemonic(bipwallet.TypeBty, seed)
 		if err != nil {
@@ -197,7 +197,7 @@ func GetPrivkeyBySeed(db dbm.DB, seed string, specificIndex uint32) (string, err
 			return "", types.ErrSubPubKeyVerifyFail
 		}
 
-	} else if SignType == 2 { //ed25519
+	} else if signType == 2 { //ed25519
 
 		//通过助记词形式的seed生成私钥和公钥,一个seed根据不同的index可以生成许多组密钥
 		//字符串形式的助记词(英语单词)通过计算一次hash转成字节形式的seed

--- a/wallet/sendtx.go
+++ b/wallet/sendtx.go
@@ -104,6 +104,9 @@ func (wallet *Wallet) SendTransaction(payload types.Message, execer []byte, priv
 	if !wallet.isInited() {
 		return nil, types.ErrNotInited
 	}
+	wallet.mtx.Lock()
+	defer wallet.mtx.Unlock()
+
 	return wallet.sendTransaction(payload, execer, priv, to)
 }
 
@@ -123,7 +126,7 @@ func (wallet *Wallet) sendTransaction(payload types.Message, execer []byte, priv
 	}
 	tx.Fee = fee
 	tx.SetExpire(time.Second * 120)
-	tx.Sign(int32(SignType), priv)
+	tx.Sign(int32(wallet.SignType), priv)
 	reply, err := wallet.sendTx(tx)
 	if err != nil {
 		return nil, err
@@ -197,6 +200,8 @@ func (wallet *Wallet) queryTx(hash []byte) (*types.TransactionDetail, error) {
 
 // SendToAddress 想合约地址转账
 func (wallet *Wallet) SendToAddress(priv crypto.PrivKey, addrto string, amount int64, note string, Istoken bool, tokenSymbol string) (*types.ReplyHash, error) {
+	wallet.mtx.Lock()
+	defer wallet.mtx.Unlock()
 	return wallet.sendToAddress(priv, addrto, amount, note, Istoken, tokenSymbol)
 }
 
@@ -261,7 +266,7 @@ func (wallet *Wallet) sendToAddress(priv crypto.PrivKey, addrto string, amount i
 	if err != nil {
 		return nil, err
 	}
-	tx.Sign(int32(SignType), priv)
+	tx.Sign(int32(wallet.SignType), priv)
 
 	reply, err := wallet.api.SendTx(tx)
 	if err != nil {


### PR DESCRIPTION
将wallet模块中的SignType全局变量，添加到wallet实例中，使用wallet的 锁来保护

该钱包插件模块提供的借口：SendTransaction和SendToAddress提供钱包的锁功能 