### PR TITLE
add by hyb for issues-955

### DIFF
--- a/blockchain/download.go
+++ b/blockchain/download.go
@@ -178,7 +178,11 @@ func (chain *BlockChain) ReadBlockToExec(height int64, isNewStart bool) {
 				}
 				chain.DefaultDownLoadInfo()
 			}
+
+			//清除快速下载的标识并从缓存中删除此执行失败的区块，
 			chain.cancelDownLoadFlag(isNewStart)
+			chain.blockStore.db.Delete(calcHeightToTempBlockKey(block.Height))
+
 			synlog.Error("ReadBlockToExec:ProcessBlock:err!", "height", block.Height, "hash", common.ToHex(block.Hash(cfg)), "isNewStart", isNewStart, "err", err)
 			break
 		}

--- a/types/tx.go
+++ b/types/tx.go
@@ -483,6 +483,8 @@ func (tx *Transaction) CheckSign() bool {
 func (tx *Transaction) checkSign() bool {
 	copytx := *tx
 	copytx.Signature = nil
+	//如果新版本扩展了字段，使用旧的数据结构解析，新字段将放在未识别字段中，导致验签失败，需要置空
+	copytx.XXX_unrecognized = nil
 	copytx.UnsetCacheHash()
 	data := Encode(&copytx)
 	if tx.GetSignature() == nil {


### PR DESCRIPTION
修改：
1.快速下载模式时区块执行失败，清除快速下载的标识以及删除此执行失败区块从数据库缓存中
2.快速下载模式时区块执行失败，不记录错误故障并删除index中本区块的缓存，方便普通模式时再次下载本区块并执行


fix #955 