### PR TITLE
fix pointer conversion bug of go1.14

### DIFF
--- a/common/crypto/sha3/xor_unaligned.go
+++ b/common/crypto/sha3/xor_unaligned.go
@@ -14,9 +14,86 @@ package sha3
 import "unsafe"
 
 func xorInUnaligned(d *state, buf []byte) {
-	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))
 	n := len(buf)
-	if n >= 72 {
+	if n >= 168 {
+		bw := (*[21]uint64)(unsafe.Pointer(&buf[0]))
+		d.a[0] ^= bw[0]
+		d.a[1] ^= bw[1]
+		d.a[2] ^= bw[2]
+		d.a[3] ^= bw[3]
+		d.a[4] ^= bw[4]
+		d.a[5] ^= bw[5]
+		d.a[6] ^= bw[6]
+		d.a[7] ^= bw[7]
+		d.a[8] ^= bw[8]
+		d.a[9] ^= bw[9]
+		d.a[10] ^= bw[10]
+		d.a[11] ^= bw[11]
+		d.a[12] ^= bw[12]
+		d.a[13] ^= bw[13]
+		d.a[14] ^= bw[14]
+		d.a[15] ^= bw[15]
+		d.a[16] ^= bw[16]
+		d.a[17] ^= bw[17]
+		d.a[18] ^= bw[18]
+		d.a[19] ^= bw[19]
+		d.a[20] ^= bw[20]
+	} else if n >= 144 {
+		bw := (*[18]uint64)(unsafe.Pointer(&buf[0]))
+		d.a[0] ^= bw[0]
+		d.a[1] ^= bw[1]
+		d.a[2] ^= bw[2]
+		d.a[3] ^= bw[3]
+		d.a[4] ^= bw[4]
+		d.a[5] ^= bw[5]
+		d.a[6] ^= bw[6]
+		d.a[7] ^= bw[7]
+		d.a[8] ^= bw[8]
+		d.a[9] ^= bw[9]
+		d.a[10] ^= bw[10]
+		d.a[11] ^= bw[11]
+		d.a[12] ^= bw[12]
+		d.a[13] ^= bw[13]
+		d.a[14] ^= bw[14]
+		d.a[15] ^= bw[15]
+		d.a[16] ^= bw[16]
+		d.a[17] ^= bw[17]
+	} else if n >= 136 {
+		bw := (*[17]uint64)(unsafe.Pointer(&buf[0]))
+		d.a[0] ^= bw[0]
+		d.a[1] ^= bw[1]
+		d.a[2] ^= bw[2]
+		d.a[3] ^= bw[3]
+		d.a[4] ^= bw[4]
+		d.a[5] ^= bw[5]
+		d.a[6] ^= bw[6]
+		d.a[7] ^= bw[7]
+		d.a[8] ^= bw[8]
+		d.a[9] ^= bw[9]
+		d.a[10] ^= bw[10]
+		d.a[11] ^= bw[11]
+		d.a[12] ^= bw[12]
+		d.a[13] ^= bw[13]
+		d.a[14] ^= bw[14]
+		d.a[15] ^= bw[15]
+		d.a[16] ^= bw[16]
+	} else if n >= 104 {
+		bw := (*[13]uint64)(unsafe.Pointer(&buf[0]))
+		d.a[0] ^= bw[0]
+		d.a[1] ^= bw[1]
+		d.a[2] ^= bw[2]
+		d.a[3] ^= bw[3]
+		d.a[4] ^= bw[4]
+		d.a[5] ^= bw[5]
+		d.a[6] ^= bw[6]
+		d.a[7] ^= bw[7]
+		d.a[8] ^= bw[8]
+		d.a[9] ^= bw[9]
+		d.a[10] ^= bw[10]
+		d.a[11] ^= bw[11]
+		d.a[12] ^= bw[12]
+	} else if n >= 72 {
+		bw := (*[9]uint64)(unsafe.Pointer(&buf[0]))
 		d.a[0] ^= bw[0]
 		d.a[1] ^= bw[1]
 		d.a[2] ^= bw[2]
@@ -27,26 +104,7 @@ func xorInUnaligned(d *state, buf []byte) {
 		d.a[7] ^= bw[7]
 		d.a[8] ^= bw[8]
 	}
-	if n >= 104 {
-		d.a[9] ^= bw[9]
-		d.a[10] ^= bw[10]
-		d.a[11] ^= bw[11]
-		d.a[12] ^= bw[12]
-	}
-	if n >= 136 {
-		d.a[13] ^= bw[13]
-		d.a[14] ^= bw[14]
-		d.a[15] ^= bw[15]
-		d.a[16] ^= bw[16]
-	}
-	if n >= 144 {
-		d.a[17] ^= bw[17]
-	}
-	if n >= 168 {
-		d.a[18] ^= bw[18]
-		d.a[19] ^= bw[19]
-		d.a[20] ^= bw[20]
-	}
+
 }
 
 func copyOutUnaligned(d *state, buf []byte) {


### PR DESCRIPTION
fixed https://github.com/33cn/plugin/issues/1003

开启`race`时默认开启`checkptr`，此时长度为n的[]byte只能转换为长度不超过 n/8的[]uint64，否则runtime检查会报错堆对象越界，导致unsafe强制类型转换失败。该pr用于修复plugin的单元测试报错

参考：
https://golang.org/src/runtime/checkptr.go?s=194:258#L1
https://github.com/etcd-io/bbolt/issues/187
https://github.com/golang/go/issues/34964
https://go-review.googlesource.com/c/net/+/203400/2/ipv4/control_bsd.go