### PR TITLE
p2p:fix light tx broadcast

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -222,9 +222,9 @@ func (p *Peer) sendStream() {
 		}
 
 		//send softversion&p2pversion
-		_, peername := p.node.nodeInfo.addrBook.GetPrivPubKey()
+		_, peerName := p.node.nodeInfo.addrBook.GetPrivPubKey()
 		p2pdata.Value = &pb.BroadCastData_Version{Version: &pb.Versions{P2Pversion: p.node.nodeInfo.channelVersion,
-			Softversion: v.GetVersion(), Peername: peername}}
+			Softversion: v.GetVersion(), Peername: peerName}}
 
 		if err := resp.Send(p2pdata); err != nil {
 			P2pComm.CollectPeerStat(err, p)
@@ -261,7 +261,7 @@ func (p *Peer) sendStream() {
 					log.Error("sendStream peer connect closed", "peerName", p.GetPeerName())
 					return
 				}
-				sendData, doSend := p.node.processSendP2P(task, p.version.GetVersion(), peername, p.Addr())
+				sendData, doSend := p.node.processSendP2P(task, p.version.GetVersion(), p.GetPeerName(), p.Addr())
 				if !doSend {
 					continue
 				}


### PR DESCRIPTION

* 短哈希交易广播，对方节点不存在交易时， 会再次请求全交易广播
* 本地发送过滤未考虑这种情况，短哈希广播时不应该增加发送过滤
* 修正peername过滤键值