### PR TITLE
fix issue #1082

### DIFF
--- a/system/p2p/dht/manage/conns.go
+++ b/system/p2p/dht/manage/conns.go
@@ -277,22 +277,22 @@ func (s *ConnManager) CheckDirection(pid peer.ID) network.Direction {
 }
 
 // OutBounds get out bounds conn peers
-func (s *ConnManager) OutBounds() []peer.ID {
-	var peers []peer.ID
+func (s *ConnManager) OutBounds() map[peer.ID][]network.Conn {
+	var peers = make(map[peer.ID][]network.Conn)
 	for _, con := range s.host.Network().Conns() {
 		if con.Stat().Direction == network.DirOutbound {
-			peers = append(peers, con.RemotePeer())
+			peers[con.RemotePeer()] = append(peers[con.RemotePeer()], con)
 		}
 	}
 	return peers
 }
 
 // InBounds get in bounds conn peers
-func (s *ConnManager) InBounds() []peer.ID {
-	var peers []peer.ID
+func (s *ConnManager) InBounds() map[peer.ID][]network.Conn {
+	var peers = make(map[peer.ID][]network.Conn)
 	for _, con := range s.host.Network().Conns() {
 		if con.Stat().Direction == network.DirInbound {
-			peers = append(peers, con.RemotePeer())
+			peers[con.RemotePeer()] = append(peers[con.RemotePeer()], con)
 		}
 	}
 	return peers
@@ -300,15 +300,19 @@ func (s *ConnManager) InBounds() []peer.ID {
 
 // BoundSize get in out conn bound size
 func (s *ConnManager) BoundSize() (insize int, outsize int) {
+	var outBounds = make(map[peer.ID][]network.Conn)
+	var inBounds = make(map[peer.ID][]network.Conn)
 	for _, con := range s.host.Network().Conns() {
 		if con.Stat().Direction == network.DirOutbound {
-			outsize++
+			outBounds[con.RemotePeer()] = append(outBounds[con.RemotePeer()], con)
 		}
 		if con.Stat().Direction == network.DirInbound {
-			insize++
+			inBounds[con.RemotePeer()] = append(inBounds[con.RemotePeer()], con)
 		}
 	}
-	return insize, outsize
+	insize = len(inBounds)
+	outsize = len(outBounds)
+	return
 }
 
 // GetNetRate get rateinfo


### PR DESCRIPTION
libp2p存在对一个peer 同时有多个连接的情况，所以只统计connect的连接数是不够准确的
调整为统计连接的peer的数量
