### PR TITLE
add by hyb for ProcGetBlockHash

### DIFF
--- a/blockchain/query_block.go
+++ b/blockchain/query_block.go
@@ -45,11 +45,11 @@ func (chain *BlockChain) ProcGetBlockHash(height *types.ReqInt) (*types.ReplyHas
 		return nil, types.ErrInvalidParam
 	}
 	var ReplyHash types.ReplyHash
-	block, err := chain.GetBlock(height.GetHeight())
+	hash, err := chain.blockStore.GetBlockHashByHeight(height.GetHeight())
 	if err != nil {
 		return nil, err
 	}
-	ReplyHash.Hash = block.Block.Hash(chain.client.GetConfig())
+	ReplyHash.Hash = hash
 	return &ReplyHash, nil
 }
 


### PR DESCRIPTION
修改通过区块height获取区块hash的接口。
    不再通过block信息计算区块hash的方式获取
    直接从本地数据库中存储的height->hash对应关系中获取区块hash。

