### PR TITLE
rpc:fix createNoBalanceTx expire setting

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -366,6 +366,9 @@ func TestChannelClient_CreateNoBalanceTransaction(t *testing.T) {
 	gtx, _ := tx.GetTxGroup()
 	assert.NoError(t, gtx.Check(cfg, 0, fee, cfg.GInt("MaxFee")))
 	assert.NoError(t, err)
+	tx, err = client.CreateNoBalanceTxs(params)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), tx.GetExpire())
 	params.Expire = "300s"
 	tx, err = client.CreateNoBalanceTxs(params)
 	assert.NoError(t, err)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -366,9 +366,6 @@ func TestChannelClient_CreateNoBalanceTransaction(t *testing.T) {
 	gtx, _ := tx.GetTxGroup()
 	assert.NoError(t, gtx.Check(cfg, 0, fee, cfg.GInt("MaxFee")))
 	assert.NoError(t, err)
-	tx, err = client.CreateNoBalanceTxs(params)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(0), tx.GetExpire())
 	params.Expire = "300s"
 	tx, err = client.CreateNoBalanceTxs(params)
 	assert.NoError(t, err)
@@ -377,6 +374,12 @@ func TestChannelClient_CreateNoBalanceTransaction(t *testing.T) {
 	params.Expire = "100"
 	tx, err = client.CreateNoBalanceTxs(params)
 	assert.Equal(t, types.ErrInvalidExpire, err)
+	params.Expire = "0"
+	_, err = client.CreateNoBalanceTxs(params)
+	assert.NotEqual(t, types.ErrInvalidExpire, err)
+	params.Expire = fmt.Sprintf("%d", types.ExpireBound+1)
+	_, err = client.CreateNoBalanceTxs(params)
+	assert.NotEqual(t, types.ErrInvalidExpire, err)
 }
 
 func TestClientReWriteRawTx(t *testing.T) {


### PR DESCRIPTION
1. 修复限制平行链设置区块高度作为过期的逻辑, 考虑特殊永不过期expire=0的情况
2. 增加expire为空时默认过期时间, 为永不过期