### PR TITLE
Redownload chunkhash

### DIFF
--- a/blockchain/blocksyn.go
+++ b/blockchain/blocksyn.go
@@ -1101,7 +1101,10 @@ func (chain *BlockChain) ChunkRecordSync() {
 	curheight := chain.GetBlockHeight()
 	// 记录检测到高度停止增长的次数
 	if curheight == atomic.LoadInt64(&chain.lastHeight) {
-		atomic.AddInt32(&chain.heightNotIncreaseTimes, 1)
+		// 若 peerList 只有一个本节点说明网络不通，不记录
+		if len(chain.GetPeers()) > 1 {
+			atomic.AddInt32(&chain.heightNotIncreaseTimes, 1)
+		}
 	} else {
 		atomic.StoreInt64(&chain.lastHeight, curheight)
 		atomic.StoreInt32(&chain.heightNotIncreaseTimes, 0)

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -138,6 +138,10 @@ type BlockChain struct {
 	processingGenChunk    int32
 	processingDeleteChunk int32
 	deleteChunkCount      int64
+
+	// TODO
+	lastHeight             int64
+	heightNotIncreaseTimes int32
 }
 
 //New new

--- a/system/p2p/dht/protocol/p2pstore/query.go
+++ b/system/p2p/dht/protocol/p2pstore/query.go
@@ -179,7 +179,7 @@ func (p *Protocol) getChunkRecords(param *types.ReqChunkRecords) *types.ChunkRec
 		sum := common.Sha256(types.Encode(records))
 		recordsCache[string(sum)] = records
 		recordsCount[string(sum)]++
-		log.Info("getChunkRecords", "peer", pid, "start", param.Start, "end", param.End)
+		log.Info("getChunkRecords", "peer", pid, "start", param.Start, "end", param.End, "addr", p.Host.Peerstore().Addrs(pid))
 		if i > 10 && len(recordsCount) != 0 {
 			break
 		}


### PR DESCRIPTION
采用数据分片后个别节点出现同步异常的问题，经排查为请求的chunkhash是错误的。

目前的分片同步策略为：
1. 从任意节点同步chunkhash，作为请求chunk数据的索引
2. 根据chunkhash请求chunk数据

考虑到大部分节点为诚实节点，目前chunkhash的校验方案比较简单，从多个节点请求chunkhash，若存在不一致则取多数节点都认可的chunkhash。目前仍存在节点同步到错误的chunkhash的情况，导致根据错误的chunkhash无法找到分片数据。解决方案是监测到区块高度超过3分钟不增长时，从当前高度重新同步chunkhash，测试可以解决区块同步异常的问题。

ps: 若没有连接上其他节点则不删除本地chunkhash。

目前没有定位到保存了错误chunkhash的节点，当前代码已通过日志记录了chunkhash的来源节点，需要通过日志进一步定位

close #1026 