### PR TITLE
modify fee set for ProcSignRawTx

### DIFF
--- a/wallet/wallet_proc.go
+++ b/wallet/wallet_proc.go
@@ -93,18 +93,18 @@ func (wallet *Wallet) ProcSignRawTx(unsigned *types.ReqSignRawTx) (string, error
 	if unsigned.NewToAddr != "" {
 		tx.To = unsigned.NewToAddr
 	}
-	if unsigned.Fee != 0 {
-		tx.Fee = unsigned.Fee
-	} else {
-		//get proper fee if not set
-		proper, err := wallet.api.GetProperFee(nil)
-		if err != nil {
-			return "", err
-		}
-		fee, err := tx.GetRealFee(proper.ProperFee)
-		if err != nil {
-			return "", err
-		}
+
+	//To to set fee based on bigger of two fees, on is from sign request and the other is calculated based on tx size
+	tx.Fee = unsigned.Fee
+	proper, err := wallet.api.GetProperFee(nil)
+	if err != nil {
+		return "", err
+	}
+	fee, err := tx.GetRealFee(proper.ProperFee)
+	if err != nil {
+		return "", err
+	}
+	if fee > tx.Fee {
 		tx.Fee = fee
 	}
 


### PR DESCRIPTION
1.因为当前的实现是如果签名的时候设置了交易费，就会按照设置的交易费来设置，而不管其是否满足根据交易体积大小的限制；这样的设置一个小的值，就会不能通过交易池的交易费检查机制；

2.evm提供了gas估算功能功能，对于部分的交易来说，估算出来的gas如果小于根据交易大小计算出来的交易费的，这时候如果让前端再来根据交易大小进行交易费的计算比较，就有点费事情了，所以在ProcSignRawTx该函数内部，把传入的交易费大小和根据交易体积大小计算出来的交易费二者取其大就好了