### PR TITLE
mempool:update calc total cache bytes

### DIFF
--- a/common/skiplist/queue_test.go
+++ b/common/skiplist/queue_test.go
@@ -34,6 +34,10 @@ func (item *scorer) Compare(cmp Scorer) int {
 	}
 }
 
+func (item *scorer) ByteSize() int64 {
+	return item.score
+}
+
 var (
 	sc1 = &scorer{1, "111"}
 	sc2 = &scorer{2, "222"}
@@ -49,6 +53,7 @@ func TestQueuePush(t *testing.T) {
 	assert.Equal(t, 2, q.Size())
 	assert.Equal(t, sc2, q.First())
 	assert.Equal(t, sc1, q.Last())
+	assert.Equal(t, sc1.score+sc2.score, q.GetCacheBytes())
 }
 
 func TestQueueFind(t *testing.T) {
@@ -72,11 +77,13 @@ func TestQueueDelete(t *testing.T) {
 	q.Push(sc1)
 	q.Push(sc2)
 	q.Push(sc3)
+	assert.Equal(t, sc1.score+sc2.score+sc3.score, q.GetCacheBytes())
 	q.Remove(string(sc3.Hash()))
 	assert.Equal(t, 2, q.Size())
 	f3, err := q.GetItem(string(sc3.Hash()))
 	assert.Equal(t, nil, f3)
 	assert.Equal(t, types.ErrNotFound, err)
+	assert.Equal(t, sc1.score+sc2.score, q.GetCacheBytes())
 }
 
 func TestQueueWalk(t *testing.T) {
@@ -129,20 +136,29 @@ func (s *scoreint) Compare(b Scorer) int {
 	return Big
 }
 
+func (s *scoreint) ByteSize() int64 {
+	return s.data
+}
+
 func TestQueue(t *testing.T) {
 	queue := NewQueue(10)
+	totalByte := 0
 	for i := 0; i < 11; i++ {
 		err := queue.Push(&scoreint{data: int64(i)})
 		assert.Nil(t, err)
+		totalByte += i
 	}
+	assert.Equal(t, int64(totalByte), queue.GetCacheBytes())
+	assert.Nil(t, queue.Push(&scoreint{data: 11}))
+	assert.Equal(t, int64(totalByte)+10, queue.GetCacheBytes())
 	assert.Equal(t, int64(10), queue.MaxSize())
 	err := queue.Push(&scoreint{data: int64(0)})
 	assert.Equal(t, err, types.ErrMemFull)
-	err = queue.Push(&scoreint{data: int64(1)})
+	err = queue.Push(&scoreint{data: int64(2)})
 	assert.Equal(t, err, types.ErrTxExist)
 	assert.Equal(t, int64(10), queue.MaxSize())
 
-	item := &scoreint{data: int64(1)}
+	item := &scoreint{data: int64(2)}
 	item2, err := queue.GetItem(string(item.Hash()))
 	assert.Nil(t, err)
 	assert.Equal(t, item.Hash(), item2.Hash())

--- a/common/skiplist/queue_test.go
+++ b/common/skiplist/queue_test.go
@@ -149,6 +149,7 @@ func TestQueue(t *testing.T) {
 		totalByte += i
 	}
 	assert.Equal(t, int64(totalByte), queue.GetCacheBytes())
+	//缓存已满,触发优先级高的替换操作, 11替换1
 	assert.Nil(t, queue.Push(&scoreint{data: 11}))
 	assert.Equal(t, int64(totalByte)+10, queue.GetCacheBytes())
 	assert.Equal(t, int64(10), queue.MaxSize())

--- a/system/mempool/base.go
+++ b/system/mempool/base.go
@@ -224,7 +224,7 @@ func (mem *Mempool) GetLatestTx() []*types.Transaction {
 func (mem *Mempool) GetTotalCacheBytes() int64 {
 	mem.proxyMtx.Lock()
 	defer mem.proxyMtx.Unlock()
-	return mem.cache.TotalByte()
+	return mem.cache.qcache.GetCacheBytes()
 }
 
 // pollLastHeader在初始化后循环获取LastHeader，直到获取成功后，返回

--- a/system/mempool/cache.go
+++ b/system/mempool/cache.go
@@ -6,7 +6,6 @@ package mempool
 
 import (
 	"github.com/33cn/chain33/types"
-	"github.com/golang/protobuf/proto"
 )
 
 //QueueCache 排队交易处理
@@ -18,6 +17,7 @@ type QueueCache interface {
 	Size() int
 	Walk(count int, cb func(tx *Item) bool)
 	GetProperFee() int64
+	GetCacheBytes() int64
 }
 
 // Item 为Mempool中包装交易的数据结构
@@ -31,9 +31,8 @@ type Item struct {
 type txCache struct {
 	*AccountTxIndex
 	*LastTxCache
-	qcache    QueueCache
-	totalFee  int64
-	totalByte int64
+	qcache   QueueCache
+	totalFee int64
 	*SHashTxCache
 }
 
@@ -65,7 +64,6 @@ func (cache *txCache) Remove(hash string) {
 	cache.AccountTxIndex.Remove(tx)
 	cache.LastTxCache.Remove(tx)
 	cache.totalFee -= tx.Fee
-	cache.totalByte -= int64(proto.Size(tx))
 	cache.SHashTxCache.Remove(tx)
 }
 
@@ -102,11 +100,6 @@ func (cache *txCache) TotalFee() int64 {
 	return cache.totalFee
 }
 
-//TotalByte 交易字节数总和
-func (cache *txCache) TotalByte() int64 {
-	return cache.totalByte
-}
-
 //Walk iter all txs
 func (cache *txCache) Walk(count int, cb func(tx *Item) bool) {
 	if cache.qcache == nil {
@@ -138,7 +131,6 @@ func (cache *txCache) Push(tx *types.Transaction) error {
 	}
 	cache.LastTxCache.Push(tx)
 	cache.totalFee += tx.Fee
-	cache.totalByte += int64(proto.Size(tx))
 	cache.SHashTxCache.Push(tx)
 	return nil
 }


### PR DESCRIPTION
fix #698 

目前的方式是，扩展queue接口增加CacheBytes函数，由底层的cache缓存自己管理好cacheSize