### PR TITLE
fix calc tx fee

### DIFF
--- a/types/tx.go
+++ b/types/tx.go
@@ -548,8 +548,8 @@ func (tx *Transaction) GetRealFee(minFee int64) (int64, error) {
 	if tx.Signature == nil {
 		txSize += 300
 	}
-	// hash cache 不作为fee大小计算
-	txSize -= len(tx.HashCache) + len(tx.FullHashCache)
+	// hash cache 不作为fee大小计算, byte数组经过proto编码会有2个字节的标志长度
+	txSize -= len(tx.HashCache) + len(tx.FullHashCache) + 4
 	if txSize > int(MaxTxSize) {
 		return 0, ErrTxMsgSizeTooBig
 	}

--- a/types/tx.go
+++ b/types/tx.go
@@ -504,15 +504,15 @@ func (tx *Transaction) Check(cfg *Chain33Config, height, minfee, maxFee int64) e
 }
 
 func (tx *Transaction) check(cfg *Chain33Config, height, minfee, maxFee int64) error {
-	txSize := Size(tx)
-	if txSize > int(MaxTxSize) {
-		return ErrTxMsgSizeTooBig
-	}
 	if minfee == 0 {
 		return nil
 	}
+	// 获取当前交易最小交易费
+	realFee, err := tx.GetRealFee(minfee)
+	if err != nil {
+		return err
+	}
 	// 检查交易费是否小于最低值
-	realFee := int64(txSize/1000+1) * minfee
 	if tx.Fee < realFee {
 		return ErrTxFeeTooLow
 	}
@@ -548,6 +548,8 @@ func (tx *Transaction) GetRealFee(minFee int64) (int64, error) {
 	if tx.Signature == nil {
 		txSize += 300
 	}
+	// hash cache 不作为fee大小计算
+	txSize -= len(tx.HashCache) + len(tx.FullHashCache)
 	if txSize > int(MaxTxSize) {
 		return 0, ErrTxMsgSizeTooBig
 	}

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -52,6 +52,31 @@ func TestCreateGroupTx(t *testing.T) {
 	t.Log(grouptx)
 }
 
+/*
+type=string  length   data
+  +--------+--------+~~+--------+
+  |xxxxxxxx|xxxxxxxx|  |xxxxxxxx|
+  +--------+--------+~~+--------+
+  在bytes hash 的情况下，应该是一个字节类型，一个是一个字节的长度
+*/
+func TestGetRealFee(t *testing.T) {
+	cfg := NewChain33Config(GetDefaultCfgstring())
+	tx := &Transaction{
+		Payload: []byte(strings.Repeat("a", 633)),
+	}
+	tx, err := FormatTx(cfg, "user.p.none", tx)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, tx.Size(), 699)
+	fee1, err := tx.GetRealFee(cfg.GetMinTxFeeRate())
+	assert.Equal(t, err, nil)
+	assert.Equal(t, fee1, cfg.GetMinTxFeeRate())
+	tx.ReCalcCacheHash()
+	assert.Equal(t, tx.Size()-699, 68)
+	fee2, err := tx.GetRealFee(cfg.GetMinTxFeeRate())
+	assert.Equal(t, err, nil)
+	assert.Equal(t, fee2, cfg.GetMinTxFeeRate())
+}
+
 func TestCreateParaGroupTx(t *testing.T) {
 	str := GetDefaultCfgstring()
 	new := strings.Replace(str, "Title=\"local\"", "Title=\"chain33\"", 1)


### PR DESCRIPTION
fix #891

* 交易check fee会分别在mempool， exec模块调用，通过统一修改GetRealFee，对hash cache字段大小进行屏蔽，不计入fee计算

