### PR TITLE
Update p2p

### DIFF
--- a/p2p/const.go
+++ b/p2p/const.go
@@ -64,6 +64,7 @@ const (
 const (
 	DefaultLtTxBroadCastTTL  = 3
 	DefaultMaxTxBroadCastTTL = 25
+	DefaultMinLtBlockTxNum   = 2
 )
 
 // P2pCacheTxSize p2pcache size of transaction

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -130,9 +130,9 @@ Retry:
 	}
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.UnaryInterceptor(interceptor), grpc.StreamInterceptor(interceptorStream))
-	//区块最多10M
-	msgRecvOp := grpc.MaxRecvMsgSize(11 * 1024 * 1024) //设置最大接收数据大小位11M
-	msgSendOp := grpc.MaxSendMsgSize(11 * 1024 * 1024) //设置最大发送数据大小为11M
+	maxMsgSize := pb.MaxBlockSize + 1024 * 1024 //最大传输数据 最大区块大小
+	msgRecvOp := grpc.MaxRecvMsgSize(maxMsgSize) //设置最大接收数据
+	msgSendOp := grpc.MaxSendMsgSize(maxMsgSize) //设置最大发送数据
 	kaep := keepalive.EnforcementPolicy{
 		MinTime:             10 * time.Second, //只允许不低于10s频率的ping周期
 		PermitWithoutStream: true,

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -133,14 +133,17 @@ Retry:
 	//区块最多10M
 	msgRecvOp := grpc.MaxRecvMsgSize(11 * 1024 * 1024) //设置最大接收数据大小位11M
 	msgSendOp := grpc.MaxSendMsgSize(11 * 1024 * 1024) //设置最大发送数据大小为11M
+	kaep := keepalive.EnforcementPolicy{
+		MinTime:             10 * time.Second, //只允许不低于10s频率的ping周期
+		PermitWithoutStream: true,
+	}
 	var keepparm keepalive.ServerParameters
 	keepparm.Time = 5 * time.Minute
 	keepparm.Timeout = 50 * time.Second
-	keepparm.MaxConnectionIdle = 1 * time.Minute
 	maxStreams := grpc.MaxConcurrentStreams(1000)
 	keepOp := grpc.KeepaliveParams(keepparm)
 	StatsOp := grpc.StatsHandler(&statshandler{})
-	opts = append(opts, msgRecvOp, msgSendOp, keepOp, maxStreams, StatsOp)
+	opts = append(opts, msgRecvOp, msgSendOp, grpc.KeepaliveEnforcementPolicy(kaep), keepOp, maxStreams, StatsOp)
 	dl.server = grpc.NewServer(opts...)
 	dl.p2pserver = pServer
 	pb.RegisterP2PgserviceServer(dl.server, pServer)

--- a/p2p/listener.go
+++ b/p2p/listener.go
@@ -130,7 +130,7 @@ Retry:
 	}
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.UnaryInterceptor(interceptor), grpc.StreamInterceptor(interceptorStream))
-	maxMsgSize := pb.MaxBlockSize + 1024 * 1024 //最大传输数据 最大区块大小
+	maxMsgSize := pb.MaxBlockSize + 1024*1024    //最大传输数据 最大区块大小
 	msgRecvOp := grpc.MaxRecvMsgSize(maxMsgSize) //设置最大接收数据
 	msgSendOp := grpc.MaxSendMsgSize(maxMsgSize) //设置最大发送数据
 	kaep := keepalive.EnforcementPolicy{

--- a/p2p/netaddress.go
+++ b/p2p/netaddress.go
@@ -146,8 +146,8 @@ func (na *NetAddress) DialTimeout(version int32) (*grpc.ClientConn, error) {
 	ch <- P2pComm.GrpcConfig()
 
 	var cliparm keepalive.ClientParameters
-	cliparm.Time = 10 * time.Second    //10秒Ping 一次
-	cliparm.Timeout = 10 * time.Second //等待10秒，如果Ping 没有响应，则超时
+	cliparm.Time = 15 * time.Second    //keepalive ping 周期
+	cliparm.Timeout = 10 * time.Second //ping后的获取ack消息超时时间
 	cliparm.PermitWithoutStream = true //启动keepalive 进行检查
 	keepaliveOp := grpc.WithKeepaliveParams(cliparm)
 	timeoutOp := grpc.WithTimeout(time.Second * 3)

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -57,6 +57,10 @@ func New(cfg *types.Chain33Config) *P2p {
 		mcfg.MaxTTL = DefaultMaxTxBroadCastTTL
 	}
 
+	if mcfg.MinLtBlockTxNum < DefaultMinLtBlockTxNum {
+		mcfg.MinLtBlockTxNum = DefaultMinLtBlockTxNum
+	}
+
 	log.Info("p2p", "Channel", mcfg.Channel, "Version", VERSION, "IsTest", cfg.IsTestNet())
 	if mcfg.InnerBounds == 0 {
 		mcfg.InnerBounds = 500

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -232,8 +232,6 @@ func testPeer(t *testing.T, p2p *P2p, q queue.Queue) {
 	localP2P.node.AddCachePeer(peer)
 	assert.Equal(t, localP2P.node.CacheBoundsSize(), len(localP2P.node.GetCacheBounds()))
 	peer.GetRunning()
-	peer.getIsRegister()
-	peer.setIsRegister(false)
 	localP2P.node.nodeInfo.FetchPeerInfo(localP2P.node)
 	peers, infos := localP2P.node.GetActivePeers()
 	assert.Equal(t, len(peers), len(infos))

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -50,7 +50,6 @@ type Peer struct {
 	taskChan     chan interface{} //tx block
 	inBounds     int32            //连接此节点的客户端节点数量
 	IsMaxInbouds bool
-	isRegister   bool //标记是否发送服务端注册peer info, 规避6.2版本no peer info问题, TODO: 全网升级到6.3后, 可删除相关代码
 }
 
 // NewPeer produce a peer object

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -37,7 +37,7 @@ func (p *Peer) Close() {
 
 // Peer object information
 type Peer struct {
-	mutx         sync.Mutex
+	mutex        sync.RWMutex
 	node         *Node
 	conn         *grpc.ClientConn // source connection
 	persistent   bool
@@ -386,8 +386,8 @@ func (p *Peer) IsPersistent() bool {
 
 // SetPeerName set name of peer
 func (p *Peer) SetPeerName(name string) {
-	p.mutx.Lock()
-	defer p.mutx.Unlock()
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 	if name == "" {
 		return
 	}
@@ -396,7 +396,7 @@ func (p *Peer) SetPeerName(name string) {
 
 // GetPeerName get name of peer
 func (p *Peer) GetPeerName() string {
-	p.mutx.Lock()
-	defer p.mutx.Unlock()
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
 	return p.name
 }

--- a/p2p/process.go
+++ b/p2p/process.go
@@ -86,11 +86,8 @@ func (n *Node) sendBlock(block *types.P2PBlock, p2pData *types.BroadCastData, pe
 		return false
 	}
 
-	if peerVersion >= lightBroadCastVersion {
+	if peerVersion >= lightBroadCastVersion && len(block.Block.Txs) >= int(n.nodeInfo.cfg.MinLtBlockTxNum) {
 
-		if len(block.Block.Txs) < 1 {
-			return false
-		}
 		ltBlock := &types.LightBlock{}
 		ltBlock.Size = int64(types.Size(block.Block))
 		ltBlock.Header = block.Block.GetHeader(n.cfg)

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -197,6 +197,8 @@ type P2P struct {
 	Channel int32 `protobuf:"varint,20,opt,name=channel" json:"channel,omitempty"`
 	//固定连接节点，只连接配置项seeds中的节点
 	FixedSeed bool `protobuf:"varint,21,opt,name=fixedSeed" json:"fixedSeed,omitempty"`
+	//区块轻广播的最低打包交易数, 大于该值时区块内交易采用短哈希广播
+	MinLtBlockTxNum int32 `protobuf:"varint,22,opt,name=minLtBlockTxNum" json:"minLtBlockTxNum,omitempty"`
 }
 
 // RPC 配置


### PR DESCRIPTION
#### p2p相关更新及优化

1. 移除兼容老版本代码, 目前全网已经6.3, 不需要进行兼容

2. 将peername锁修改为读写锁

3. 更新p2p grpc的keepalive设置

4. p2p配置增加区块轻广播最低交易数设置, 低于该交易数的区块采用全广播, 同时也适配空区块情况, 该配置默认值为2