### PR TITLE
调整系统的连接数最低和最高配置

### DIFF
--- a/system/p2p/dht/manage/connectionGater.go
+++ b/system/p2p/dht/manage/connectionGater.go
@@ -100,6 +100,9 @@ func (s *Conngater) validateDial(addr multiaddr.Multiaddr) bool {
 }
 
 func (s *Conngater) isPeerAtLimit(direction network.Direction) bool {
+	if s.cfg.MaxConnectNum == 0 { //不对连接节点数量进行限制
+		return false
+	}
 	numOfConns := len((*s.host).Network().Peers())
 	var maxPeers int
 	if direction == network.DirInbound { //inbound connect

--- a/system/p2p/dht/manage/connectionGater.go
+++ b/system/p2p/dht/manage/connectionGater.go
@@ -110,7 +110,6 @@ func (s *Conngater) isPeerAtLimit(direction network.Direction) bool {
 	} else {
 		maxPeers = int(s.cfg.MaxConnectNum + CacheLimit)
 	}
-
 	return numOfConns >= maxPeers
 }
 

--- a/system/p2p/dht/manage/connectionGater_test.go
+++ b/system/p2p/dht/manage/connectionGater_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	core "github.com/libp2p/go-libp2p-core"
 	"testing"
 	"time"
+
+	core "github.com/libp2p/go-libp2p-core"
 
 	p2pty "github.com/33cn/chain33/system/p2p/dht/types"
 	"github.com/libp2p/go-libp2p"

--- a/system/p2p/dht/p2p.go
+++ b/system/p2p/dht/p2p.go
@@ -259,8 +259,12 @@ func (p *P2P) buildHostOptions(priv p2pcrypto.PrivKey, bandwidthTracker metrics.
 	if p.subCfg.MaxConnectNum > 0 { //如果不设置最大连接数量，默认允许dht自由连接并填充路由表
 
 		var maxconnect = int(p.subCfg.MaxConnectNum)
-		//5分钟的宽限期,定期清理
-		options = append(options, libp2p.ConnectionManager(connmgr.NewConnManager(maxconnect, maxconnect+int(manage.CacheLimit), time.Minute*5)))
+		minconnect := maxconnect - int(manage.CacheLimit) //调整为不超过配置的上限
+		if minconnect < 0 {
+			minconnect = maxconnect / 2
+		}
+		//2分钟的宽限期,定期清理
+		options = append(options, libp2p.ConnectionManager(connmgr.NewConnManager(minconnect, maxconnect, time.Minute*2)))
 		//ConnectionGater,处理网络连接的策略
 		options = append(options, libp2p.ConnectionGater(manage.NewConnGater(&p.host, p.subCfg, p.blackCache)))
 	}


### PR DESCRIPTION
发现如果不调整这个配置，系统在极端情况连接数达到上限之前，就会提前限制对方节点连进来 @yann-sjtu 