### PR TITLE
p2p:add peer close with unsub all topics

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -30,7 +30,10 @@ func (p *Peer) Close() {
 		return
 	}
 	p.mconn.Close()
-	p.node.pubsub.Unsub(p.taskChan, "block", "tx")
+	if p.taskChan != nil {
+		//unsub all topics
+		p.node.pubsub.Unsub(p.taskChan)
+	}
 	log.Info("Peer", "closed", p.Addr())
 
 }


### PR DESCRIPTION

取消订阅时遗漏了topic, 此时不能释放sub最初分配的channel, 导致内存泄漏, 修改为close时释放所有