### PR TITLE
Update dht broadcast

### DIFF
--- a/blockchain/proc.go
+++ b/blockchain/proc.go
@@ -284,17 +284,17 @@ func (chain *BlockChain) broadcastAddBlock(msg *queue.Message) {
 	backWardMaximum := curheight > MaxRollBlockNum && castheight < curheight-MaxRollBlockNum
 
 	if futureMaximum || backWardMaximum {
-		chainlog.Debug("EventBroadcastAddBlock", "curheight", curheight, "castheight", castheight, "hash", common.ToHex(blockwithpid.Block.Hash(chain.client.GetConfig())), "pid", blockwithpid.Pid, "result", "Do not handle broad cast Block in sync")
+		chainlog.Debug("EventBroadcastAddBlock", "curheight", curheight, "castheight", castheight, "hash", common.ToHex(blockwithpid.Block.Hash(chain.client.GetConfig())), "pid", blockwithpid.Pid)
 		msg.Reply(chain.client.NewMessage("", types.EventReply, &reply))
 		return
 	}
 	_, err := chain.ProcAddBlockMsg(true, &types.BlockDetail{Block: blockwithpid.Block}, blockwithpid.Pid)
 	if err != nil {
-		chainlog.Error("ProcAddBlockMsg", "err", err.Error())
+		chainlog.Error("EventBroadcastAddBlock", "height", castheight, "err", err.Error())
 		reply.IsOk = false
 		reply.Msg = []byte(err.Error())
 	}
-	chainlog.Debug("EventBroadcastAddBlock", "height", blockwithpid.Block.Height, "hash", common.ToHex(blockwithpid.Block.Hash(chain.client.GetConfig())), "pid", blockwithpid.Pid, "success", "ok")
+	chainlog.Debug("EventBroadcastAddBlock", "height", castheight, "hash", common.ToHex(blockwithpid.Block.Hash(chain.client.GetConfig())), "pid", blockwithpid.Pid)
 
 	msg.Reply(chain.client.NewMessage("", types.EventReply, &reply))
 }

--- a/p2p/event.go
+++ b/p2p/event.go
@@ -76,7 +76,7 @@ func (mgr *Manager) PubBroadCast(hash string, data interface{}, eventTy int) err
 
 	exist, _ := mgr.broadcastFilter.ContainsOrAdd(hash, true)
 	// eventTy, 交易=1, 区块=54
-	log.Debug("PubBroadCast", "eventTy", eventTy, "hash", hash, "exist", exist)
+	//log.Debug("PubBroadCast", "eventTy", eventTy, "hash", hash, "exist", exist)
 	if exist {
 		return nil
 	}

