### PR TITLE
reset tx hash cache after tx check

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1358,7 +1358,7 @@ func TestEnableCmpBestBlock(t *testing.T) {
 	temblock := types.Clone(block.Block)
 	newblock := temblock.(*types.Block)
 	newblock.GetTxs()[0].Nonce = newblock.GetTxs()[0].Nonce + 1
-	newblock.GetTxs()[0].ResetCacheHash()
+	newblock.GetTxs()[0].ReCalcCacheHash()
 	newblock.TxHash = merkle.CalcMerkleRoot(cfg, newblock.GetHeight(), newblock.GetTxs())
 	blockDetail := types.BlockDetail{Block: newblock}
 	_, err = blockchain.ProcAddBlockMsg(true, &blockDetail, "peer")
@@ -1433,7 +1433,7 @@ func TestDisableCmpBestBlock(t *testing.T) {
 	temblock := types.Clone(block.Block)
 	newblock := temblock.(*types.Block)
 	newblock.GetTxs()[0].Nonce = newblock.GetTxs()[0].Nonce + 1
-	newblock.GetTxs()[0].ResetCacheHash()
+	newblock.GetTxs()[0].ReCalcCacheHash()
 	newblock.TxHash = merkle.CalcMerkleRoot(cfg, newblock.GetHeight(), newblock.GetTxs())
 	blockDetail := types.BlockDetail{Block: newblock}
 	_, err = blockchain.ProcAddBlockMsg(true, &blockDetail, "peer")

--- a/system/mempool/check.go
+++ b/system/mempool/check.go
@@ -107,7 +107,7 @@ func (mem *Mempool) checkTxs(msg *queue.Message) *queue.Message {
 		}
 	}
 	//放在交易费检查后面进行 哈希缓存设置，避免哈希缓存改变原始交易size
-	txmsg.ResetCacheHash()
+	txmsg.ReCalcCacheHash()
 	//检查txgroup 中的每个交易
 	txs, err := tx.GetTxGroup()
 	if err != nil {

--- a/system/mempool/check.go
+++ b/system/mempool/check.go
@@ -91,7 +91,6 @@ func (mem *Mempool) checkTxs(msg *queue.Message) *queue.Message {
 	}
 	header := mem.GetHeader()
 	txmsg := msg.GetData().(*types.Transaction)
-	txmsg.ResetCacheHash()
 	//普通的交易
 	tx := types.NewTransactionCache(txmsg)
 	types.AssertConfig(mem.client)
@@ -107,6 +106,8 @@ func (mem *Mempool) checkTxs(msg *queue.Message) *queue.Message {
 			return msg
 		}
 	}
+	//放在交易费检查后面进行 哈希缓存设置，避免哈希缓存改变原始交易size
+	txmsg.ResetCacheHash()
 	//检查txgroup 中的每个交易
 	txs, err := tx.GetTxGroup()
 	if err != nil {

--- a/types/tx.go
+++ b/types/tx.go
@@ -831,8 +831,8 @@ func (tx *Transaction) UnsetCacheHash() {
 	tx.FullHashCache = nil
 }
 
-// ResetCacheHash 重新计算 hash缓存， 通常交易首次进入系统时调用
-func (tx *Transaction) ResetCacheHash() {
+// ReCalcCacheHash 重新计算 hash缓存， 通常交易首次进入系统时调用
+func (tx *Transaction) ReCalcCacheHash() {
 	tx.UnsetCacheHash()
 	tx.HashCache = tx.Hash()
 	tx.FullHashCache = tx.FullHash()

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -507,14 +507,14 @@ func TestCacheHash(t *testing.T) {
 	hash := tx.Hash()
 	fullHash := tx.FullHash()
 
-	tx.ResetCacheHash()
+	tx.ReCalcCacheHash()
 	assert.Equal(t, hash, tx.HashCache)
 	assert.Equal(t, fullHash, tx.FullHashCache)
 	tx.Nonce++
 	tx.UnsetCacheHash()
 	hashNew := tx.Hash()
 	fullHashNew := tx.FullHash()
-	tx.ResetCacheHash()
+	tx.ReCalcCacheHash()
 	assert.NotEqual(t, hash, tx.HashCache)
 	assert.NotEqual(t, fullHash, tx.FullHashCache)
 	assert.Equal(t, hashNew, tx.HashCache)


### PR DESCRIPTION

调整ResetHashCache位置，放在交易费检查之后，避免hashCache改变原始交易的size，导致临界情况交易费计算变化