### PR TITLE
增加rpc的用户名和密码访问认证

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -68,6 +68,11 @@ func (j *JSONRPCServer) Listen() (int, error) {
 			writeError(w, r, 0, fmt.Sprintf(`The %s Address is not authorized!`, ip))
 			return
 		}
+
+		if !checkBasicAuth(r) {
+			writeError(w, r, 0, fmt.Sprintf(`Unauthozied`))
+			return
+		}
 		if r.URL.Path == "/" {
 			data, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -38,6 +38,27 @@ func TestCheckIpWhitelist(t *testing.T) {
 
 }
 
+func TestCheckBasicAuth(t *testing.T) {
+	rpcCfg = new(types.RPC)
+	var r = &http.Request{Header: make(http.Header)}
+	assert.True(t, checkBasicAuth(r))
+	r.SetBasicAuth("1212121", "chain33-mypasswd")
+	assert.True(t, checkBasicAuth(r))
+	rpcCfg.JrpcUserName = "chain33-user"
+	rpcCfg.JrpcUserPasswd = "chain33-mypasswd"
+	r.SetBasicAuth("", "chain33-mypasswd")
+	assert.False(t, checkBasicAuth(r))
+	r.SetBasicAuth("", "")
+	assert.False(t, checkBasicAuth(r))
+	r.SetBasicAuth("chain33-user", "")
+	assert.False(t, checkBasicAuth(r))
+	r.SetBasicAuth("chain33", "1234")
+	assert.False(t, checkBasicAuth(r))
+	r.SetBasicAuth("chain33-user", "chain33-mypasswd")
+	assert.True(t, checkBasicAuth(r))
+
+}
+
 func TestJSONClient_Call(t *testing.T) {
 	rpcCfg = new(types.RPC)
 	rpcCfg.GrpcBindAddr = "127.0.0.1:8101"

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -6,6 +6,7 @@ package rpc
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -228,6 +228,10 @@ type RPC struct {
 	CertFile string `json:"certFile,omitempty"`
 	// 私钥文件
 	KeyFile string `json:"keyFile,omitempty"`
+	//basic auth 用户名
+	JrpcUserName string `json:"jrpcUserName,omitempty"`
+	//basic auth 用户密码
+	JrpcUserPasswd string `json:"jrpcUserPasswd,omitempty"`
 }
 
 // Exec 配置


### PR DESCRIPTION
RPC配置项增加：
        //basic auth 用户名
	JrpcUserName string `json:"jrpcUserName,omitempty"`
	//basic auth 用户密码
	JrpcUserPasswd string `json:"jrpcUserPasswd,omitempty"`
1.增加RPC接口的JsonRPC BasicAuth 用户名和密码访问的配置项
2. 如果不填写此配置，默认不启用