### PR TITLE
add by hyb for print hex string

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -325,7 +325,7 @@ func checkDupTxHeight(cacheTxsTxHeigt []*types.Transaction, blockchain *blockcha
 	i := blockchain.GetBlockHeight()
 	for j, tx := range cacheTxsTxHeigt {
 		txhash := tx.Hash()
-		chainlog.Info("checkDupTxHeight", "height", i, "count", j, "txhash", txhash)
+		chainlog.Info("checkDupTxHeight", "height", i, "count", j, "txhash", common.ToHex(txhash))
 		txhashlist.Hashes = append(txhashlist.Hashes, txhash[:])
 		txhashlist.Expire = append(txhashlist.Expire, tx.Expire)
 	}

--- a/blockchain/query_tx.go
+++ b/blockchain/query_tx.go
@@ -271,7 +271,6 @@ func getTxFullHashProofs(Txs []*types.Transaction, index int32) [][]byte {
 	}
 
 	proofs := merkle.GetMerkleBranch(leaves, uint32(index))
-	chainlog.Debug("getTxProofs", "index", index, "proofs", proofs)
 
 	return proofs
 }


### PR DESCRIPTION
删除获取proof时没有必要的打印，此时打印的是branch hash值所以没有必要再转换成hex打印出来。

test中hash输出时使用hex格式
close #878 