--- a/p2p/utils/util_test.go
+++ b/p2p/utils/util_test.go
@@ -10,6 +10,7 @@ import (
 func Test_spaceLimitCache(t *testing.T) {
 
 	c := NewSpaceLimitCache(3, 10)
+	assert.Equal(t, 3, c.capacity)
 	assert.True(t, c.Add(1, 1, 1))
 	assert.True(t, c.Add(1, 1, 1))
 	assert.False(t, c.Add(2, 2, 20))
@@ -18,16 +19,23 @@ func Test_spaceLimitCache(t *testing.T) {
 	c.Add(3, 2, 2)
 	c.Add(4, 2, 2)
 	c.Add(5, 2, 2)
-	c.Add(6, 2, 2)
-	assert.False(t, c.Contains(2))
+	c.Add(6, 2, 1)
+	assert.False(t, c.Contains(3))
 	assert.Equal(t, 3, c.data.Len())
-	assert.True(t, c.Add(7, 7, 10))
+	assert.Equal(t, 3, len(c.sizeMap))
+	assert.Equal(t, 5, c.currSize)
+	assert.True(t, c.Contains(4))
+	assert.True(t, c.Contains(5))
+	assert.True(t, c.Add(7, 7, 8))
 	assert.True(t, c.Contains(7))
-	assert.Equal(t, 1, c.data.Len())
-	_, exist := c.Remove(7)
+	assert.Equal(t, 2, c.data.Len())
+	assert.Equal(t, 2, len(c.sizeMap))
+	assert.Equal(t, 9, c.currSize)
+	_, exist := c.Remove(6)
 	assert.True(t, exist)
-	_, exist = c.Remove(6)
+	_, exist = c.Remove(5)
 	assert.False(t, exist)
+	assert.Equal(t, 8, c.currSize)
 }
 
 func testChannelVersion(t *testing.T, channel, version int32) {

--- a/system/p2p/dht/p2p.go
+++ b/system/p2p/dht/p2p.go
@@ -73,7 +73,7 @@ func New(mgr *p2p.Manager, subCfg []byte) p2p.IP2P {
 	priv := addrbook.GetPrivkey()
 
 	bandwidthTracker := metrics.NewBandwidthCounter()
-	host := newHost(mcfg.Port, priv, bandwidthTracker, int(mcfg.MaxConnnectNum))
+	host := newHost(mcfg.Port, priv, bandwidthTracker, int(mcfg.MaxConnectNum))
 	p2p := &P2P{
 		host:          host,
 		peerInfoManag: manage.NewPeerInfoManager(mgr.Client),

--- a/system/p2p/dht/p2p_test.go
+++ b/system/p2p/dht/p2p_test.go
@@ -2,7 +2,10 @@ package dht
 
 import (
 	"context"
+	"os"
 	"testing"
+
+	"github.com/33cn/chain33/util"
 
 	p2p2 "github.com/33cn/chain33/p2p"
 	p2pty "github.com/33cn/chain33/system/p2p/dht/types"
@@ -235,9 +238,15 @@ func Test_p2p(t *testing.T) {
 
 	cfg := types.NewChain33Config(types.ReadFile("../../../cmd/chain33/chain33.test.toml"))
 	q := queue.New("channel")
+	datadir := util.ResetDatadir(cfg.GetModuleConfig(), "$TEMP/")
 	q.SetConfig(cfg)
 	processMsg(q)
 	p2p := NewP2p(cfg)
+	defer func(path string) {
+		if err := os.RemoveAll(path); err != nil {
+			log.Error("removeTestDatadir", "err", err)
+		}
+	}(datadir)
 	testP2PEvent(t, q.Client())
 	testP2PClose(t, p2p)
 	testStreamEOFReSet(t)

--- a/system/p2p/dht/protocol/broadcast/block.go
+++ b/system/p2p/dht/protocol/broadcast/block.go
@@ -166,7 +166,7 @@ func (protocol *broadCastProtocol) recvLtBlock(ltBlock *types.LightBlock, pid, p
 	}
 
 	//需要将不完整的block预存
-	protocol.ltBlockCache.Add(blockHash, block, int64(block.Size()))
+	protocol.ltBlockCache.Add(blockHash, block, block.Size())
 	//pub to specified peer
 	_, err := protocol.sendPeer(pid, query, false)
 	if err != nil {

--- a/system/p2p/dht/protocol/broadcast/block.go
+++ b/system/p2p/dht/protocol/broadcast/block.go
@@ -169,14 +169,16 @@ func (protocol *broadCastProtocol) recvLtBlock(ltBlock *types.LightBlock, pid, p
 			},
 		},
 	}
+
+	//需要将不完整的block预存
+	protocol.ltBlockCache.Add(blockHash, block, int64(block.Size()))
 	//pub to specified peer
 	_, err := protocol.sendPeer(pid, query, false)
 	if err != nil {
 		log.Error("recvLtBlock", "pid", pid, "sendStreamErr", err)
 		protocol.blockFilter.Remove(blockHash)
+		protocol.ltBlockCache.Remove(blockHash)
 		return errSendStream
 	}
-	//需要将不完整的block预存
-	protocol.ltBlockCache.Add(blockHash, block, int64(block.Size()))
 	return nil
 }

--- a/system/p2p/dht/protocol/broadcast/block.go
+++ b/system/p2p/dht/protocol/broadcast/block.go
@@ -19,7 +19,7 @@ func (protocol *broadCastProtocol) sendBlock(block *types.P2PBlock, p2pData *typ
 		return false
 	}
 	blockSize := types.Size(block.Block)
-	log.Debug("P2PSendBlock", "blockHash", blockHash, "peerAddr", peerAddr, "blockSize(KB)", float32(blockSize)/1024)
+	//log.Debug("P2PSendBlock", "blockHash", blockHash, "peerAddr", peerAddr, "blockSize(KB)", float32(blockSize)/1024)
 	//区块内交易采用哈希广播
 	if blockSize >= int(protocol.p2pCfg.MinLtBlockSize*1024) {
 		ltBlock := &types.LightBlock{}
@@ -50,12 +50,10 @@ func (protocol *broadCastProtocol) recvBlock(block *types.P2PBlock, pid, peerAdd
 	//将节点id添加到发送过滤, 避免冗余发送
 	addIgnoreSendPeerAtomic(protocol.blockSendFilter, blockHash, pid)
 	//如果重复接收, 则不再发到blockchain执行
-	isDuplicate := protocol.blockFilter.AddWithCheckAtomic(blockHash, true)
-	log.Debug("recvBlock", "blockHeight", block.GetBlock().GetHeight(), "peerAddr", peerAddr,
-		"block size(KB)", float32(block.Block.Size())/1024, "blockHash", blockHash, "duplicateBlock", isDuplicate)
-	if isDuplicate {
+	if protocol.blockFilter.AddWithCheckAtomic(blockHash, true) {
 		return nil
 	}
+	log.Debug("recvBlock", "height", block.GetBlock().GetHeight(), "size(KB)", float32(types.Size(block.GetBlock()))/1024)
 	//发送至blockchain执行
 	if err := protocol.postBlockChain(blockHash, pid, block.GetBlock()); err != nil {
 		log.Error("recvBlock", "send block to blockchain Error", err.Error())
@@ -70,12 +68,10 @@ func (protocol *broadCastProtocol) recvLtBlock(ltBlock *types.LightBlock, pid, p
 	//将节点id添加到发送过滤, 避免冗余发送
 	addIgnoreSendPeerAtomic(protocol.blockSendFilter, blockHash, pid)
 	//检测是否已经收到此block
-	isDuplicate := protocol.blockFilter.AddWithCheckAtomic(blockHash, true)
-	log.Debug("recvLtBlock", "blockHash", blockHash, "blockHeight", ltBlock.GetHeader().GetHeight(),
-		"peerAddr", peerAddr, "duplicateBlock", isDuplicate, "txCount", ltBlock.Header.TxCount)
-	if isDuplicate {
+	if protocol.blockFilter.AddWithCheckAtomic(blockHash, true) {
 		return nil
 	}
+
 	//组装block
 	block := &types.Block{}
 	block.TxHash = ltBlock.Header.TxHash
@@ -129,31 +125,28 @@ func (protocol *broadCastProtocol) recvLtBlock(ltBlock *types.LightBlock, pid, p
 		block.Txs = append(block.Txs, tx)
 	}
 	nilTxLen := len(nilTxIndices)
-	log.Debug("recvLtBlock", "missTxCount", nilTxLen, "existTxCount", len(block.Txs),
-		"buildBlockSize(KB)", float32(block.Size())/1024,
-		"totalBlockSize", float32(ltBlock.Size)/1024)
 
 	//需要比较交易根哈希是否一致, 不一致需要请求区块内所有的交易
-	if nilTxLen == 0 && len(block.Txs) == int(ltBlock.Header.TxCount) &&
-		bytes.Equal(block.TxHash, merkle.CalcMerkleRoot(protocol.BaseProtocol.ChainCfg, block.GetHeight(), block.Txs)) {
+	if nilTxLen == 0 && bytes.Equal(block.TxHash, merkle.CalcMerkleRoot(protocol.BaseProtocol.ChainCfg, block.GetHeight(), block.Txs)) {
 
-		log.Debug("recvLtBlockBuildSuccess", "buildHeight", block.GetHeight(), "peerAddr", peerAddr,
-			"blockHash", blockHash, "blockSize(KB)", float32(ltBlock.Size)/1024)
+		log.Debug("recvLtBlock", "height", block.GetHeight(), "txCount", ltBlock.Header.TxCount, "size(KB)", float32(ltBlock.Size)/1024)
 		//发送至blockchain执行
 		if err := protocol.postBlockChain(blockHash, pid, block); err != nil {
 			log.Error("recvLtBlock", "send block to blockchain Error", err.Error())
 			return errSendBlockChain
 		}
-
 		return nil
 	}
+	//本地缺失交易或者根哈希不同(nilTxLen==0)
+	log.Debug("recvLtBlock", "height", ltBlock.Header.Height, "hash", blockHash,
+		"txCount", ltBlock.Header.TxCount, "missTxCount", nilTxLen,
+		"blockSize(KB)", float32(ltBlock.Size)/1024, "buildBlockSize(KB)", float32(block.Size())/1024)
 	// 缺失的交易个数大于总数1/3 或者缺失数据大小大于2/3, 触发请求区块所有交易数据
 	if nilTxLen > 0 && (float32(nilTxLen) > float32(ltBlock.Header.TxCount)/3 ||
 		float32(block.Size()) < float32(ltBlock.Size)/3) {
+		//空的TxIndices表示请求区块内所有交易
 		nilTxIndices = nilTxIndices[:0]
 	}
-	log.Debug("recvLtBlock", "queryBlockHash", blockHash,
-		"queryHeight", ltBlock.GetHeader().GetHeight(), "queryTxNum", len(nilTxIndices))
 
 	// query not exist txs
 	query := &types.P2PQueryData{
@@ -170,7 +163,7 @@ func (protocol *broadCastProtocol) recvLtBlock(ltBlock *types.LightBlock, pid, p
 	//pub to specified peer
 	_, err := protocol.sendPeer(pid, query, false)
 	if err != nil {
-		log.Error("recvLtBlock", "pid", pid, "sendStreamErr", err)
+		log.Error("recvLtBlock", "pid", pid, "addr", peerAddr, "err", err)
 		protocol.blockFilter.Remove(blockHash)
 		protocol.ltBlockCache.Remove(blockHash)
 		return errSendStream

--- a/system/p2p/dht/protocol/broadcast/block.go
+++ b/system/p2p/dht/protocol/broadcast/block.go
@@ -33,11 +33,6 @@ func (protocol *broadCastProtocol) sendBlock(block *types.P2PBlock, p2pData *typ
 			ltBlock.STxHashes = append(ltBlock.STxHashes, types.CalcTxShortHash(tx.Hash()))
 		}
 
-		// cache block
-		if !protocol.totalBlockCache.Contains(blockHash) {
-			protocol.totalBlockCache.Add(blockHash, block.Block, ltBlock.Size)
-		}
-
 		p2pData.Value = &types.BroadCastData_LtBlock{LtBlock: ltBlock}
 	} else {
 		p2pData.Value = &types.BroadCastData_Block{Block: block}

--- a/system/p2p/dht/protocol/broadcast/block.go
+++ b/system/p2p/dht/protocol/broadcast/block.go
@@ -98,7 +98,7 @@ func (protocol *broadCastProtocol) recvLtBlock(ltBlock *types.LightBlock, pid, p
 	ok := false
 	//get tx list from mempool
 	if len(ltBlock.STxHashes) > 0 {
-		resp, err := protocol.SendToMemPool(types.EventTxListByHash,
+		resp, err := protocol.QueryMempool(types.EventTxListByHash,
 			&types.ReqTxHashList{Hashes: ltBlock.STxHashes, IsShortHash: true})
 		if err != nil {
 			log.Error("recvLtBlock", "queryTxListByHashErr", err)

--- a/system/p2p/dht/protocol/broadcast/broadcast.go
+++ b/system/p2p/dht/protocol/broadcast/broadcast.go
@@ -77,8 +77,8 @@ func (protocol *broadCastProtocol) InitProtocol(env *prototypes.P2PEnv) {
 		subCfg.MaxTTL = defaultMaxTxBroadCastTTL
 	}
 
-	if subCfg.MinLtBlockTxNum <= 0 {
-		subCfg.MinLtBlockTxNum = defaultMinLtBlockTxNum
+	if subCfg.MinLtBlockSize <= 0 {
+		subCfg.MinLtBlockSize = defaultMinLtBlockSize
 	}
 	protocol.p2pCfg = &subCfg
 }

--- a/system/p2p/dht/protocol/broadcast/broadcast.go
+++ b/system/p2p/dht/protocol/broadcast/broadcast.go
@@ -41,7 +41,6 @@ type broadCastProtocol struct {
 	blockFilter     *utils.Filterdata
 	txSendFilter    *utils.Filterdata
 	blockSendFilter *utils.Filterdata
-	totalBlockCache *utils.SpaceLimitCache
 	ltBlockCache    *utils.SpaceLimitCache
 	p2pCfg          *p2pty.P2PSubConfig
 }
@@ -59,8 +58,6 @@ func (protocol *broadCastProtocol) InitProtocol(env *prototypes.P2PEnv) {
 	protocol.txSendFilter = utils.NewFilter(txSendFilterCacheNum)
 	protocol.blockSendFilter = utils.NewFilter(blockSendFilterCacheNum)
 
-	//在本地暂时缓存一些区块数据, 限制最大大小
-	protocol.totalBlockCache = utils.NewSpaceLimitCache(ltBlockCacheNum, maxBlockCacheByteSize)
 	// 单独复制一份， 避免data race
 	subCfg := *(env.SubConfig)
 	//注册事件处理函数
@@ -115,7 +112,6 @@ func (handler *broadCastHandler) SetProtocol(protocol prototypes.IProtocol) {
 
 // VerifyRequest verify request
 func (handler *broadCastHandler) VerifyRequest(types.Message, *types.MessageComm) bool {
-
 	return true
 }
 

--- a/system/p2p/dht/protocol/broadcast/broadcast.go
+++ b/system/p2p/dht/protocol/broadcast/broadcast.go
@@ -80,7 +80,7 @@ func (protocol *broadCastProtocol) InitProtocol(env *prototypes.P2PEnv) {
 
 	//接收到短哈希区块数据,只构建出区块部分交易,需要缓存, 并继续向对端节点请求剩余数据
 	//内部组装成功失败或成功都会进行清理，实际运行并不会长期占用内存，只要限制极端情况最大值
-	protocol.ltBlockCache = utils.NewSpaceLimitCache(ltBlockCacheNum, int64(subCfg.LtBlockCacheSize*1024*1024))
+	protocol.ltBlockCache = utils.NewSpaceLimitCache(ltBlockCacheNum, int(subCfg.LtBlockCacheSize*1024*1024))
 	protocol.p2pCfg = &subCfg
 }
 

--- a/system/p2p/dht/protocol/broadcast/broadcast_test.go
+++ b/system/p2p/dht/protocol/broadcast/broadcast_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/33cn/chain33/p2p"
 
 	"github.com/33cn/chain33/client"
+	commlog "github.com/33cn/chain33/common/log"
 	"github.com/33cn/chain33/queue"
 	prototypes "github.com/33cn/chain33/system/p2p/dht/protocol/types"
 	p2pty "github.com/33cn/chain33/system/p2p/dht/types"
@@ -18,16 +19,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	commlog.SetLogLevel("error")
+}
+
 var (
 	payload = []byte("testpayload")
 	minerTx = &types.Transaction{Execer: []byte("coins"), Payload: payload, Fee: 14600, Expire: 200}
 	tx      = &types.Transaction{Execer: []byte("coins"), Payload: payload, Fee: 4600, Expire: 2}
 	tx1     = &types.Transaction{Execer: []byte("coins"), Payload: payload, Fee: 460000000, Expire: 0}
 	tx2     = &types.Transaction{Execer: []byte("coins"), Payload: payload, Fee: 100, Expire: 1}
-	//txGroup, _ = types.CreateTxGroup([]*types.Transaction{tx1, tx2}, cfg.GetMinTxFeeRate())
-	//gtx := txGroup.Tx()
-	txList = append([]*types.Transaction{}, minerTx, tx, tx1, tx2)
-	//memTxList := append([]*types.Transaction{}, tx, gtx)
+	txList  = append([]*types.Transaction{}, minerTx, tx, tx1, tx2)
 
 	testBlock = &types.Block{
 		TxHash: []byte("test"),
@@ -39,7 +41,6 @@ var (
 )
 
 func newTestEnv(q queue.Queue) *prototypes.P2PEnv {
-
 	cfg := types.NewChain33Config(types.ReadFile("../../../../../cmd/chain33/chain33.test.toml"))
 	q.SetConfig(cfg)
 	go q.Start()
@@ -50,8 +51,6 @@ func newTestEnv(q queue.Queue) *prototypes.P2PEnv {
 
 	subCfg := &p2pty.P2PSubConfig{}
 	types.MustDecode(cfg.GetSubConfig().P2P[p2pty.DHTTypeName], subCfg)
-	subCfg.MinLtBlockTxNum = 1
-
 	env := &prototypes.P2PEnv{
 		ChainCfg:        cfg,
 		QueueClient:     q.Client(),
@@ -82,7 +81,7 @@ func newTestProtocol() *broadCastProtocol {
 func TestBroadCastProtocol_InitProtocol(t *testing.T) {
 
 	protocol := newTestProtocol()
-	assert.Equal(t, int32(1), protocol.p2pCfg.MinLtBlockTxNum)
+	assert.Equal(t, defaultMinLtBlockSize, int(protocol.p2pCfg.MinLtBlockSize))
 	assert.Equal(t, defaultLtTxBroadCastTTL, int(protocol.p2pCfg.LightTxTTL))
 }
 

--- a/system/p2p/dht/protocol/broadcast/const.go
+++ b/system/p2p/dht/protocol/broadcast/const.go
@@ -31,7 +31,9 @@ const (
 
 // 内部自定义错误
 var (
-	errSendMempool      = errors.New("errSendMempool")
+	errQueryMempool     = errors.New("errQueryMempool")
+	errQueryBlockChain  = errors.New("errQueryBlockChain")
+	errRecvBlockChain   = errors.New("errRecvBlockChain")
 	errRecvMempool      = errors.New("errRecvMempool")
 	errSendStream       = errors.New("errSendStream")
 	errSendBlockChain   = errors.New("errSendBlockChain")

--- a/system/p2p/dht/protocol/broadcast/const.go
+++ b/system/p2p/dht/protocol/broadcast/const.go
@@ -11,8 +11,8 @@ const (
 	defaultLtTxBroadCastTTL = 3
 	// 默认交易最大的广播发送ttl， 大于该值不再向外发送
 	defaultMaxTxBroadCastTTL = 25
-	// 默认区块轻广播的最小交易数
-	defaultMinLtBlockTxNum = 5
+	// 默认最小区块轻广播的大小， 100KB
+	defaultMinLtBlockSize = 100
 )
 
 // P2pCacheTxSize p2pcache size of transaction

--- a/system/p2p/dht/protocol/broadcast/const.go
+++ b/system/p2p/dht/protocol/broadcast/const.go
@@ -26,7 +26,6 @@ const (
 	txSendFilterCacheNum    = 500
 	blockSendFilterCacheNum = 50
 	ltBlockCacheNum         = 1000
-	maxBlockCacheByteSize   = 100 * 1024 * 1024
 )
 
 // 内部自定义错误

--- a/system/p2p/dht/protocol/broadcast/const.go
+++ b/system/p2p/dht/protocol/broadcast/const.go
@@ -13,6 +13,8 @@ const (
 	defaultMaxTxBroadCastTTL = 25
 	// 默认最小区块轻广播的大小， 100KB
 	defaultMinLtBlockSize = 100
+	// 默认轻广播组装临时区块缓存， 50M
+	defaultLtBlockCacheSize = 50
 )
 
 // P2pCacheTxSize p2pcache size of transaction
@@ -23,7 +25,7 @@ const (
 	//发送过滤主要用于发送时冗余检测, 发送完即可以被删除, 维护较小缓存数
 	txSendFilterCacheNum    = 500
 	blockSendFilterCacheNum = 50
-	blockCacheNum           = 10
+	ltBlockCacheNum         = 1000
 	maxBlockCacheByteSize   = 100 * 1024 * 1024
 )
 
@@ -34,4 +36,5 @@ var (
 	errSendStream       = errors.New("errSendStream")
 	errSendBlockChain   = errors.New("errSendBlockChain")
 	errBuildBlockFailed = errors.New("errBuildBlockFailed")
+	errLtBlockNotExist  = errors.New("errLtBlockNotExist")
 )

--- a/system/p2p/dht/protocol/broadcast/query.go
+++ b/system/p2p/dht/protocol/broadcast/query.go
@@ -136,7 +136,7 @@ func (protocol *broadCastProtocol) recvQueryReply(rep *types.P2PBlockTxReply, pi
 		},
 	}
 	block.Txs = nil
-	protocol.ltBlockCache.Add(rep.BlockHash, block, int64(block.Size()))
+	protocol.ltBlockCache.Add(rep.BlockHash, block, block.Size())
 	//query peer
 	_, err = protocol.sendPeer(pid, query, false)
 	if err != nil {

--- a/system/p2p/dht/protocol/broadcast/query.go
+++ b/system/p2p/dht/protocol/broadcast/query.go
@@ -31,7 +31,7 @@ func (protocol *broadCastProtocol) recvQueryData(query *types.P2PQueryData, pid,
 		txHash := hex.EncodeToString(txReq.TxHash)
 		log.Debug("recvQueryTx", "txHash", txHash, "peerAddr", peerAddr)
 		//向mempool请求交易
-		resp, err := protocol.SendToMemPool(types.EventTxListByHash, &types.ReqTxHashList{Hashes: []string{string(txReq.TxHash)}})
+		resp, err := protocol.QueryMempool(types.EventTxListByHash, &types.ReqTxHashList{Hashes: []string{string(txReq.TxHash)}})
 		if err != nil {
 			log.Error("recvQuery", "queryMempoolErr", err)
 			return errSendMempool

--- a/system/p2p/dht/protocol/broadcast/query_test.go
+++ b/system/p2p/dht/protocol/broadcast/query_test.go
@@ -38,7 +38,8 @@ func Test_recvQueryData(t *testing.T) {
 			TxReq: &types.P2PTxReq{TxHash: tx.Hash()}}}
 	sendData, _ := proto.handleSend(query, testPid, testAddr)
 	memTxs := []*types.Transaction{nil}
-	go testHandleMempool(q, &memTxs)
+	done := startHandleMempool(q, &memTxs)
+	<-done
 	err := proto.handleReceive(sendData, testPid, testAddr)
 	assert.Equal(t, errRecvMempool, err)
 	memTxs = []*types.Transaction{tx}

--- a/system/p2p/dht/protocol/broadcast/query_test.go
+++ b/system/p2p/dht/protocol/broadcast/query_test.go
@@ -79,10 +79,10 @@ func Test_recvQueryReply(t *testing.T) {
 	}
 	sendData, _ := proto.handleSend(reply, testPid, testAddr)
 	err := proto.handleReceive(sendData, testPid, testAddr)
-	assert.Equal(t, types.ErrInvalidParam, err)
+	assert.Equal(t, errLtBlockNotExist, err)
 	proto.ltBlockCache.Add(blockHash, nil, 1)
 	err = proto.handleReceive(sendData, testPid, testAddr)
-	assert.Equal(t, types.ErrInvalidParam, err)
+	assert.Equal(t, errLtBlockNotExist, err)
 	proto.ltBlockCache.Add(blockHash, block, 1)
 	//block组装失败,重新请求
 	reply.Txs = []*types.Transaction{tx}

--- a/system/p2p/dht/protocol/broadcast/tx.go
+++ b/system/p2p/dht/protocol/broadcast/tx.go
@@ -15,20 +15,13 @@ func (protocol *broadCastProtocol) sendTx(tx *types.P2PTx, p2pData *types.BroadC
 	txHash := hex.EncodeToString(tx.Tx.Hash())
 	ttl := tx.GetRoute().GetTTL()
 	isLightSend := ttl >= protocol.p2pCfg.LightTxTTL
-	//检测冗余发送
-	ignoreSend := false
 
-	//短哈希广播不记录发送过滤
-	if !isLightSend {
-		ignoreSend = addIgnoreSendPeerAtomic(protocol.txSendFilter, txHash, pid)
-	}
-
-	log.Debug("P2PSendTx", "txHash", txHash, "ttl", ttl, "isLightSend", isLightSend,
-		"peerAddr", peerAddr, "ignoreSend", ignoreSend)
-
-	if ignoreSend { //说明已经发送或者接收过此Tx
+	//检测冗余发送, 短哈希广播不记录发送过滤, 已经发送或者接收过此Tx
+	if !isLightSend && addIgnoreSendPeerAtomic(protocol.txSendFilter, txHash, pid) {
 		return false
 	}
+
+	//log.Debug("P2PSendTx", "txHash", txHash, "ttl", ttl, "peerAddr", peerAddr)
 	//超过最大的ttl, 不再发送
 	if ttl > protocol.p2pCfg.MaxTTL { //超过最大发送次数
 		return false
@@ -56,11 +49,10 @@ func (protocol *broadCastProtocol) recvTx(tx *types.P2PTx, pid, peerAddr string)
 	//将节点id添加到发送过滤, 避免冗余发送
 	addIgnoreSendPeerAtomic(protocol.txSendFilter, txHash, pid)
 	//避免重复接收
-	isDuplicate := protocol.txFilter.AddWithCheckAtomic(txHash, true)
-	log.Debug("recvTx", "tx", txHash, "ttl", tx.GetRoute().GetTTL(), "peerAddr", peerAddr, "duplicateTx", isDuplicate)
-	if isDuplicate {
+	if protocol.txFilter.AddWithCheckAtomic(txHash, true) {
 		return
 	}
+	//log.Debug("recvTx", "tx", txHash, "ttl", tx.GetRoute().GetTTL(), "peerAddr", peerAddr)
 	//有可能收到老版本的交易路由,此时route是空指针
 	if tx.GetRoute() == nil {
 		tx.Route = &types.P2PRoute{TTL: 1}
@@ -75,24 +67,25 @@ func (protocol *broadCastProtocol) recvLtTx(tx *types.LightTx, pid, peerAddr str
 	txHash := hex.EncodeToString(tx.TxHash)
 	//将节点id添加到发送过滤, 避免冗余发送
 	addIgnoreSendPeerAtomic(protocol.txSendFilter, txHash, pid)
-	exist := protocol.txFilter.Contains(txHash)
-	log.Debug("recvLtTx", "txHash", txHash, "ttl", tx.GetRoute().GetTTL(), "peerAddr", peerAddr, "exist", exist)
-	//本地不存在, 需要向对端节点发起完整交易请求. 如果存在则表示本地已经接收过此交易, 不做任何操作
-	if !exist {
-
-		query := &types.P2PQueryData{}
-		query.Value = &types.P2PQueryData_TxReq{
-			TxReq: &types.P2PTxReq{
-				TxHash: tx.TxHash,
-			},
-		}
-		//发布到指定的节点
-		_, err = protocol.sendPeer(pid, query, false)
-		if err != nil {
-			log.Error("recvLtTx", "pid", pid, "sendStreamErr", err)
-			return errSendStream
-		}
+	//存在则表示本地已经接收过此交易, 不做任何操作
+	if protocol.txFilter.Contains(txHash) {
+		return nil
 	}
 
-	return
+	//log.Debug("recvLtTx", "txHash", txHash, "ttl", tx.GetRoute().GetTTL(), "peerAddr", peerAddr)
+	//本地不存在, 需要向对端节点发起完整交易请求
+	query := &types.P2PQueryData{}
+	query.Value = &types.P2PQueryData_TxReq{
+		TxReq: &types.P2PTxReq{
+			TxHash: tx.TxHash,
+		},
+	}
+	//发布到指定的节点
+	_, err = protocol.sendPeer(pid, query, false)
+	if err != nil {
+		log.Error("recvLtTx", "pid", pid, "addr", peerAddr, "err", err)
+		return errSendStream
+	}
+
+	return nil
 }

--- a/system/p2p/dht/protocol/download/download.go
+++ b/system/p2p/dht/protocol/download/download.go
@@ -79,7 +79,7 @@ func (d *downloadProtol) processReq(id string, message *types.P2PGetBlocks) (*ty
 
 	reqblock := &types.ReqBlocks{Start: message.GetStartHeight(), End: message.GetEndHeight()}
 
-	resp, err := d.SendToBlockChain(types.EventGetBlocks, reqblock)
+	resp, err := d.QueryBlockChain(types.EventGetBlocks, reqblock)
 	if err != nil {
 		log.Error("sendToBlockChain", "Error", err.Error())
 		return nil, err

--- a/system/p2p/dht/protocol/download/download_test.go
+++ b/system/p2p/dht/protocol/download/download_test.go
@@ -39,7 +39,6 @@ func newTestEnv(q queue.Queue) *prototypes.P2PEnv {
 
 	subCfg := &p2pty.P2PSubConfig{}
 	types.MustDecode(cfg.GetSubConfig().P2P[p2pty.DHTTypeName], subCfg)
-	subCfg.MinLtBlockTxNum = 1
 	m, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", 12345))
 	if err != nil {
 		return nil

--- a/system/p2p/dht/protocol/download/download_test.go
+++ b/system/p2p/dht/protocol/download/download_test.go
@@ -164,7 +164,7 @@ func Test_util(t *testing.T) {
 
 	protocol.processReq("uid122222", p2pgetblocks)
 
-	resp, _ := protocol.SendToBlockChain(types.EventGetBlocks, blockReq)
+	resp, _ := protocol.QueryBlockChain(types.EventGetBlocks, blockReq)
 	assert.NotNil(t, resp)
 }
 

--- a/system/p2p/dht/protocol/headers/header.go
+++ b/system/p2p/dht/protocol/headers/header.go
@@ -45,7 +45,7 @@ func (h *headerInfoProtol) processReq(id string, getheaders *types.P2PGetHeaders
 		return nil, errors.New("param err")
 	}
 
-	blockResp, err := h.SendToBlockChain(types.EventGetHeaders, &types.ReqBlocks{Start: getheaders.GetStartHeight(), End: getheaders.GetEndHeight()})
+	blockResp, err := h.QueryBlockChain(types.EventGetHeaders, &types.ReqBlocks{Start: getheaders.GetStartHeight(), End: getheaders.GetEndHeight()})
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (h *headerInfoProtol) handleEvent(msg *queue.Message) {
 			continue
 		}
 
-		h.SendToBlockChain(types.EventAddBlockHeaders, &types.HeadersPid{Pid: pid, Headers: &types.Headers{Items: resp.GetMessage().GetHeaders()}})
+		h.QueryBlockChain(types.EventAddBlockHeaders, &types.HeadersPid{Pid: pid, Headers: &types.Headers{Items: resp.GetMessage().GetHeaders()}})
 
 		break
 

--- a/system/p2p/dht/protocol/headers/header_test.go
+++ b/system/p2p/dht/protocol/headers/header_test.go
@@ -37,7 +37,6 @@ func newTestEnv(q queue.Queue) *prototypes.P2PEnv {
 
 	subCfg := &p2pty.P2PSubConfig{}
 	types.MustDecode(cfg.GetSubConfig().P2P[p2pty.DHTTypeName], subCfg)
-	subCfg.MinLtBlockTxNum = 1
 	m, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", 12345))
 	if err != nil {
 		return nil

--- a/system/p2p/dht/protocol/peer/peerinfo.go
+++ b/system/p2p/dht/protocol/peer/peerinfo.go
@@ -59,7 +59,7 @@ func (p *peerInfoProtol) fetchPeersInfo() {
 func (p *peerInfoProtol) getLoacalPeerInfo() *types.P2PPeerInfo {
 	var peerinfo types.P2PPeerInfo
 
-	resp, err := p.SendToMemPool(types.EventGetMempoolSize, nil)
+	resp, err := p.QueryMempool(types.EventGetMempoolSize, nil)
 	if err != nil {
 		log.Error("getlocalPeerInfo", "sendToMempool", err)
 		return nil
@@ -68,7 +68,7 @@ func (p *peerInfoProtol) getLoacalPeerInfo() *types.P2PPeerInfo {
 	meminfo := resp.(*types.MempoolSize)
 	peerinfo.MempoolSize = int32(meminfo.GetSize())
 
-	resp, err = p.SendToBlockChain(types.EventGetLastHeader, nil)
+	resp, err = p.QueryBlockChain(types.EventGetLastHeader, nil)
 	if err != nil {
 		log.Error("getlocalPeerInfo", "sendToBlockChain", err)
 		return nil

--- a/system/p2p/dht/protocol/peer/peerinfo_test.go
+++ b/system/p2p/dht/protocol/peer/peerinfo_test.go
@@ -42,7 +42,6 @@ func newTestEnv(q queue.Queue) *prototypes.P2PEnv {
 
 	subCfg := &p2pty.P2PSubConfig{}
 	types.MustDecode(cfg.GetSubConfig().P2P[p2pty.DHTTypeName], subCfg)
-	subCfg.MinLtBlockTxNum = 1
 	m, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", 12345))
 	if err != nil {
 		return nil

--- a/system/p2p/dht/protocol/types/protocol.go
+++ b/system/p2p/dht/protocol/types/protocol.go
@@ -175,6 +175,7 @@ func (base *BaseProtocol) QueryMempool(ty int64, req interface{}) (interface{}, 
 func (base *BaseProtocol) QueryBlockChain(ty int64, req interface{}) (interface{}, error) {
 	return base.QueryModule("blockchain", ty, req)
 }
+
 // QueryModule query msg queue module
 func (base *BaseProtocol) QueryModule(module string, msgTy int64, req interface{}) (interface{}, error) {
 

--- a/system/p2p/dht/protocol/types/protocol.go
+++ b/system/p2p/dht/protocol/types/protocol.go
@@ -166,25 +166,20 @@ func (base *BaseProtocol) GetPeerInfoManager() *manage.PeerInfoManager {
 	return base.PeerInfoManager
 }
 
-// SendToMemPool send to mempool for request
-func (base *BaseProtocol) SendToMemPool(ty int64, data interface{}) (interface{}, error) {
-	client := base.GetQueueClient()
-	msg := client.NewMessage("mempool", ty, data)
-	err := client.Send(msg, true)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.WaitTimeout(msg, time.Second*10)
-	if err != nil {
-		return nil, err
-	}
-	return resp.GetData(), nil
+// QueryMempool query mempool
+func (base *BaseProtocol) QueryMempool(ty int64, req interface{}) (interface{}, error) {
+	return base.QueryModule("mempool", ty, req)
 }
 
-// SendToBlockChain send to blockchain for request
-func (base *BaseProtocol) SendToBlockChain(ty int64, data interface{}) (interface{}, error) {
+// QueryBlockChain query blockchain
+func (base *BaseProtocol) QueryBlockChain(ty int64, req interface{}) (interface{}, error) {
+	return base.QueryModule("blockchain", ty, req)
+}
+// QueryModule query msg queue module
+func (base *BaseProtocol) QueryModule(module string, msgTy int64, req interface{}) (interface{}, error) {
+
 	client := base.GetQueueClient()
-	msg := client.NewMessage("blockchain", ty, data)
+	msg := client.NewMessage(module, msgTy, req)
 	err := client.Send(msg, true)
 	if err != nil {
 		return nil, err

--- a/system/p2p/dht/protocol/types/stream.go
+++ b/system/p2p/dht/protocol/types/stream.go
@@ -90,7 +90,7 @@ func (s *BaseStreamHandler) GetProtocol() IProtocol {
 
 // HandleStream stream事件预处理函数
 func (s *BaseStreamHandler) HandleStream(stream core.Stream) {
-	log.Debug("BaseStreamHandler", "HandlerStream", stream.Conn().RemoteMultiaddr().String(), "proto", stream.Protocol())
+	//log.Debug("BaseStreamHandler", "HandlerStream", stream.Conn().RemoteMultiaddr().String(), "proto", stream.Protocol())
 	//TODO verify校验放在这里
 	s.child.Handle(stream)
 	CloseStream(stream)

--- a/system/p2p/dht/types/types.go
+++ b/system/p2p/dht/types/types.go
@@ -9,29 +9,20 @@ package types
 type P2PSubConfig struct {
 	// P2P服务监听端口号
 	Port int32 `protobuf:"varint,1,opt,name=port" json:"port,omitempty"`
-	// 种子节点，格式为ip:port，多个节点以逗号分隔，如seeds=
+	// 手动配置节点
 	Seeds []string `protobuf:"bytes,2,rep,name=seeds" json:"seeds,omitempty"`
-	// 是否为种子节点
-	IsSeed bool `protobuf:"varint,3,opt,name=isSeed" json:"isSeed,omitempty"`
-	//固定连接节点，只连接配置项seeds中的节点
-	FixedSeed bool `protobuf:"varint,4,opt,name=fixedSeed" json:"fixedSeed,omitempty"`
-	// 是否使用内置的种子节点
-	InnerSeedEnable bool `protobuf:"varint,5,opt,name=innerSeedEnable" json:"innerSeedEnable,omitempty"`
-	// 是否使用Github获取种子节点
-	UseGithub bool `protobuf:"varint,6,opt,name=useGithub" json:"useGithub,omitempty"`
-	// 是否作为服务端，对外提供服务
-	ServerStart bool `protobuf:"varint,7,opt,name=serverStart" json:"serverStart,omitempty"`
-	// 最多的接入节点个数
-	InnerBounds int32 `protobuf:"varint,8,opt,name=innerBounds" json:"innerBounds,omitempty"`
 	//交易开始采用哈希广播的ttl
-	LightTxTTL int32 `protobuf:"varint,9,opt,name=lightTxTTL" json:"lightTxTTL,omitempty"`
+	LightTxTTL int32 `protobuf:"varint,3,opt,name=lightTxTTL" json:"lightTxTTL,omitempty"`
 	// 最大传播ttl, ttl达到该值将停止继续向外发送
-	MaxTTL int32 `protobuf:"varint,10,opt,name=maxTTL" json:"maxTTL,omitempty"`
+	MaxTTL int32 `protobuf:"varint,4,opt,name=maxTTL" json:"maxTTL,omitempty"`
 	// p2p网络频道,用于区分主网/测试网/其他网络
-	Channel int32 `protobuf:"varint,11,opt,name=channel" json:"channel,omitempty"`
-	//区块轻广播的最低打包交易数, 大于该值时区块内交易采用短哈希广播
-	MinLtBlockTxNum int32 `protobuf:"varint,12,opt,name=minLtBlockTxNum" json:"minLtBlockTxNum,omitempty"`
-	//指定p2p类型, 支持gossip, dht
-	MaxConnnectNum int32    `protobuf:"varint,13,opt,name=maxConnnectNum" json:"maxConnnectNum,omitempty"`
-	BootStraps     []string `protobuf:"bytes,14,rep,name=bootStraps" json:"bootStraps,omitempty"`
+	Channel int32 `protobuf:"varint,5,opt,name=channel" json:"channel,omitempty"`
+	//区块轻广播的最低区块大小,单位KB, 大于该值时区块内交易采用短哈希广播
+	MinLtBlockSize int32 `protobuf:"varint,6,opt,name=minLtBlockSize" json:"minLtBlockSize,omitempty"`
+	//最大dht连接数
+	MaxConnectNum int32 `protobuf:"varint,7,opt,name=maxConnectNum" json:"maxConnectNum,omitempty"`
+	//引导节点配置
+	BootStraps []string `protobuf:"bytes,8,rep,name=bootStraps" json:"bootStraps,omitempty"`
+	//轻广播本地区块缓存大小, 单位M
+	LtBlockCacheSize int32 `protobuf:"varint,9,opt,name=ltBlockCacheSize" json:"ltBlockCacheSize,omitempty"`
 }


### PR DESCRIPTION
### dht 轻广播区块缓存调整，相关优化

* 区块是否轻广播阈值，修改为按照区块大小，默认大于100k进行区块轻广播，支持配置minLtBlockSize

* 轻广播接收端缓存（本地缺失交易时组装部分进行缓存）空间大小，修改为可配置

* 删除轻广播发送端区块缓存，修改为直接从blockchain模块获取，blockchain模块默认缓存了最近的128个区块，p2p不再进行区块缓存

* 调整广播相关日志，减少debug日志量

fix #825 