### PR TITLE
update p2pstore datadir

### DIFF
--- a/system/p2p/dht/p2p.go
+++ b/system/p2p/dht/p2p.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -135,7 +136,8 @@ func initP2P(p *P2P) *P2P {
 	p.connManager = manage.NewConnManager(p.ctx, p.host, p.discovery.RoutingTable(), bandwidthTracker, p.subCfg)
 	p.peerInfoManager = manage.NewPeerInfoManager(p.ctx, p.host, p.client)
 	p.taskGroup = &sync.WaitGroup{}
-	p.db = newDB("", p.p2pCfg.Driver, p.subCfg.DHTDataPath, p.subCfg.DHTDataCache)
+
+	p.db = newDB("", p.p2pCfg.Driver, filepath.Dir(p.p2pCfg.DbPath), p.subCfg.DHTDataCache)
 	return p
 }
 
@@ -447,7 +449,7 @@ func newDB(name, backend, dir string, cache int32) dbm.DB {
 	if backend == "" {
 		backend = "leveldb"
 	}
-	if dir == "" {
+	if dir == "" || dir == "." {
 		dir = "datadir"
 	}
 	if cache <= 0 {

--- a/system/p2p/dht/p2p_test.go
+++ b/system/p2p/dht/p2p_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -395,12 +396,11 @@ func Test_p2p(t *testing.T) {
 	var tcfg types.P2P
 	tcfg.Driver = "leveldb"
 	tcfg.DbCache = 4
-	tcfg.DbPath = datadir
+	tcfg.DbPath = filepath.Join(datadir, "addrbook")
 	testAddrbook(t, &tcfg)
 
 	var mcfg p2pty.P2PSubConfig
 	types.MustDecode(cfg.GetSubConfig().P2P[p2pty.DHTTypeName], &mcfg)
-	mcfg.DHTDataPath = datadir
 	jcfg, err := json.Marshal(mcfg)
 	require.Nil(t, err)
 	cfg.GetSubConfig().P2P[p2pty.DHTTypeName] = jcfg


### PR DESCRIPTION
dht 配置项中统一使用 p2p 根配置项中指定的 dbPath，便于 bityuan 中重新指定 datadir 目录。