### PR TITLE
to fix push ut's data race

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -401,9 +401,7 @@ func (b *BlockChain) connectBlock(node *blockNode, blockdetail *types.BlockDetai
 
 	//目前非平行链并开启isRecordBlockSequence功能和enablePushSubscribe
 	if b.isRecordBlockSequence && b.enablePushSubscribe {
-		b.pushRWLock.RLock()
 		b.push.UpdateSeq(lastSequence)
-		b.pushRWLock.RUnlock()
 		chainlog.Debug("isRecordBlockSequence", "lastSequence", lastSequence, "height", block.Height)
 	}
 	return blockdetail, nil
@@ -472,9 +470,7 @@ func (b *BlockChain) disconnectBlock(node *blockNode, blockdetail *types.BlockDe
 
 	//目前非平行链并开启isRecordBlockSequence功能和enablePushSubscribe
 	if b.isRecordBlockSequence && b.enablePushSubscribe {
-		b.pushRWLock.RLock()
 		b.push.UpdateSeq(lastSequence)
-		b.pushRWLock.RUnlock()
 		chainlog.Debug("isRecordBlockSequence", "lastSequence", lastSequence, "height", blockdetail.Block.Height)
 	}
 

--- a/blockchain/push.go
+++ b/blockchain/push.go
@@ -155,8 +155,6 @@ func (chain *BlockChain) procSubscribePush(subscribe *types.PushSubscribeReq) er
 		chainlog.Error("Tx receipts are reduced on this node")
 		return types.ErrTxReceiptReduced
 	}
-	chain.pushRWLock.RLock()
-	defer chain.pushRWLock.RUnlock()
 	return chain.push.addSubscriber(subscribe)
 }
 
@@ -169,9 +167,7 @@ func (chain *BlockChain) ProcListPush() (*types.PushSubscribes, error) {
 		return nil, types.ErrPushNotSupport
 	}
 
-	chain.pushRWLock.RLock()
 	values, err := chain.push.store.List(pushPrefix)
-	chain.pushRWLock.RUnlock()
 	if err != nil {
 		return nil, err
 	}
@@ -196,9 +192,7 @@ func (chain *BlockChain) ProcGetLastPushSeq(name string) (int64, error) {
 		return -1, types.ErrPushNotSupport
 	}
 
-	chain.pushRWLock.RLock()
 	lastSeqbytes, err := chain.push.store.GetKey(calcLastPushSeqNumKey(name))
-	chain.pushRWLock.RUnlock()
 	if lastSeqbytes == nil || err != nil {
 		if err != dbm.ErrNotFoundInDb {
 			storeLog.Error("getSeqCBLastNum", "error", err)

--- a/blockchain/push_test.go
+++ b/blockchain/push_test.go
@@ -163,9 +163,6 @@ func Test_procSubscribePush_nilParacheck(t *testing.T) {
 func Test_addSubscriber_Paracheck(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
-	chain.pushRWLock.Lock()
-	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.LastSequence = 1
 	err := chain.procSubscribePush(subscribe)
@@ -175,9 +172,6 @@ func Test_addSubscriber_Paracheck(t *testing.T) {
 func Test_addSubscriber_conflictPara(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
-	chain.pushRWLock.Lock()
-	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.LastSequence = 1
 	err := chain.procSubscribePush(subscribe)
@@ -187,9 +181,6 @@ func Test_addSubscriber_conflictPara(t *testing.T) {
 func Test_addSubscriber_InvalidURL(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
-	chain.pushRWLock.Lock()
-	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.URL = ""
@@ -200,9 +191,6 @@ func Test_addSubscriber_InvalidURL(t *testing.T) {
 func Test_addSubscriber_InvalidType(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
-	chain.pushRWLock.Lock()
-	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.Type = int32(3)
@@ -213,9 +201,6 @@ func Test_addSubscriber_InvalidType(t *testing.T) {
 func Test_addSubscriber_inconsistentSeqHash(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
-	chain.pushRWLock.Lock()
-	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.URL = "http://localhost"
@@ -232,9 +217,6 @@ func Test_addSubscriber_inconsistentSeqHash(t *testing.T) {
 func Test_addSubscriber_Success(t *testing.T) {
 	chain, mock33 := createBlockChain(t)
 	defer mock33.Close()
-	chain.pushRWLock.Lock()
-	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	subscribe := new(types.PushSubscribeReq)
 	subscribe.Name = "push-test"
 	subscribe.URL = "http://localhost"
@@ -257,9 +239,7 @@ func Test_addSubscriber_Success(t *testing.T) {
 	pushes, _ := chain.ProcListPush()
 	assert.Equal(t, subscribe.Name, pushes.Pushes[0].Name)
 
-	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	recoverpushes, _ := chain.ProcListPush()
 	assert.Equal(t, subscribe.Name, recoverpushes.Pushes[0].Name)
 }
@@ -298,9 +278,7 @@ func Test_addSubscriber_WithSeqHashHeight(t *testing.T) {
 	assert.Equal(t, subscribe.Name, pushes.Pushes[0].Name)
 
 	//重新创建push，能够从数据库中恢复原先注册成功的push
-	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	recoverpushes, _ := chain.ProcListPush()
 	assert.Equal(t, subscribe.Name, recoverpushes.Pushes[0].Name)
 }
@@ -536,10 +514,7 @@ func Test_AddPush_PushNameShouldDiff(t *testing.T) {
 	assert.Equal(t, err, types.ErrNotAllowModifyPush)
 
 	//push 能够正常从数据库恢复
-	chain.push = nil
-	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	assert.Equal(t, 10, len(chain.push.tasks))
 	for _, name := range pushNames {
 		assert.NotEqual(t, chain.push.tasks[string(calcPushKey(name))], nil)
@@ -674,9 +649,7 @@ func Test_RecoverPush(t *testing.T) {
 	lastSeq, _ = chain.ProcGetLastPushSeq(subscribe.Name)
 
 	//chain33的push服务重启后，不会将其添加到task中，推送成功的序列号不成功
-	chain.pushRWLock.Lock()
 	chain.push = newpush(chain.blockStore, chain.blockStore, chain.client.GetConfig())
-	chain.pushRWLock.Unlock()
 	chain.push.postService = ps
 	createBlocks(t, mock33, chain, 10)
 	time.Sleep(1 * time.Second)

--- a/blockchain/rollback.go
+++ b/blockchain/rollback.go
@@ -117,9 +117,7 @@ func (chain *BlockChain) disBlock(blockdetail *types.BlockDetail, sequence int64
 
 	//目前非平行链并开启isRecordBlockSequence功能和enablePushSubscribe
 	if chain.isRecordBlockSequence && chain.enablePushSubscribe {
-		chain.pushRWLock.RLock()
 		chain.push.UpdateSeq(lastSequence)
-		chain.pushRWLock.RUnlock()
 		chainlog.Debug("isRecordBlockSequence", "lastSequence", lastSequence, "height", blockdetail.Block.Height)
 	}
 


### PR DESCRIPTION
在push的ut中删除多余的赋值操作，这样在push的功能代码中就不需要使用rwlock机制，减少为了UT而增加冗余代码