### PR TITLE
Fix mempool expired tx removing

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -621,14 +621,12 @@ func (chain *BlockChain) DelCacheBlock(height int64, hash []byte) {
 
 //InitAllowPackHeight 根据配置修改LowAllowPackHeight和值HighAllowPackHeight
 func InitAllowPackHeight(mcfg *types.BlockChain) {
-	if mcfg.HighAllowPackHeight != 0 && mcfg.LowAllowPackHeight != 0 {
-		if mcfg.HighAllowPackHeight+mcfg.LowAllowPackHeight < types.MaxAllowPackInterval {
-			types.HighAllowPackHeight = mcfg.HighAllowPackHeight
-			types.LowAllowPackHeight = mcfg.LowAllowPackHeight
-		} else {
+	if mcfg.HighAllowPackHeight > 0 && mcfg.LowAllowPackHeight > 0 {
+		if mcfg.HighAllowPackHeight+mcfg.LowAllowPackHeight > types.MaxAllowPackInterval {
 			panic("when Enable TxHeight HighAllowPackHeight + LowAllowPackHeight must less than types.MaxAllowPackInterval")
 		}
+		types.HighAllowPackHeight = mcfg.HighAllowPackHeight
+		types.LowAllowPackHeight = mcfg.LowAllowPackHeight
 	}
-	chainlog.Debug("InitAllowPackHeight", "mcfg.HighAllowPackHeight", mcfg.HighAllowPackHeight, "mcfg.LowAllowPackHeight", mcfg.LowAllowPackHeight)
 	chainlog.Debug("InitAllowPackHeight", "types.HighAllowPackHeight", types.HighAllowPackHeight, "types.LowAllowPackHeight", types.LowAllowPackHeight)
 }

--- a/blockchain/chain_duptx_test.go
+++ b/blockchain/chain_duptx_test.go
@@ -210,11 +210,10 @@ func TestCheckDupTxHashList05(t *testing.T) {
 	cfg := mock33.GetClient().GetConfig()
 	cfg.S("TxHeight", true)
 	chainlog.Debug("TestCheckDupTxHashList05 begin --------------------")
-	TxHeightOffset = 60
 	//发送带TxHeight交易且TxHeight不满足条件
-	for i := 1; i < 10; i++ {
+	for i := 2; i < 10; i++ {
 		_, _, err := addTxTxHeigt(cfg, mock33.GetGenesisKey(), mock33.GetAPI(), int64(i))
-		require.EqualError(t, err, "ErrTxExpire")
+		require.EqualErrorf(t, err, "ErrTxExpire", "index-%d", i)
 		time.Sleep(sendTxWait)
 	}
 	chainlog.Debug("TestCheckDupTxHashList05 end --------------------")

--- a/blockchain/proc.go
+++ b/blockchain/proc.go
@@ -249,13 +249,13 @@ func (chain *BlockChain) addBlockDetail(msg *queue.Message) {
 	chainlog.Debug("EventAddBlockDetail", "height", blockDetail.Block.Height, "parent", common.ToHex(blockDetail.Block.ParentHash))
 	blockDetail, err := chain.ProcAddBlockMsg(true, blockDetail, "self")
 	if err != nil {
-		chainlog.Error("addBlockDetail", "err", err.Error())
+		chainlog.Error("addBlockDetail", "height", Height, "procAddBlockMsg err", err.Error())
 		msg.Reply(chain.client.NewMessage("consensus", types.EventAddBlockDetail, err))
 		return
 	}
 	if blockDetail == nil {
 		err = types.ErrExecBlockNil
-		chainlog.Error("addBlockDetail", "err", err.Error())
+		chainlog.Error("addBlockDetail", "height", Height, "nil block err", err.Error())
 		msg.Reply(chain.client.NewMessage("consensus", types.EventAddBlockDetail, err))
 		return
 	}

--- a/blockchain/query_block.go
+++ b/blockchain/query_block.go
@@ -244,7 +244,7 @@ func (chain *BlockChain) ProcAddBlockMsg(broadcast bool, blockdetail *types.Bloc
 	beg := types.Now()
 	defer func() {
 		chainlog.Debug("ProcAddBlockMsg", "height", blockdetail.GetBlock().GetHeight(),
-			"txCount", blockdetail.GetBlock().GetHeight(), "recvFrom", pid, "cost", types.Since(beg))
+			"txCount", len(blockdetail.GetBlock().GetTxs()), "recvFrom", pid, "cost", types.Since(beg))
 	}()
 
 	block := blockdetail.Block

--- a/system/mempool/base.go
+++ b/system/mempool/base.go
@@ -126,8 +126,9 @@ func (mem *Mempool) getTxList(filterList *types.TxHashList) (txs []*types.Transa
 }
 
 func (mem *Mempool) filterTxList(count int64, dupMap map[string]bool, isAll bool) (txs []*types.Transaction) {
-	height := mem.header.GetHeight()
-	blocktime := mem.header.GetBlockTime()
+	//mempool中的交易都是未打包的，需要用下一个区块的高度和时间作为交易过期判定
+	height := mem.header.GetHeight() + 1
+	blockTime := mem.header.GetBlockTime() + 1
 	types.AssertConfig(mem.client)
 	cfg := mem.client.GetConfig()
 	var expiredTxHashes [][]byte
@@ -138,12 +139,12 @@ func (mem *Mempool) filterTxList(count int64, dupMap map[string]bool, isAll bool
 				return true
 			}
 		}
-		if isExpired(cfg, tx, height, blocktime) && !isAll {
+		if isExpired(cfg, tx, height, blockTime) && !isAll {
 			expiredTxHashes = append(expiredTxHashes, tx.Value.Hash())
 			return true
 		}
 		txs = append(txs, tx.Value)
-		//达到设定的交易数，退出循环
+		//达到设定的交易数，退出循环, count为0获取所有
 		if count > 0 && len(txs) == int(count) {
 			return false
 		}

--- a/system/mempool/base.go
+++ b/system/mempool/base.go
@@ -128,7 +128,7 @@ func (mem *Mempool) getTxList(filterList *types.TxHashList) (txs []*types.Transa
 func (mem *Mempool) filterTxList(count int64, dupMap map[string]bool, isAll bool) (txs []*types.Transaction) {
 	//mempool中的交易都是未打包的，需要用下一个区块的高度和时间作为交易过期判定
 	height := mem.header.GetHeight() + 1
-	blockTime := mem.header.GetBlockTime() + 1
+	blockTime := mem.header.GetBlockTime()
 	types.AssertConfig(mem.client)
 	cfg := mem.client.GetConfig()
 	//由于mempool可能存在过期交易，先遍历所有，满足目标交易数再退出，否则存在无法获取到实际交易情况
@@ -266,7 +266,7 @@ func (mem *Mempool) removeExpired() {
 	defer mem.proxyMtx.Unlock()
 	types.AssertConfig(mem.client)
 	//mempool的header是当前高度，而交易将被下一个区块打包，过期判定采用下一个区块的高度和时间
-	mem.cache.removeExpiredTx(mem.client.GetConfig(), mem.header.GetHeight()+1, mem.header.GetBlockTime()+1)
+	mem.cache.removeExpiredTx(mem.client.GetConfig(), mem.header.GetHeight()+1, mem.header.GetBlockTime())
 }
 
 // removeBlockedTxs 每隔1分钟清理一次已打包的交易

--- a/system/mempool/cache.go
+++ b/system/mempool/cache.go
@@ -131,7 +131,7 @@ func (cache *txCache) removeExpiredTx(cfg *types.Chain33Config, height, blocktim
 		}
 		return true
 	})
-	mlog.Info("removeExpiredTx", "totalTxs", cache.Size(), "expiredTxs", len(txs))
+	mlog.Info("removeExpiredTx", "height", height, "totalTxs", cache.Size(), "expiredTxs", len(txs))
 	cache.RemoveTxs(txs)
 }
 

--- a/system/mempool/cache.go
+++ b/system/mempool/cache.go
@@ -131,6 +131,7 @@ func (cache *txCache) removeExpiredTx(cfg *types.Chain33Config, height, blocktim
 		}
 		return true
 	})
+	mlog.Info("removeExpiredTx", "totalTxs", cache.Size(), "expiredTxs", len(txs))
 	cache.RemoveTxs(txs)
 }
 

--- a/system/mempool/check.go
+++ b/system/mempool/check.go
@@ -50,7 +50,8 @@ func (mem *Mempool) checkTxListRemote(txlist *types.ExecTxList) (*types.ReceiptC
 
 func (mem *Mempool) checkExpireValid(tx *types.Transaction) bool {
 	types.AssertConfig(mem.client)
-	if tx.IsExpire(mem.client.GetConfig(), mem.header.GetHeight(), mem.header.GetBlockTime()) {
+	//进入mempool中的交易可能被下一个区块打包，这里用下一个区块的高度和时间作为交易过期判定
+	if tx.IsExpire(mem.client.GetConfig(), mem.header.GetHeight()+1, mem.header.GetBlockTime()+1) {
 		return false
 	}
 	if tx.Expire > 1000000000 && tx.Expire < types.Now().Unix()+int64(time.Minute/time.Second) {

--- a/system/mempool/check.go
+++ b/system/mempool/check.go
@@ -51,7 +51,7 @@ func (mem *Mempool) checkTxListRemote(txlist *types.ExecTxList) (*types.ReceiptC
 func (mem *Mempool) checkExpireValid(tx *types.Transaction) bool {
 	types.AssertConfig(mem.client)
 	//进入mempool中的交易可能被下一个区块打包，这里用下一个区块的高度和时间作为交易过期判定
-	if tx.IsExpire(mem.client.GetConfig(), mem.header.GetHeight()+1, mem.header.GetBlockTime()+1) {
+	if tx.IsExpire(mem.client.GetConfig(), mem.header.GetHeight()+1, mem.header.GetBlockTime()) {
 		return false
 	}
 	if tx.Expire > 1000000000 && tx.Expire < types.Now().Unix()+int64(time.Minute/time.Second) {

--- a/system/mempool/eventprocess.go
+++ b/system/mempool/eventprocess.go
@@ -155,7 +155,8 @@ func (mem *Mempool) eventTxList(msg *queue.Message) {
 // EventAddBlock 将添加到区块内的交易从mempool中删除
 func (mem *Mempool) eventAddBlock(msg *queue.Message) {
 	block := msg.GetData().(*types.BlockDetail).Block
-	if block.Height > mem.Height() || (block.Height == 0 && mem.Height() == 0) {
+	height := mem.Height()
+	if block.Height > height || (block.Height == 0 && height == 0) {
 		header := &types.Header{}
 		header.BlockTime = block.BlockTime
 		header.Height = block.Height
@@ -163,6 +164,7 @@ func (mem *Mempool) eventAddBlock(msg *queue.Message) {
 		mem.setHeader(header)
 	}
 	mem.RemoveTxsOfBlock(block)
+	mem.removeExpired()
 }
 
 // EventGetMempoolSize 获取mempool大小

--- a/system/mempool/mempool_test.go
+++ b/system/mempool/mempool_test.go
@@ -44,7 +44,7 @@ var (
 	v          = &cty.CoinsAction_Transfer{Transfer: &types.AssetsTransfer{Amount: amount}}
 	bigByte    = make([]byte, 99510)
 	transfer   = &cty.CoinsAction{Value: v, Ty: cty.CoinsActionTransfer}
-	tx1        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 1000000, Expire: 3, To: toAddr}
+	tx1        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 1000000, Expire: 4, To: toAddr}
 	tx2        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 100000000, Expire: 0, To: toAddr}
 	tx3        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 200000000, Expire: 0, To: toAddr}
 	tx4        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 300000000, Expire: 0, To: toAddr}
@@ -521,10 +521,7 @@ func TestRemoveTxOfBlock(t *testing.T) {
 		t.Error(err)
 		return
 	}
-
-	if reply.GetData().(*types.MempoolSize).Size != 3 {
-		t.Error("TestGetMempoolSize failed")
-	}
+	require.Equal(t, int64(3), reply.GetData().(*types.MempoolSize).Size)
 }
 
 func TestAddBlockedTx(t *testing.T) {
@@ -1298,7 +1295,9 @@ func TestGetTxList(t *testing.T) {
 	// 取交易自动过滤过期交易
 	txs := mem.getTxList(&types.TxHashList{Hashes: nil, Count: int64(5)})
 	require.Equal(t, 5, len(txs))
-	require.Equal(t, 10, mem.cache.Size())
+	require.Equal(t, 20, mem.cache.Size())
+	txs = mem.getTxList(&types.TxHashList{Hashes: nil, Count: int64(20)})
+	require.Equal(t, 10, len(txs))
 }
 
 func TestCheckTxsExist(t *testing.T) {

--- a/system/mempool/mempool_test.go
+++ b/system/mempool/mempool_test.go
@@ -44,7 +44,7 @@ var (
 	v          = &cty.CoinsAction_Transfer{Transfer: &types.AssetsTransfer{Amount: amount}}
 	bigByte    = make([]byte, 99510)
 	transfer   = &cty.CoinsAction{Value: v, Ty: cty.CoinsActionTransfer}
-	tx1        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 1000000, Expire: 2, To: toAddr}
+	tx1        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 1000000, Expire: 3, To: toAddr}
 	tx2        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 100000000, Expire: 0, To: toAddr}
 	tx3        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 200000000, Expire: 0, To: toAddr}
 	tx4        = &types.Transaction{Execer: []byte("coins"), Payload: types.Encode(transfer), Fee: 300000000, Expire: 0, To: toAddr}
@@ -470,10 +470,7 @@ func TestAddMoreTxThanPoolSize(t *testing.T) {
 	defer mem.Close()
 
 	err := add4Tx(mem.client)
-	if err != nil {
-		t.Error("add tx error", err.Error())
-		return
-	}
+	require.Nil(t, err)
 
 	msg5 := mem.client.NewMessage("mempool", types.EventTx, tx5)
 	mem.client.Send(msg5, true)

--- a/types/const.go
+++ b/types/const.go
@@ -141,20 +141,19 @@ const (
 //TxHeightFlag 标记是一个时间还是一个 TxHeight
 var TxHeightFlag int64 = 1 << 62
 
-//HighAllowPackHeight eg: current Height is 10000
-//TxHeight is  10010
-//=> Height <= TxHeight + HighAllowPackHeight
-//=> Height >= TxHeight - LowAllowPackHeight
+//HighAllowPackHeight txHeight打包上限高度
+//eg: currentHeight = 10000
+//某交易的expire=TxHeightFlag+ currentHeight + 10, 则TxHeight=10010
+//打包的区块高度必须满足， Height >= TxHeight - LowAllowPackHeight && Height <= TxHeight + HighAllowPackHeight
 //那么交易可以打包的范围是: 10010 - 100 = 9910 , 10010 + 200 =  10210 (9910,10210)
-//可以合法的打包交易
 //注意，这两个条件必须同时满足.
-//关于交易去重复:
-//也就是说，另外一笔相同的交易，只能被打包在这个区间(9910,10210)。
-//那么检查交易重复的时候，我只要检查 9910 - currentHeight 这个区间的交易不要重复就好了
-var HighAllowPackHeight int64 = 90
+//关于交易查重:
+//也就是说，两笔相同的交易必然有相同的expire，即TxHeight相同，以及对应的打包区间一致，只能被打包在这个区间(9910,10210)。
+//那么检查交易重复的时候，我只要检查 9910 - currentHeight 这个区间的交易是否有重复
+var HighAllowPackHeight int64 = 200
 
 //LowAllowPackHeight 允许打包的low区块高度
-var LowAllowPackHeight int64 = 30
+var LowAllowPackHeight int64 = 100
 
 //MaxAllowPackInterval 允许打包的最大区间值
 var MaxAllowPackInterval int64 = 5000

--- a/util/util.go
+++ b/util/util.go
@@ -227,7 +227,7 @@ func CreateTxWithTxHeight(cfg *types.Chain33Config, priv crypto.PrivKey, to stri
 func GenTxsTxHeigt(cfg *types.Chain33Config, priv crypto.PrivKey, n, height int64) (txs []*types.Transaction) {
 	to, _ := Genaddress()
 	for i := 0; i < int(n); i++ {
-		tx := CreateTxWithTxHeight(cfg, priv, to, types.Coin*(n+1), 20+height)
+		tx := CreateTxWithTxHeight(cfg, priv, to, types.Coin*(n+1), types.LowAllowPackHeight+height)
 		txs = append(txs, tx)
 	}
 	return txs

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -124,7 +124,7 @@ func TestGenTx(t *testing.T) {
 	assert.Equal(t, 2, len(txs))
 	assert.Equal(t, "coins", string(txs[0].Execer))
 	assert.Equal(t, "coins", string(txs[1].Execer))
-	assert.Equal(t, types.TxHeightFlag+10+20, txs[0].Expire)
+	assert.Equal(t, types.TxHeightFlag+10+types.LowAllowPackHeight, txs[0].Expire)
 }
 
 func TestGenBlock(t *testing.T) {


### PR DESCRIPTION
1. mempool获取交易时，增加过期判定以及对过期的交易进行删除删除, 相关问题33cn/plugin#948, 33cn/plugin#954, 33cn/plugin#961

2. fix #822 , 增加txHeight允许打包区间，默认设为300，支持配置，对于1w交易的区块，交易哈希缓存内存开销约90MB

