### PR TITLE
add by hyb for Consensus policy Conflict

### DIFF
--- a/wallet/common/mine_status_report.go
+++ b/wallet/common/mine_status_report.go
@@ -9,4 +9,5 @@ type MineStatusReport interface {
 	IsAutoMining() bool
 	// 返回挖矿买票锁的状态
 	IsTicketLocked() bool
+	PolicyName() string
 }

--- a/wallet/sendtx.go
+++ b/wallet/sendtx.go
@@ -319,8 +319,10 @@ func (wallet *Wallet) queryBalance(in *types.ReqBalance) ([]*types.Account, erro
 
 func (wallet *Wallet) getMinerColdAddr(addr string) ([]string, error) {
 	reqaddr := &types.ReqString{Data: addr}
+	//ticket和pos33执行器有对应的miner
+	consensus := wallet.client.GetConfig().GetModuleConfig().Consensus.Name
 	req := types.ChainExecutor{
-		Driver:   "ticket",
+		Driver:   consensus,
 		FuncName: "MinerSourceList",
 		Param:    types.Encode(reqaddr),
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -381,7 +381,9 @@ func (wallet *Wallet) isTransfer(addr string) (bool, error) {
 	//钱包已经锁定，挖矿锁已经解锁,需要判断addr是否是挖矿合约地址
 	//这里依赖了ticket 挖矿合约
 	if !wallet.isTicketLocked() {
-		if addr == address.ExecAddress("ticket") {
+		consensus := wallet.client.GetConfig().GetModuleConfig().Consensus.Name
+
+		if addr == address.ExecAddress(consensus) {
 			return true, nil
 		}
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -136,8 +136,19 @@ func (wallet *Wallet) RegisterMineStatusReporter(reporter wcom.MineStatusReport)
 	if wallet.mineStatusReporter != nil {
 		return errors.New("ReporterIsExisted")
 	}
-	wallet.mineStatusReporter = reporter
+	consensus := wallet.client.GetConfig().GetModuleConfig().Consensus.Name
+
+	if !isConflict(consensus, reporter.PolicyName()) {
+		wallet.mineStatusReporter = reporter
+	}
 	return nil
+}
+
+//检测当policy和Consensus有冲突时，不挂接对应的reporter
+func isConflict(curConsensus string, policy string) bool {
+	walletlog.Info("isConflict", "curConsensus", curConsensus, "policy", policy)
+
+	return curConsensus == "ticket" && policy == "pos33" || curConsensus == "pos33" && policy == "ticket"
 }
 
 // GetConfig 获取钱包配置

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -148,7 +148,7 @@ func (wallet *Wallet) RegisterMineStatusReporter(reporter wcom.MineStatusReport)
 func isConflict(curConsensus string, policy string) bool {
 	walletlog.Info("isConflict", "curConsensus", curConsensus, "policy", policy)
 
-	return curConsensus == "ticket" && policy == "pos33" || curConsensus == "pos33" && policy == "ticket"
+	return curConsensus != policy
 }
 
 // GetConfig 获取钱包配置

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -848,7 +848,10 @@ func testWallet(t *testing.T, wallet *Wallet) {
 	wallet.IsClose()
 	wallet.AddWaitGroup(1)
 	wallet.WaitGroupDone()
-	wallet.RegisterMineStatusReporter(nil)
+	report := &WalletReport{}
+	err = wallet.RegisterMineStatusReporter(report)
+	assert.NoError(t, err)
+
 }
 
 func testSendTx(t *testing.T, wallet *Wallet) {
@@ -1109,4 +1112,19 @@ func testProcImportPrivkeysFile2(t *testing.T, wallet *Wallet) {
 	os.Remove(fileName)
 	println("testProcImportPrivkeysFile end")
 	println("--------------------------")
+}
+
+type WalletReport struct {
+}
+
+func (report WalletReport) IsAutoMining() bool {
+	return true
+
+}
+func (report WalletReport) IsTicketLocked() bool {
+	return true
+
+}
+func (report WalletReport) PolicyName() string {
+	return "ticket"
 }


### PR DESCRIPTION
RegisterMineStatusReporter 函数处理时需要检测当前的共识和wallet插件是否有冲突，不允许注册有冲突的钱包插件 。
相应的plugin工程的ticket和pos33  wallet 插件需要实现PolicyName() 方法，返回各自的wallet插件名字