### PR TITLE
Update extend routing table

### DIFF
--- a/system/p2p/dht/protocol/p2pstore/handler.go
+++ b/system/p2p/dht/protocol/p2pstore/handler.go
@@ -133,6 +133,7 @@ func (p *Protocol) handleStreamFetchChunk(stream network.Stream) {
 */
 func (p *Protocol) handleStreamStoreChunks(req *types.P2PRequest) {
 	param := req.Request.(*types.P2PRequest_ChunkInfoList).ChunkInfoList.Items
+	log.Info("handleStreamStoreChunks", "len", len(param))
 	for _, info := range param {
 		chunkHash := hex.EncodeToString(info.ChunkHash)
 		//已有其他节点通知该节点保存该chunk，避免接收到多个节点的通知后重复查询数据
@@ -235,9 +236,10 @@ func (p *Protocol) handleEventNotifyStoreChunk(m *queue.Message) {
 	}
 
 	//如果本节点是本地路由表中距离该chunk最近的节点，则保存数据；否则不需要保存数据
-	tmpRoutingTable := p.genTempRoutingTable(req.ChunkHash, backup)
-	pid := tmpRoutingTable.NearestPeer(genDHTID(req.ChunkHash))
+	extendRoutingTable := p.genExtendRoutingTable(req.ChunkHash, backup)
+	pid := extendRoutingTable.NearestPeer(genDHTID(req.ChunkHash))
 	if pid != "" && kb.Closer(pid, p.Host.ID(), genChunkNameSpaceKey(req.ChunkHash)) {
+		log.Info("handleEventNotifyStoreChunk", "pid", pid, "chunk hash", hex.EncodeToString(req.ChunkHash), "start", req.Start)
 		return
 	}
 	log.Info("handleEventNotifyStoreChunk", "local nearest peer", p.Host.ID(), "chunk hash", hex.EncodeToString(req.ChunkHash))

--- a/system/p2p/dht/protocol/p2pstore/p2pstore.go
+++ b/system/p2p/dht/protocol/p2pstore/p2pstore.go
@@ -51,6 +51,10 @@ type Protocol struct {
 	localChunkInfoMutex sync.RWMutex
 
 	concurrency int64
+
+	// 增加一个扩展路由表的缓存，每小时最多生成一次
+	extendShardHealthyRoutingTable *kb.RoutingTable
+	refreshedTime time.Time
 }
 
 func init() {

--- a/system/p2p/dht/protocol/p2pstore/p2pstore.go
+++ b/system/p2p/dht/protocol/p2pstore/p2pstore.go
@@ -54,7 +54,7 @@ type Protocol struct {
 
 	// 增加一个扩展路由表的缓存，每小时最多生成一次
 	extendShardHealthyRoutingTable *kb.RoutingTable
-	refreshedTime time.Time
+	refreshedTime                  time.Time
 }
 
 func init() {

--- a/system/p2p/dht/protocol/p2pstore/p2pstore.go
+++ b/system/p2p/dht/protocol/p2pstore/p2pstore.go
@@ -72,6 +72,16 @@ func InitProtocol(env *protocol.P2PEnv) {
 	if env.SubConfig.Backup > 1 {
 		backup = env.SubConfig.Backup
 	}
+	if env.SubConfig.MinExtendRoutingTableSize == 0 {
+		env.SubConfig.MinExtendRoutingTableSize = types2.DefaultMinExtendRoutingTableSize
+	}
+	if env.SubConfig.MaxExtendRoutingTableSize == 0 {
+		env.SubConfig.MaxExtendRoutingTableSize = types2.DefaultMaxExtendRoutingTableSize
+	}
+	if env.SubConfig.MaxExtendRoutingTableSize < env.SubConfig.MinExtendRoutingTableSize {
+		env.SubConfig.MaxExtendRoutingTableSize = env.SubConfig.MinExtendRoutingTableSize
+	}
+
 	// RoutingTable更新时同时更新ShardHealthyRoutingTable
 	p.RoutingTable.PeerRemoved = func(id peer.ID) {
 		p.ShardHealthyRoutingTable.Remove(id)

--- a/system/p2p/dht/protocol/p2pstore/query.go
+++ b/system/p2p/dht/protocol/p2pstore/query.go
@@ -28,6 +28,7 @@ func (p *Protocol) fetchCloserPeers(key []byte, count int, pid peer.ID) ([]peer.
 	if err != nil {
 		return nil, err
 	}
+	_ = stream.SetDeadline(time.Now().Add(time.Second * 5))
 	defer protocol.CloseStream(stream)
 	req := types.P2PRequest{
 		Request: &types.P2PRequest_ReqPeers{

--- a/system/p2p/dht/protocol/p2pstore/republish.go
+++ b/system/p2p/dht/protocol/p2pstore/republish.go
@@ -106,7 +106,7 @@ func (p *Protocol) genExtendRoutingTable(key []byte, count int) *kb.RoutingTable
 	searchedPeers := make(map[peer.ID]struct{})
 	for i, pid := range peers {
 		// 保证 extendRoutingTable 至少有 300 个节点，且至少从 3 个节点上获取新节点，
-		if i+1 > 3 && extendRoutingTable.Size() > 300 {
+		if i+1 > 3 && extendRoutingTable.Size() > p.SubConfig.MaxExtendRoutingTableSize {
 			break
 		}
 		searchedPeers[pid] = struct{}{}
@@ -125,7 +125,7 @@ func (p *Protocol) genExtendRoutingTable(key []byte, count int) *kb.RoutingTable
 
 	// 如果扩展路由表节点数小于200，则迭代查询增加节点
 	var lastSize int //如果经过一轮迭代节点数没有增加则结束迭代，防止节点数不到200导致无法退出
-	for extendRoutingTable.Size() < 200 && extendRoutingTable.Size() > lastSize {
+	for extendRoutingTable.Size() < p.SubConfig.MinExtendRoutingTableSize && extendRoutingTable.Size() > lastSize {
 		lastSize = extendRoutingTable.Size()
 		for _, pid := range extendRoutingTable.ListPeers() {
 			if _, ok := searchedPeers[pid]; ok {

--- a/system/p2p/dht/types/const.go
+++ b/system/p2p/dht/types/const.go
@@ -18,6 +18,11 @@ const (
 
 	// DefaultP2PPort 默认端口
 	DefaultP2PPort = 13803
+
+	// DefaultMinExtendRoutingTableSize ...
+	DefaultMinExtendRoutingTableSize = 200
+	// DefaultMaxExtendRoutingTableSize ...
+	DefaultMaxExtendRoutingTableSize = 300
 )
 
 var (

--- a/system/p2p/dht/types/types.go
+++ b/system/p2p/dht/types/types.go
@@ -49,4 +49,9 @@ type P2PSubConfig struct {
 	DisableShard bool `protobuf:"varint,120,opt,name=disableShard" json:"disableShard,omitempty"`
 	//特定场景下的p2p白名单，只连接配置的节点,联盟链使用
 	WhitePeerList []string `protobuf:"bytes,21,rep,name=whitePeerList" json:"whitePeerList,omitempty"`
+
+	// 扩展路由表最小节点数
+	MinExtendRoutingTableSize int `protobuf:"varint,22,opt,name=minExtendRoutingTableSize" json:"minExtendRoutingTableSize,omitempty"`
+	// 扩展路由表最大节点数
+	MaxExtendRoutingTableSize int `protobuf:"varint,23,opt,name=n=maxExtendRoutingTableSize" json:"maxExtendRoutingTableSize,omitempty"`
 }


### PR DESCRIPTION
从连接的其他节点获取更多节点信息，生成一个至少有200个节点信息的扩展路由表，防止连接节点数太少导致网络的局部性问题