### PR TITLE
bug fix for data race

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -110,6 +110,7 @@ type BlockChain struct {
 	downLoadlock     sync.Mutex
 	downLoadModeLock sync.Mutex
 	isNtpClockSync   bool //ntp时间是否同步
+	pushRWLock       sync.RWMutex
 
 	//cfg
 	MaxFetchBlockNum int64 //一次最多申请获取block个数
@@ -231,10 +232,12 @@ func (chain *BlockChain) Close() {
 	chainlog.Info("blockchain wait for reducewg quit")
 	chain.reducewg.Wait()
 
+	chain.pushRWLock.RLock()
 	if chain.push != nil {
 		chainlog.Info("blockchain wait for push quit")
 		chain.push.Close()
 	}
+	chain.pushRWLock.RUnlock()
 
 	//关闭数据库
 	chain.blockStore.db.Close()
@@ -252,7 +255,9 @@ func (chain *BlockChain) SetQueueClient(client queue.Client) {
 	stateHash := chain.getStateHash()
 	chain.query = NewQuery(blockStoreDB, chain.client, stateHash)
 	if chain.enablePushSubscribe && chain.isRecordBlockSequence {
+		chain.pushRWLock.Lock()
 		chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+		chain.pushRWLock.Unlock()
 		chainlog.Info("chain push is setup")
 	}
 

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -401,7 +401,9 @@ func (b *BlockChain) connectBlock(node *blockNode, blockdetail *types.BlockDetai
 
 	//目前非平行链并开启isRecordBlockSequence功能和enablePushSubscribe
 	if b.isRecordBlockSequence && b.enablePushSubscribe {
+		b.pushRWLock.RLock()
 		b.push.UpdateSeq(lastSequence)
+		b.pushRWLock.RUnlock()
 		chainlog.Debug("isRecordBlockSequence", "lastSequence", lastSequence, "height", block.Height)
 	}
 	return blockdetail, nil
@@ -470,7 +472,9 @@ func (b *BlockChain) disconnectBlock(node *blockNode, blockdetail *types.BlockDe
 
 	//目前非平行链并开启isRecordBlockSequence功能和enablePushSubscribe
 	if b.isRecordBlockSequence && b.enablePushSubscribe {
+		b.pushRWLock.RLock()
 		b.push.UpdateSeq(lastSequence)
+		b.pushRWLock.RUnlock()
 		chainlog.Debug("isRecordBlockSequence", "lastSequence", lastSequence, "height", blockdetail.Block.Height)
 	}
 

--- a/blockchain/push.go
+++ b/blockchain/push.go
@@ -155,7 +155,8 @@ func (chain *BlockChain) procSubscribePush(subscribe *types.PushSubscribeReq) er
 		chainlog.Error("Tx receipts are reduced on this node")
 		return types.ErrTxReceiptReduced
 	}
-
+	chain.pushRWLock.RLock()
+	defer chain.pushRWLock.RUnlock()
 	return chain.push.addSubscriber(subscribe)
 }
 
@@ -168,7 +169,9 @@ func (chain *BlockChain) ProcListPush() (*types.PushSubscribes, error) {
 		return nil, types.ErrPushNotSupport
 	}
 
+	chain.pushRWLock.RLock()
 	values, err := chain.push.store.List(pushPrefix)
+	chain.pushRWLock.RUnlock()
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +196,9 @@ func (chain *BlockChain) ProcGetLastPushSeq(name string) (int64, error) {
 		return -1, types.ErrPushNotSupport
 	}
 
+	chain.pushRWLock.RLock()
 	lastSeqbytes, err := chain.push.store.GetKey(calcLastPushSeqNumKey(name))
+	chain.pushRWLock.RUnlock()
 	if lastSeqbytes == nil || err != nil {
 		if err != dbm.ErrNotFoundInDb {
 			storeLog.Error("getSeqCBLastNum", "error", err)

--- a/blockchain/push_test.go
+++ b/blockchain/push_test.go
@@ -163,7 +163,9 @@ func Test_procSubscribePush_nilParacheck(t *testing.T) {
 func Test_addSubscriber_Paracheck(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.LastSequence = 1
 	err := chain.procSubscribePush(subscribe)
@@ -173,7 +175,9 @@ func Test_addSubscriber_Paracheck(t *testing.T) {
 func Test_addSubscriber_conflictPara(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.LastSequence = 1
 	err := chain.procSubscribePush(subscribe)
@@ -183,7 +187,9 @@ func Test_addSubscriber_conflictPara(t *testing.T) {
 func Test_addSubscriber_InvalidURL(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.URL = ""
@@ -194,7 +200,9 @@ func Test_addSubscriber_InvalidURL(t *testing.T) {
 func Test_addSubscriber_InvalidType(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.Type = int32(3)
@@ -205,7 +213,9 @@ func Test_addSubscriber_InvalidType(t *testing.T) {
 func Test_addSubscriber_inconsistentSeqHash(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.URL = "http://localhost"
@@ -222,7 +232,9 @@ func Test_addSubscriber_inconsistentSeqHash(t *testing.T) {
 func Test_addSubscriber_Success(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.URL = "http://localhost"
@@ -245,7 +257,9 @@ func Test_addSubscriber_Success(t *testing.T) {
 	pushes, _ := chain.ProcListPush()
 	assert.Equal(t, subscribe.Name, pushes.Pushes[0].Name)
 
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	recoverpushes, _ := chain.ProcListPush()
 	assert.Equal(t, subscribe.Name, recoverpushes.Pushes[0].Name)
 }
@@ -284,7 +298,9 @@ func Test_addSubscriber_WithSeqHashHeight(t *testing.T) {
 	assert.Equal(t, subscribe.Name, pushes.Pushes[0].Name)
 
 	//重新创建push，能够从数据库中恢复原先注册成功的push
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	recoverpushes, _ := chain.ProcListPush()
 	assert.Equal(t, subscribe.Name, recoverpushes.Pushes[0].Name)
 }
@@ -521,7 +537,9 @@ func Test_AddPush_PushNameShouldDiff(t *testing.T) {
 
 	//push 能够正常从数据库恢复
 	chain.push = nil
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	assert.Equal(t, 10, len(chain.push.tasks))
 	for _, name := range pushNames {
 		assert.NotEqual(t, chain.push.tasks[string(calcPushKey(name))], nil)
@@ -656,7 +674,9 @@ func Test_RecoverPush(t *testing.T) {
 	lastSeq, _ = chain.ProcGetLastPushSeq(subscribe.Name)
 
 	//chain33的push服务重启后，不会将其添加到task中，推送成功的序列号不成功
+	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
+	chain.pushRWLock.Unlock()
 	chain.push.postService = ps
 	createBlocks(t, mock33, chain, 10)
 	time.Sleep(1 * time.Second)

--- a/blockchain/rollback.go
+++ b/blockchain/rollback.go
@@ -117,7 +117,9 @@ func (chain *BlockChain) disBlock(blockdetail *types.BlockDetail, sequence int64
 
 	//目前非平行链并开启isRecordBlockSequence功能和enablePushSubscribe
 	if chain.isRecordBlockSequence && chain.enablePushSubscribe {
+		chain.pushRWLock.RLock()
 		chain.push.UpdateSeq(lastSequence)
+		chain.pushRWLock.RUnlock()
 		chainlog.Debug("isRecordBlockSequence", "lastSequence", lastSequence, "height", blockdetail.Block.Height)
 	}
 


### PR DESCRIPTION
1.解决ut过程中push的data race问题，
解决方法，增加一个读写锁，该办法纯粹是为ut解决问题，实际blockchain运行过程中，不会发生该数据竞争问题，一定程度上会影响系统的开销，但是该读写锁的频率是出块的频率，没有大的影响。