### PR TITLE
rpc:fix CreateNoBalance rpc tx expire setting

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -332,11 +332,25 @@ func TestChannelClient_CreateNoBalanceTransaction(t *testing.T) {
 	fee := types.GInt("MinFee") * 2
 	api.On("GetProperFee", mock.Anything).Return(&types.ReplyProperFee{ProperFee: fee}, nil)
 	in := &types.NoBalanceTx{}
-	tx, err := client.CreateNoBalanceTransaction(in)
+	params := &types.NoBalanceTxs{
+		TxHexs:  []string{in.GetTxHex()},
+		PayAddr: in.GetPayAddr(),
+		Privkey: in.GetPrivkey(),
+		Expire:  in.GetExpire(),
+	}
+	tx, err := client.CreateNoBalanceTxs(params)
 	assert.NoError(t, err)
 	gtx, _ := tx.GetTxGroup()
 	assert.NoError(t, gtx.Check(0, fee, types.GInt("MaxFee")))
 	assert.NoError(t, err)
+	params.Expire = "300s"
+	tx, err = client.CreateNoBalanceTxs(params)
+	assert.NoError(t, err)
+	assert.Equal(t, true, (tx.GetExpire() > types.Now().Unix()) && (tx.GetExpire() <= types.Now().Unix()+300))
+	params.TxHexs[0] = hex.EncodeToString(types.Encode(&types.Transaction{Execer: []byte("user.p.para.coins")}))
+	params.Expire = "100"
+	tx, err = client.CreateNoBalanceTxs(params)
+	assert.Equal(t, types.ErrInvalidExpire, err)
 }
 
 func TestClientReWriteRawTx(t *testing.T) {

--- a/rpc/grpchandler.go
+++ b/rpc/grpchandler.go
@@ -31,7 +31,13 @@ func (g *Grpc) CreateNoBalanceTxs(ctx context.Context, in *pb.NoBalanceTxs) (*pb
 
 // CreateNoBalanceTransaction create transaction with no balance
 func (g *Grpc) CreateNoBalanceTransaction(ctx context.Context, in *pb.NoBalanceTx) (*pb.ReplySignRawTx, error) {
-	reply, err := g.cli.CreateNoBalanceTransaction(in)
+	params := &pb.NoBalanceTxs{
+		TxHexs:  []string{in.GetTxHex()},
+		PayAddr: in.GetPayAddr(),
+		Privkey: in.GetPrivkey(),
+		Expire:  in.GetExpire(),
+	}
+	reply, err := g.cli.CreateNoBalanceTxs(params)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jrpchandler.go
+++ b/rpc/jrpchandler.go
@@ -86,7 +86,13 @@ func (c *Chain33) CreateNoBlanaceTxs(in *types.NoBalanceTxs, result *string) err
 
 // CreateNoBalanceTransaction create transaction with no balance
 func (c *Chain33) CreateNoBalanceTransaction(in *types.NoBalanceTx, result *string) error {
-	tx, err := c.cli.CreateNoBalanceTransaction(in)
+	params := &types.NoBalanceTxs{
+		TxHexs:  []string{in.GetTxHex()},
+		PayAddr: in.GetPayAddr(),
+		Privkey: in.GetPrivkey(),
+		Expire:  in.GetExpire(),
+	}
+	tx, err := c.cli.CreateNoBalanceTxs(params)
 	if err != nil {
 		return err
 	}

--- a/types/error.go
+++ b/types/error.go
@@ -49,6 +49,7 @@ var (
 	ErrBlockNotFound           = errors.New("ErrBlockNotFound")
 	ErrLogType                 = errors.New("ErrLogType")
 	ErrInvalidParam            = errors.New("ErrInvalidParam")
+	ErrInvalidExpire           = errors.New("ErrInvalidExpire")
 	ErrInvalidAddress          = errors.New("ErrInvalidAddress")
 	ErrNotInited               = errors.New("ErrNotInited")
 

--- a/wallet/wallet_proc.go
+++ b/wallet/wallet_proc.go
@@ -126,6 +126,9 @@ func (wallet *Wallet) ProcSignRawTx(unsigned *types.ReqSignRawTx) (string, error
 		return "", types.ErrIndex
 	}
 	if index <= 0 {
+		//设置过期需要重构
+		group.SetExpire(0, time.Duration(expire))
+		group.RebuiltGroup()
 		for i := range group.Txs {
 			err := group.SignN(i, int32(wallet.SignType), key)
 			if err != nil {


### PR DESCRIPTION
fix #706 
* 修正CreateNoBalance接口，未处理expire参数错误
* 将CreateNoBalance内部接口合二为一

> 相关说明
* 交易组过期，设置其中一笔即可生效
* SignRawTx接口设置了首笔过期， 不需要修改
