### PR TITLE
p2p:fix nil route info from old version

### DIFF
--- a/p2p/p2pcli.go
+++ b/p2p/p2pcli.go
@@ -81,7 +81,7 @@ func (m *Cli) BroadCastTx(msg *queue.Message, taskindex int64) {
 		route := &pb.P2PRoute{TTL: 1}
 		//是否已存在记录，不存在表示本节点发起的交易
 		if ttl, exist := txHashFilter.Get(txHash).(*pb.P2PRoute); exist {
-			route.TTL = ttl.TTL + 1
+			route.TTL = ttl.GetTTL() + 1
 		} else {
 			txHashFilter.RegRecvData(txHash)
 		}

--- a/p2p/process.go
+++ b/p2p/process.go
@@ -172,7 +172,11 @@ func (n *Node) recvTx(tx *types.P2PTx, pid, peerAddr string) {
 	if isDuplicate {
 		return
 	}
-	txHashFilter.Add(txHash, tx.Route)
+	//有可能收到老版本的交易路由,此时route是空指针
+	if tx.GetRoute() == nil {
+		tx.Route = &types.P2PRoute{TTL: 1}
+	}
+	txHashFilter.Add(txHash, tx.GetRoute())
 
 	msg := n.nodeInfo.client.NewMessage("mempool", types.EventTx, tx.GetTx())
 	errs := n.nodeInfo.client.Send(msg, false)


### PR DESCRIPTION

老版本发来的交易不带Route.TTL信息，新版本解析出来是空指针