### PR TITLE
Fix get addr overview 6.3

### DIFF
--- a/blockchain/query_tx.go
+++ b/blockchain/query_tx.go
@@ -227,9 +227,6 @@ func (chain *BlockChain) ProcGetAddrOverview(addr *types.ReqAddr) (*types.AddrOv
 	} else {
 		addrOverview.Reciver = amount.(*types.Int64).GetData()
 	}
-	if err != nil {
-		return nil, err
-	}
 
 	var reqkey types.ReqKey
 

--- a/blockchain/query_tx.go
+++ b/blockchain/query_tx.go
@@ -227,6 +227,9 @@ func (chain *BlockChain) ProcGetAddrOverview(addr *types.ReqAddr) (*types.AddrOv
 	} else {
 		addrOverview.Reciver = amount.(*types.Int64).GetData()
 	}
+	if err != nil && err != types.ErrEmpty {
+		return nil, err
+	}
 
 	var reqkey types.ReqKey
 


### PR DESCRIPTION
修复： ProcGetAddrOverview: 在没有资产，有交易的情况下，返回出错。
close #702