### PR TITLE
忽略coins 转账时, 交易中输入的symbol. 

### DIFF
--- a/system/dapp/coins/types/types.go
+++ b/system/dapp/coins/types/types.go
@@ -150,10 +150,10 @@ func (c *CoinsType) GetAssets(tx *types.Transaction) ([]*types.Asset, error) {
 	if err != nil || len(assets) == 0 {
 		return nil, err
 	}
-	if assets[0].Symbol == "" {
-		types := c.GetConfig()
-		assets[0].Symbol = types.GetCoinSymbol()
-	}
+
+	types := c.GetConfig()
+	assets[0].Symbol = types.GetCoinSymbol()
+
 	if assets[0].Symbol == "bty" {
 		assets[0].Symbol = "BTY"
 	}

--- a/system/dapp/coins/types/types_test.go
+++ b/system/dapp/coins/types/types_test.go
@@ -39,12 +39,14 @@ func TestCoinsType(t *testing.T) {
 	assert.Equal(t, logmap, ty.GetLogMap())
 	assert.Equal(t, actionName, ty.GetTypeMap())
 
-	create := &types.CreateTx{}
+	create := &types.CreateTx{TokenSymbol: "NotMe"}
 	tx, err := ty.RPC_Default_Process("transfer", create)
 	assert.NoError(t, err)
 
-	_, err = ty.GetAssets(tx)
+	assets, err := ty.GetAssets(tx)
 	assert.NoError(t, err)
+	assert.Equal(t, 1, len(assets))
+	assert.Equal(t, "BTY", assets[0].GetSymbol())
 }
 
 func TestCoinsPb(t *testing.T) {


### PR DESCRIPTION
 coins  交易处理的对象是主币.  如果根据交易的symbol 输出 asset是错误的.

查询交易结果输出的asset 不对, 会引起误解. 