### PR TITLE
Fix queue ut

### DIFF
--- a/client/queueprotocol_test.go
+++ b/client/queueprotocol_test.go
@@ -7,6 +7,7 @@ package client_test
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/33cn/chain33/client"
 	"github.com/33cn/chain33/common/version"
@@ -39,8 +40,8 @@ func TestMain(m *testing.M) {
 
 func TestQueueProtocolAPI(t *testing.T) {
 	var option client.QueueProtocolOption
-	option.SendTimeout = 100
-	option.WaitTimeout = 200
+	option.SendTimeout = time.Millisecond
+	option.WaitTimeout = 2 * time.Millisecond
 
 	_, err := client.New(nil, nil)
 	if err == nil {


### PR DESCRIPTION
```
func TestQueueProtocolAPI(t *testing.T) {
	var option client.QueueProtocolOption
	option.SendTimeout = time.Millisecond
	option.WaitTimeout = 2 * time.Millisecond

	_, err := client.New(nil, nil)
	if err == nil {
		t.Error("client.New(nil, nil) need return error")
	}

	var q = queue.New("channel")
	qc, err := client.New(q.Client(), &option)
	if err != nil {
		t.Errorf("client.New() cause error %v", err)
	}
	if qc == nil {
		t.Error("queueprotoapi object is nil")
	}
	_, err = qc.Notify("", 1, "data")
	assert.Nil(t, err)

}
```

本地执行几十次未能复现。低优先级消息队列容量defaultLowChanBuffer = 40960，可以排除消息队列已满导致的超时问题，初步考虑是因为超时时间设置的太短引起的问题。

option.SendTimeout原来是100纳秒，即千万分之一秒，等待时间太短可能导致因为机器具体执行环境导致超时。考虑到生产环境不会等待如此短的时间，ut中把等待时间设置为1毫秒即千分之一秒，既可以覆盖生产环境的极端使用场景，也不会对ut执行效率造成影响