### PR TITLE
add by hyb for issues-822

### DIFF
--- a/blockchain/cache.go
+++ b/blockchain/cache.go
@@ -121,7 +121,7 @@ type cacheTx struct {
 	txHashes []string
 }
 
-//BlockCache 区块缓存
+//TxCache 交易hash缓存
 type TxCache struct {
 	capacity int
 	cacheTxs map[string]bool

--- a/blockchain/cache.go
+++ b/blockchain/cache.go
@@ -9,13 +9,13 @@ import (
 	"sync"
 
 	"github.com/33cn/chain33/types"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 //BlockCache 区块缓存
 type BlockCache struct {
 	cache      map[int64]*list.Element
 	cacheHash  map[string]*list.Element
-	cacheTxs   map[string]bool
 	cacheSize  int64
 	cachelock  sync.Mutex
 	cacheQueue *list.List
@@ -28,7 +28,6 @@ func NewBlockCache(param *types.Chain33Config, defCacheSize int64) *BlockCache {
 	return &BlockCache{
 		cache:      make(map[int64]*list.Element),
 		cacheHash:  make(map[string]*list.Element),
-		cacheTxs:   make(map[string]bool),
 		cacheSize:  defCacheSize,
 		cacheQueue: list.New(),
 		maxHeight:  0,
@@ -59,14 +58,6 @@ func (chain *BlockCache) GetCacheBlock(hash []byte) (block *types.BlockDetail) {
 		return elem.Value.(*types.BlockDetail)
 	}
 	return nil
-}
-
-//HasCacheTx 缓存中是否包含该交易
-func (chain *BlockCache) HasCacheTx(hash []byte) bool {
-	chain.cachelock.Lock()
-	defer chain.cachelock.Unlock()
-	_, ok := chain.cacheTxs[string(hash)]
-	return ok
 }
 
 //CacheBlock 添加block到cache中，方便快速查询
@@ -115,15 +106,100 @@ func (chain *BlockCache) addCacheBlock(blockdetail *types.BlockDetail) {
 	elem := chain.cacheQueue.PushBack(blockdetail)
 	chain.cache[blockdetail.Block.Height] = elem
 	chain.cacheHash[string(blockdetail.Block.Hash(chain.sysPm))] = elem
-	for _, tx := range blockdetail.Block.Txs {
-		chain.cacheTxs[string(tx.Hash())] = true
-	}
 }
 
 func (chain *BlockCache) delCacheBlock(blockdetail *types.BlockDetail) {
 	delete(chain.cache, blockdetail.Block.Height)
 	delete(chain.cacheHash, string(blockdetail.Block.Hash(chain.sysPm)))
-	for _, tx := range blockdetail.Block.Txs {
-		delete(chain.cacheTxs, string(tx.Hash()))
+}
+
+// cache tx
+
+// 存储指定高度的所有交易的hash值
+type cacheTx struct {
+	height   int64 //用来辅助判断cache 是否正确
+	txHashes []string
+}
+
+//BlockCache 区块缓存
+type TxCache struct {
+	capacity int
+	cacheTxs map[string]bool
+	data     *lru.Cache
+	lock     *sync.RWMutex
+}
+
+//NewTxCache new
+func NewTxCache(defCacheSize int) *TxCache {
+	cache := &TxCache{cacheTxs: make(map[string]bool), capacity: defCacheSize, lock: &sync.RWMutex{}}
+	var err error
+	cache.data, err = lru.New(defCacheSize)
+	if err != nil {
+		panic(err)
 	}
+	return cache
+
+}
+
+// Add :缓存指定高度区块的所有交易的hash值
+func (c *TxCache) Add(block *types.Block) bool {
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	//如果存在先删除再添加
+	if txcache, exist := c.data.Peek(block.GetHeight()); exist {
+		for _, tx := range txcache.(cacheTx).txHashes {
+			delete(c.cacheTxs, tx)
+		}
+		c.data.Remove(block.GetHeight())
+	}
+
+	//超过最大大小, 移除最早的值
+	if c.data.Len() >= c.capacity {
+		_, v, ok := c.data.RemoveOldest()
+		if !ok {
+			chainlog.Error("TxCache.Add RemoveOldest fail ...", "len", c.data.Len(), "capacity", c.capacity)
+			return false
+		}
+		for _, tx := range v.(cacheTx).txHashes {
+			delete(c.cacheTxs, tx)
+		}
+	}
+
+	//添加新区块的交易hash列表
+	var txs cacheTx
+	txs.height = block.GetHeight()
+	for _, tx := range block.Txs {
+		txhash := string(tx.Hash())
+		txs.txHashes = append(txs.txHashes, txhash)
+		c.cacheTxs[txhash] = true
+	}
+	c.data.Add(block.GetHeight(), txs)
+	return true
+}
+
+// Del :删除指定高度区块的所有交易hash
+func (c *TxCache) Del(height int64) bool {
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	//如果存在就删除
+	if txcache, exist := c.data.Peek(height); exist {
+		for _, tx := range txcache.(cacheTx).txHashes {
+			delete(c.cacheTxs, tx)
+		}
+		return c.data.Remove(height)
+	}
+	return true
+}
+
+//HasCacheTx 缓存中是否包含该交易
+func (c *TxCache) HasCacheTx(hash []byte) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	_, ok := c.cacheTxs[string(hash)]
+	return ok
 }

--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -333,8 +333,9 @@ func (b *BlockChain) connectBlock(node *blockNode, blockdetail *types.BlockDetai
 	//cache new add block
 	beg = types.Now()
 	b.cache.CacheBlock(blockdetail)
-
+	b.txCache.Add(blockdetail.Block)
 	cacheCost := types.Since(beg)
+
 	//保存block的总难度到db中
 	difficulty := difficulty.CalcWork(block.Difficulty)
 	var blocktd *big.Int

--- a/blockchain/query_tx.go
+++ b/blockchain/query_tx.go
@@ -114,7 +114,7 @@ func (chain *BlockChain) GetTxResultFromDb(txhash []byte) (tx *types.TxResult, e
 
 //HasTx 是否包含该交易
 func (chain *BlockChain) HasTx(txhash []byte, onlyquerycache bool) (has bool, err error) {
-	has = chain.cache.HasCacheTx(txhash)
+	has = chain.txCache.HasCacheTx(txhash)
 	if has {
 		return true, nil
 	}

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -176,6 +176,12 @@ type BlockChain struct {
 	MaxActiveBlockNum int `json:"maxActiveBlockNum,omitempty"`
 	// 当前活跃区块的缓存大小M为单位
 	MaxActiveBlockSize int `json:"maxActiveBlockSize,omitempty"`
+
+	//HighAllowPackHeight 允许打包的High区块高度
+	HighAllowPackHeight int64 `json:"highAllowPackHeight,omitempty"`
+
+	//LowAllowPackHeight 允许打包的low区块高度
+	LowAllowPackHeight int64 `json:"lowAllowPackHeight,omitempty"`
 }
 
 // P2P 配置

--- a/types/const.go
+++ b/types/const.go
@@ -155,3 +155,6 @@ var HighAllowPackHeight int64 = 90
 
 //LowAllowPackHeight 允许打包的low区块高度
 var LowAllowPackHeight int64 = 30
+
+//MaxAllowPackInterval 允许打包的最大区间值
+var MaxAllowPackInterval int64 = 5000


### PR DESCRIPTION
修改blockchian模块最新区块和交易的缓存：
将block和txhash的缓存分开存储，各自有对应的可配置选项
1.BlockCache 只缓存最新的区块，缓存的大小由defCacheSize配置项决定，默认缓存128最新的区块
2.TxCache只缓存交易hash值，方便交易去重时快速查找，缓存的大小由highAllowPackHeight + lowAllowPackHeight 配置项之和决定。默认是120区块的所有交易hash，最大不能超过5000个

