### PR TITLE
add upgrade option when blockchain is start

### DIFF
--- a/blockchain/restore.go
+++ b/blockchain/restore.go
@@ -20,8 +20,23 @@ func (chain *BlockChain) Upgrade() {
 	chain.UpgradeChain()
 	chainlog.Info("storedb upgrade start")
 	chain.UpgradeStore()
+	chainlog.Info("upgrade all dapp")
+	chain.upgradePlugin()
 	chainlog.Info("chain reduce start")
 	chain.ReduceChain()
+}
+
+func (chain *BlockChain) upgradePlugin() {
+	client := chain.client
+	msg := client.NewMessage("execs", types.EventUpgrade, nil)
+	err := client.Send(msg, true)
+	if err != nil {
+		panic(err)
+	}
+	_, err = client.Wait(msg)
+	if err != nil {
+		panic(err)
+	}
 }
 
 //UpgradeStore 升级storedb

--- a/common/db/db.go
+++ b/common/db/db.go
@@ -108,6 +108,7 @@ func MustWrite(batch Batch) {
 //IteratorSeeker ...
 type IteratorSeeker interface {
 	Rewind() bool
+	// 返回false， 表示系统中没有指定的key，Iterator会指向key附近
 	Seek(key []byte) bool
 	Next() bool
 }

--- a/common/db/db_test.go
+++ b/common/db/db_test.go
@@ -169,28 +169,28 @@ func testDBIterator(t *testing.T, db DB) {
 	assert.Equal(t, list0, list)
 	require.Equal(t, list, [][]byte{[]byte("aaaaaa/1"), []byte("my"), []byte("my_"), []byte("my_key/1"), []byte("my_key/2"), []byte("my_key/3"), []byte("my_key/4"), []byte("zzzzzz/1"), []byte("0xff")})
 	t.Log("test IteratorScanFromFirst")
-	list = it.IteratorScanFromFirst([]byte("my"), 2, 0)
+	list = it.IteratorScanFromFirst([]byte("my"), 2, ListASC)
 	/*for _, v = range list {
 		t.Log(string(v))
 	}*/
 	require.Equal(t, list, [][]byte{[]byte("my"), []byte("my_")})
 
 	t.Log("test IteratorScanFromLast")
-	list = it.IteratorScanFromLast([]byte("my"), 100, 0)
+	list = it.IteratorScanFromLast([]byte("my"), 100, ListDESC)
 	/*for _, v = range list {
 		t.Log(string(v))
 	}*/
 	require.Equal(t, list, [][]byte{[]byte("my_key/4"), []byte("my_key/3"), []byte("my_key/2"), []byte("my_key/1"), []byte("my_"), []byte("my")})
 
 	t.Log("test IteratorScan 1")
-	list = it.IteratorScan([]byte("my"), []byte("my_key/3"), 100, 1)
+	list = it.IteratorScan([]byte("my"), []byte("my_key/3"), 100, ListASC)
 	/*for _, v = range list {
 		t.Log(string(v))
 	}*/
 	require.Equal(t, list, [][]byte{[]byte("my_key/4")})
 
 	t.Log("test IteratorScan 0")
-	list = it.IteratorScan([]byte("my"), []byte("my_key/3"), 100, 0)
+	list = it.IteratorScan([]byte("my"), []byte("my_key/3"), 100, ListDESC)
 	/*for _, v = range list {
 		t.Log(string(v))
 	}*/
@@ -217,19 +217,19 @@ func testDBBoundary(t *testing.T, db DB) {
 	require.Equal(t, list, [][]byte{[]byte("0x0f"), []byte("0x0fff")})
 
 	t.Log("IteratorScanFromFirst")
-	list = it.IteratorScanFromFirst(a, 2, 0)
+	list = it.IteratorScanFromFirst(a, 2, ListASC)
 	require.Equal(t, list, [][]byte{[]byte("0x0f"), []byte("0x0fff")})
 
 	t.Log("IteratorScanFromLast")
-	list = it.IteratorScanFromLast(a, 100, 0)
+	list = it.IteratorScanFromLast(a, 100, ListDESC)
 	require.Equal(t, list, [][]byte{[]byte("0x0fff"), []byte("0x0f")})
 
 	t.Log("IteratorScan 1")
-	list = it.IteratorScan(a, a, 100, 1)
+	list = it.IteratorScan(a, a, 100, ListASC)
 	require.Equal(t, list, [][]byte{[]byte("0x0fff")})
 
 	t.Log("IteratorScan 0")
-	list = it.IteratorScan(a, a, 100, 0)
+	list = it.IteratorScan(a, a, 100, ListDESC)
 	require.Equal(t, list, [][]byte(nil))
 
 	// ff为prefix
@@ -238,19 +238,19 @@ func testDBBoundary(t *testing.T, db DB) {
 	require.Equal(t, list, [][]byte{[]byte("0xff"), []byte("0xffff")})
 
 	t.Log("IteratorScanFromFirst")
-	list = it.IteratorScanFromFirst(b, 2, 0)
+	list = it.IteratorScanFromFirst(b, 2, ListASC)
 	require.Equal(t, list, [][]byte{[]byte("0xff"), []byte("0xffff")})
 
 	t.Log("IteratorScanFromLast")
-	list = it.IteratorScanFromLast(b, 100, 0)
+	list = it.IteratorScanFromLast(b, 100, ListDESC)
 	require.Equal(t, list, [][]byte{[]byte("0xffff"), []byte("0xff")})
 
 	t.Log("IteratorScan 1")
-	list = it.IteratorScan(b, b, 100, 1)
+	list = it.IteratorScan(b, b, 100, ListASC)
 	require.Equal(t, list, [][]byte{[]byte("0xffff")})
 
 	t.Log("IteratorScan 0")
-	list = it.IteratorScan(b, d, 100, 0)
+	list = it.IteratorScan(b, d, 100, ListDESC)
 	require.Equal(t, list, [][]byte{[]byte("0xff")})
 }
 
@@ -342,15 +342,15 @@ func testDBIteratorResult(t *testing.T, db DB) {
 	require.Equal(t, string(v), "aaaaaa/1")
 	//test list:
 	it0 := NewListHelper(db)
-	list0 := it0.List([]byte("my_key"), nil, 100, 1|ListKeyOnly)
+	list0 := it0.List([]byte("my_key"), nil, 100, ListASC|ListKeyOnly)
 	require.Equal(t, list0, [][]byte{[]byte("my_key/1"), []byte("my_key/2"), []byte("my_key/3"), []byte("my_key/4")})
 
 	it1 := NewListHelper(db)
-	list1 := it1.List([]byte("my_key"), nil, 100, 1)
+	list1 := it1.List([]byte("my_key"), nil, 100, ListASC)
 	require.Equal(t, list1, [][]byte{[]byte("my_value/1"), []byte("my_value/2"), []byte("my_value/3"), []byte("my_value/4")})
 
 	it2 := NewListHelper(db)
-	list2 := it2.List([]byte("my_key"), nil, 100, 1|ListWithKey)
+	list2 := it2.List([]byte("my_key"), nil, 100, ListASC|ListWithKey)
 	require.Equal(t, 4, len(list2))
 	for i, v := range list2 {
 		var kv types.KeyValue

--- a/common/db/db_test.go
+++ b/common/db/db_test.go
@@ -169,14 +169,14 @@ func testDBIterator(t *testing.T, db DB) {
 	assert.Equal(t, list0, list)
 	require.Equal(t, list, [][]byte{[]byte("aaaaaa/1"), []byte("my"), []byte("my_"), []byte("my_key/1"), []byte("my_key/2"), []byte("my_key/3"), []byte("my_key/4"), []byte("zzzzzz/1"), []byte("0xff")})
 	t.Log("test IteratorScanFromFirst")
-	list = it.IteratorScanFromFirst([]byte("my"), 2)
+	list = it.IteratorScanFromFirst([]byte("my"), 2, 0)
 	/*for _, v = range list {
 		t.Log(string(v))
 	}*/
 	require.Equal(t, list, [][]byte{[]byte("my"), []byte("my_")})
 
 	t.Log("test IteratorScanFromLast")
-	list = it.IteratorScanFromLast([]byte("my"), 100)
+	list = it.IteratorScanFromLast([]byte("my"), 100, 0)
 	/*for _, v = range list {
 		t.Log(string(v))
 	}*/
@@ -217,11 +217,11 @@ func testDBBoundary(t *testing.T, db DB) {
 	require.Equal(t, list, [][]byte{[]byte("0x0f"), []byte("0x0fff")})
 
 	t.Log("IteratorScanFromFirst")
-	list = it.IteratorScanFromFirst(a, 2)
+	list = it.IteratorScanFromFirst(a, 2, 0)
 	require.Equal(t, list, [][]byte{[]byte("0x0f"), []byte("0x0fff")})
 
 	t.Log("IteratorScanFromLast")
-	list = it.IteratorScanFromLast(a, 100)
+	list = it.IteratorScanFromLast(a, 100, 0)
 	require.Equal(t, list, [][]byte{[]byte("0x0fff"), []byte("0x0f")})
 
 	t.Log("IteratorScan 1")
@@ -238,11 +238,11 @@ func testDBBoundary(t *testing.T, db DB) {
 	require.Equal(t, list, [][]byte{[]byte("0xff"), []byte("0xffff")})
 
 	t.Log("IteratorScanFromFirst")
-	list = it.IteratorScanFromFirst(b, 2)
+	list = it.IteratorScanFromFirst(b, 2, 0)
 	require.Equal(t, list, [][]byte{[]byte("0xff"), []byte("0xffff")})
 
 	t.Log("IteratorScanFromLast")
-	list = it.IteratorScanFromLast(b, 100)
+	list = it.IteratorScanFromLast(b, 100, 0)
 	require.Equal(t, list, [][]byte{[]byte("0xffff"), []byte("0xff")})
 
 	t.Log("IteratorScan 1")

--- a/common/db/go_level_db_test.go
+++ b/common/db/go_level_db_test.go
@@ -277,3 +277,16 @@ func int642Bytes(i int64) []byte {
 func bytes2Int64(buf []byte) int64 {
 	return int64(binary.BigEndian.Uint64(buf))
 }
+
+// leveldb返回值测试
+func TestGoLevelDBResult(t *testing.T) {
+	dir, err := ioutil.TempDir("", "goleveldb")
+	require.NoError(t, err)
+	t.Log(dir)
+
+	leveldb, err := NewGoLevelDB("goleveldb", dir, 128)
+	require.NoError(t, err)
+	defer leveldb.Close()
+
+	testDBIteratorResult(t, leveldb)
+}

--- a/common/db/list_helper.go
+++ b/common/db/list_helper.go
@@ -250,8 +250,9 @@ func (c *collector) collect(it Iterator) {
 		v := types.KeyValue{Key: cloneByte(it.Key()), Value: cloneByte(it.Value())}
 		c.results = append(c.results, types.Encode(&v))
 		// c.results = append(c.results, Key: cloneByte(it.Key()), Value: cloneByte(it.Value()))
+	} else {
+		c.results = append(c.results, cloneByte(it.Value()))
 	}
-	c.results = append(c.results, cloneByte(it.Value()))
 }
 
 func (c *collector) result() [][]byte {

--- a/common/db/list_helper.go
+++ b/common/db/list_helper.go
@@ -13,15 +13,14 @@ import (
 
 //ListHelper ...
 type ListHelper struct {
-	db      IteratorDB
-	results *collector
+	db IteratorDB
 }
 
 var listlog = log.New("module", "db.ListHelper")
 
 //NewListHelper new
 func NewListHelper(db IteratorDB) *ListHelper {
-	return &ListHelper{db: db, results: newCollector()}
+	return &ListHelper{db: db}
 }
 
 //PrefixScan 前缀
@@ -243,9 +242,9 @@ type collector struct {
 	direction int32
 }
 
-func newCollector() *collector {
+func newCollector(direction int32) *collector {
 	r := make([][]byte, 0)
-	return &collector{results: r, direction: 0}
+	return &collector{results: r, direction: direction}
 }
 
 func (c *collector) collect(it Iterator) {

--- a/common/db/list_helper.go
+++ b/common/db/list_helper.go
@@ -50,14 +50,15 @@ const (
 
 //List 列表
 func (db *ListHelper) List(prefix, key []byte, count, direction int32) (values [][]byte) {
+	if len(key) != 0 && count == 1 && direction == ListSeek {
+		return db.nextKeyValue(prefix, key, count, direction)
+	}
+
 	if len(key) == 0 {
 		if direction == ListASC {
 			return db.IteratorScanFromFirst(prefix, count)
 		}
 		return db.IteratorScanFromLast(prefix, count)
-	}
-	if count == 1 && direction == ListSeek {
-		return db.nextKeyValue(prefix, key, count, direction)
 	}
 	return db.IteratorScan(prefix, key, count, direction)
 }

--- a/common/db/list_helper.go
+++ b/common/db/list_helper.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	log "github.com/33cn/chain33/common/log/log15"
+	"github.com/33cn/chain33/types"
 )
 
 //ListHelper ...
@@ -46,8 +47,8 @@ const (
 	// 000， <- 位从低位开始数
 	// 0位：direction  ListDESC ListASC
 	// 1位：next key， 目前是一个特殊用途， 因为其他的都是返回value， 这个模式同时返回key， value。 不和其他位组合
-	// 2位: 返回时，返回 key value， 不指定 只返回value
-	// 3位: 返回时，返回 key， 不指定 只返回value. 和 2位不可以同时设置为1
+	// 2位: 为1返回时，返回 key+value，默认只返回value. 返回的是 types.Encode(types.KeyValue)
+	// 3位: 为1返回时，返回 key， 默认只返回value. 和 2位不可以同时设置为1
 	ListDESC    = int32(0) // 0
 	ListASC     = int32(1) // 1
 	ListSeek    = int32(2) // 10
@@ -246,7 +247,9 @@ func (c *collector) collect(it Iterator) {
 	if c.direction&ListKeyOnly != 0 {
 		c.results = append(c.results, cloneByte(it.Key()))
 	} else if c.direction&ListWithKey != 0 {
-		c.results = append(c.results, cloneByte(it.Key()), cloneByte(it.Value()))
+		v := types.KeyValue{Key: cloneByte(it.Key()), Value: cloneByte(it.Value())}
+		c.results = append(c.results, types.Encode(&v))
+		// c.results = append(c.results, Key: cloneByte(it.Key()), Value: cloneByte(it.Value()))
 	}
 	c.results = append(c.results, cloneByte(it.Value()))
 }

--- a/common/db/list_helper.go
+++ b/common/db/list_helper.go
@@ -37,7 +37,7 @@ func (db *ListHelper) PrefixScan(prefix []byte) [][]byte {
 		resutls.collect(it)
 		//blog.Debug("PrefixScan", "key", string(item.Key()), "value", string(value))
 	}
-	return resutls.results
+	return resutls.result()
 }
 
 //const
@@ -97,7 +97,7 @@ func (db *ListHelper) IteratorScan(prefix []byte, key []byte, count int32, direc
 			break
 		}
 	}
-	return results.results
+	return results.result()
 }
 
 func (db *ListHelper) iteratorScan(prefix []byte, count int32, reverse bool, direction int32) [][]byte {
@@ -119,7 +119,7 @@ func (db *ListHelper) iteratorScan(prefix []byte, count int32, reverse bool, dir
 			break
 		}
 	}
-	return results.results
+	return results.result()
 }
 
 //IteratorScanFromFirst 从头迭代
@@ -249,4 +249,11 @@ func (c *collector) collect(it Iterator) {
 		c.results = append(c.results, cloneByte(it.Key()), cloneByte(it.Value()))
 	}
 	c.results = append(c.results, cloneByte(it.Value()))
+}
+
+func (c *collector) result() [][]byte {
+	if len(c.results) == 0 {
+		return nil
+	}
+	return c.results
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -157,7 +157,7 @@ func (exec *Executor) upgradePlugin(plugin string) error {
 		return err
 	}
 	var localdb dbm.KVDB
-	if exec.disableLocal {
+	if !exec.disableLocal {
 		localdb = NewLocalDB(exec.client)
 		defer localdb.(*LocalDB).Close()
 		driver.SetLocalDB(localdb)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -157,7 +157,7 @@ func (exec *Executor) upgradePlugin(plugin string) error {
 		return err
 	}
 	var localdb dbm.KVDB
-	if !exec.disableLocal {
+	if exec.disableLocal {
 		localdb = NewLocalDB(exec.client)
 		defer localdb.(*LocalDB).Close()
 		driver.SetLocalDB(localdb)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -131,7 +131,7 @@ func (exec *Executor) SetQueueClient(qcli queue.Client) {
 func (exec *Executor) procUpgrade(msg *queue.Message) {
 	for _, plugin := range pluginmgr.GetExecList() {
 		elog.Info("begin upgrade plugin ", "name", plugin)
-		err := exec.upgradePlugin(msg, plugin)
+		err := exec.upgradePlugin(plugin)
 		if err != nil {
 			msg.Reply(exec.client.NewMessage("", types.EventUpgrade, err))
 			panic(err)
@@ -143,7 +143,7 @@ func (exec *Executor) procUpgrade(msg *queue.Message) {
 	}))
 }
 
-func (exec *Executor) upgradePlugin(msg *queue.Message, plugin string) error {
+func (exec *Executor) upgradePlugin(plugin string) error {
 	header, err := exec.qclient.GetLastHeader()
 	if err != nil {
 		return err

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -133,6 +133,7 @@ func (exec *Executor) procUpgrade(msg *queue.Message) {
 		elog.Info("begin upgrade plugin ", "name", plugin)
 		err := exec.upgradePlugin(msg, plugin)
 		if err != nil {
+			msg.Reply(exec.client.NewMessage("", types.EventUpgrade, err))
 			panic(err)
 		}
 	}
@@ -145,7 +146,6 @@ func (exec *Executor) procUpgrade(msg *queue.Message) {
 func (exec *Executor) upgradePlugin(msg *queue.Message, plugin string) error {
 	header, err := exec.qclient.GetLastHeader()
 	if err != nil {
-		msg.Reply(exec.client.NewMessage("", types.EventUpgrade, err))
 		return err
 	}
 	driver, err := drivers.LoadDriverWithClient(exec.qclient, plugin, header.GetHeight())
@@ -154,7 +154,6 @@ func (exec *Executor) upgradePlugin(msg *queue.Message, plugin string) error {
 		return nil
 	}
 	if err != nil {
-		msg.Reply(exec.client.NewMessage("", types.EventUpgrade, err))
 		return err
 	}
 	var localdb dbm.KVDB
@@ -172,7 +171,6 @@ func (exec *Executor) upgradePlugin(msg *queue.Message, plugin string) error {
 	err = driver.Upgrade()
 	if err != nil {
 		localdb.Rollback()
-		msg.Reply(exec.client.NewMessage("", types.EventUpgrade, err))
 		return err
 	}
 	localdb.Commit()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -136,6 +136,10 @@ func (exec *Executor) procUpgrade(msg *queue.Message) {
 			panic(err)
 		}
 	}
+	elog.Info("upgrade plugin success")
+	msg.Reply(exec.client.NewMessage("", types.EventUpgrade, &types.Reply{
+		IsOk: true,
+	}))
 }
 
 func (exec *Executor) upgradePlugin(msg *queue.Message, plugin string) error {
@@ -172,9 +176,6 @@ func (exec *Executor) upgradePlugin(msg *queue.Message, plugin string) error {
 		return err
 	}
 	localdb.Commit()
-	msg.Reply(exec.client.NewMessage("", types.EventUpgrade, &types.Reply{
-		IsOk: true,
-	}))
 	return nil
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -311,7 +311,6 @@ func TestCheckTx(t *testing.T) {
 
 func TestExecutorUpgradeMsg(t *testing.T) {
 	exec, q := initEnv(types.GetDefaultCfgstring())
-	exec.disableLocal = true
 	cfg := exec.client.GetConfig()
 	cfg.SetMinFee(0)
 	Register(cfg)
@@ -326,7 +325,6 @@ func TestExecutorUpgradeMsg(t *testing.T) {
 
 func TestExecutorPluginUpgrade(t *testing.T) {
 	exec, q := initEnv(types.GetDefaultCfgstring())
-	exec.disableLocal = true
 	cfg := exec.client.GetConfig()
 	cfg.SetMinFee(0)
 	Register(cfg)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7,6 +7,7 @@ package executor
 import (
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -186,11 +187,16 @@ func TestKeyLocalAllow(t *testing.T) {
 }
 
 func init() {
-	types.AllowUserExec = append(types.AllowUserExec, []byte("demo"))
+	types.AllowUserExec = append(types.AllowUserExec, []byte("demo"), []byte("demof"))
 }
 
+var testRegOnce sync.Once
+
 func Register(cfg *types.Chain33Config) {
-	drivers.Register(cfg, "demo", newdemoApp, 1)
+	testRegOnce.Do(func() {
+		drivers.Register(cfg, "demo", newdemoApp, 1)
+		drivers.Register(cfg, "demof", newdemofApp, 1)
+	})
 }
 
 //ErrEnvAPI 测试
@@ -210,6 +216,35 @@ func (demo *demoApp) GetDriverName() string {
 
 func (demo *demoApp) Exec(tx *types.Transaction, index int) (receipt *types.Receipt, err error) {
 	return nil, queue.ErrQueueTimeout
+}
+
+func (demo *demoApp) Upgrade() (err error) {
+	db := demo.GetLocalDB()
+	db.Set([]byte("LODB-demo-a"), []byte("t1"))
+	db.Set([]byte("LODB-demo-b"), []byte("t2"))
+	return nil
+}
+
+type demofApp struct {
+	*drivers.DriverBase
+}
+
+func newdemofApp() drivers.Driver {
+	demo := &demofApp{DriverBase: &drivers.DriverBase{}}
+	demo.SetChild(demo)
+	return demo
+}
+
+func (demo *demofApp) GetDriverName() string {
+	return "demof"
+}
+
+func (demo *demofApp) Exec(tx *types.Transaction, index int) (receipt *types.Receipt, err error) {
+	return nil, queue.ErrQueueTimeout
+}
+
+func (demo *demofApp) Upgrade() (err error) {
+	return types.ErrInvalidParam
 }
 
 func TestExecutorErrAPIEnv(t *testing.T) {
@@ -272,4 +307,45 @@ func TestCheckTx(t *testing.T) {
 	execute := newExecutor(ctx, exec, nil, txs, nil)
 	err := execute.execCheckTx(tx, 0)
 	assert.Equal(t, err, types.ErrNoBalance)
+}
+
+func TestExecutorUpgradeMsg(t *testing.T) {
+	exec, q := initEnv(types.GetDefaultCfgstring())
+	exec.disableLocal = true
+	cfg := exec.client.GetConfig()
+	cfg.SetMinFee(0)
+	Register(cfg)
+	execInit(cfg)
+
+	exec.SetQueueClient(q.Client())
+	client := q.Client()
+	msg := client.NewMessage("execs", types.EventUpgrade, nil)
+	err := client.Send(msg, true)
+	assert.Nil(t, err)
+}
+
+func TestExecutorPluginUpgrade(t *testing.T) {
+	exec, q := initEnv(types.GetDefaultCfgstring())
+	exec.disableLocal = true
+	cfg := exec.client.GetConfig()
+	cfg.SetMinFee(0)
+	Register(cfg)
+	execInit(cfg)
+
+	go func() {
+		client := q.Client()
+		client.Sub("blockchain")
+		for msg := range client.Recv() {
+			if msg.Ty == types.EventLocalNew {
+				msg.Reply(client.NewMessage("", types.EventHeader, &types.Int64{Data: 100}))
+			} else {
+				msg.Reply(client.NewMessage("", types.EventHeader, &types.Header{Height: 100}))
+			}
+		}
+	}()
+
+	err := exec.upgradePlugin("demo")
+	assert.Nil(t, err)
+	err = exec.upgradePlugin("demof")
+	assert.NotNil(t, err)
 }

--- a/pluginmgr/manager.go
+++ b/pluginmgr/manager.go
@@ -26,6 +26,14 @@ func InitExec(cfg *typ.Chain33Config) {
 	})
 }
 
+//GetExecList 获取插件名字列表
+func GetExecList() (datas []string) {
+	for _, plugin := range pluginItems {
+		datas = append(datas, plugin.GetExecutorName())
+	}
+	return
+}
+
 // InitWallet init wallet plugin
 func InitWallet(wallet wcom.WalletOperate, sub map[string][]byte) {
 	once.Do(func() {

--- a/system/dapp/driver.go
+++ b/system/dapp/driver.go
@@ -73,6 +73,7 @@ type Driver interface {
 	GetExecutorType() types.ExecutorType
 	CheckReceiptExecOk() bool
 	ExecutorOrder() int64
+	Upgrade() error
 }
 
 // DriverBase defines driverbase type
@@ -95,6 +96,12 @@ type DriverBase struct {
 	txs                  []*types.Transaction
 	receipts             []*types.ReceiptData
 	ety                  types.ExecutorType
+}
+
+//Upgrade default upgrade only print a message
+func (d *DriverBase) Upgrade() error {
+	blog.Info("upgrade ", "dapp", d.GetName())
+	return nil
 }
 
 // GetPayloadValue define get payload func

--- a/types/event.go
+++ b/types/event.go
@@ -156,6 +156,7 @@ const (
 	//exec
 	EventBlockChainQuery = 212
 	EventConsensusQuery  = 213
+	EventUpgrade         = 214
 
 	// BlockChain 接收的事件
 	EventGetLastBlockMainSequence   = 300
@@ -336,4 +337,5 @@ var eventName = map[int]string{
 	EventReplyHeightByTitle:         "EventReplyHeightByTitle",
 	EventGetParaTxByTitleAndHeight:  "EventGetParaTxByTitleAndHeight",
 	EventCmpBestBlock:               "EventCmpBestBlock",
+	EventUpgrade:                    "EventUpgrade",
 }

--- a/wallet/common/store.go
+++ b/wallet/common/store.go
@@ -208,9 +208,9 @@ func (store *Store) GetTxDetailByIter(TxList *types.ReqWalletTransactionList) (*
 	if len(TxList.FromTx) == 0 {
 		list := store.NewListHelper()
 		if TxList.Direction == 0 {
-			txbytes = list.IteratorScanFromLast(CalcTxKey(""), TxList.Count)
+			txbytes = list.IteratorScanFromLast(CalcTxKey(""), TxList.Count, 0)
 		} else {
-			txbytes = list.IteratorScanFromFirst(CalcTxKey(""), TxList.Count)
+			txbytes = list.IteratorScanFromFirst(CalcTxKey(""), TxList.Count, 0)
 		}
 		if len(txbytes) == 0 {
 			storelog.Error("GetTxDetailByIter IteratorScanFromLast does not exist tx!")

--- a/wallet/common/store.go
+++ b/wallet/common/store.go
@@ -208,9 +208,9 @@ func (store *Store) GetTxDetailByIter(TxList *types.ReqWalletTransactionList) (*
 	if len(TxList.FromTx) == 0 {
 		list := store.NewListHelper()
 		if TxList.Direction == 0 {
-			txbytes = list.IteratorScanFromLast(CalcTxKey(""), TxList.Count, 0)
+			txbytes = list.IteratorScanFromLast(CalcTxKey(""), TxList.Count, db.ListDESC)
 		} else {
-			txbytes = list.IteratorScanFromFirst(CalcTxKey(""), TxList.Count, 0)
+			txbytes = list.IteratorScanFromFirst(CalcTxKey(""), TxList.Count, db.ListASC)
 		}
 		if len(txbytes) == 0 {
 			storelog.Error("GetTxDetailByIter IteratorScanFromLast does not exist tx!")


### PR DESCRIPTION
合约增加升级机制：

1. 升级只允许升级 localdb，不能访问 statedb
2. locals set 后，并且 upgrade 函数返回 没有err 那么自动提交到数据库中，否则，会回滚set 的内容。
3. TODO： 补充单元测试