### PR TITLE
 Improve solo performance

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -365,7 +365,7 @@ func (chain *BlockChain) connectBlock(node *blockNode, blockdetail *types.BlockD
 		panic(err)
 	}
 	writeCost := types.Since(beg)
-	chainlog.Debug("ConnectBlock", "execLocal", txCost, "saveBlk", saveBlkCost, "cacheBlk", cacheCost, "writeBatch", writeCost)
+	chainlog.Info("ConnectBlock", "execLocal", txCost, "saveBlk", saveBlkCost, "cacheBlk", cacheCost, "writeBatch", writeCost)
 	chainlog.Debug("connectBlock info", "height", block.Height, "batchsync", sync, "hash", common.ToHex(blockdetail.Block.Hash(cfg)))
 
 	// 更新最新的高度和header

--- a/blockchain/query_block.go
+++ b/blockchain/query_block.go
@@ -243,7 +243,7 @@ func (chain *BlockChain) ProcGetBlockDetailsMsg(requestblock *types.ReqBlocks) (
 func (chain *BlockChain) ProcAddBlockMsg(broadcast bool, blockdetail *types.BlockDetail, pid string) (*types.BlockDetail, error) {
 	beg := types.Now()
 	defer func() {
-		chainlog.Debug("ProcAddBlockMsg", "height", blockdetail.GetBlock().GetHeight(),
+		chainlog.Info("ProcAddBlockMsg", "height", blockdetail.GetBlock().GetHeight(),
 			"txCount", len(blockdetail.GetBlock().GetTxs()), "recvFrom", pid, "cost", types.Since(beg))
 	}()
 

--- a/blockchain/reduce.go
+++ b/blockchain/reduce.go
@@ -133,18 +133,18 @@ func (chain *BlockChain) deleteTx(batch dbm.Batch, block *types.Block) {
 
 // reduceReceipts 精简receipts
 func reduceReceipts(src *types.BlockBody) []*types.ReceiptData {
-	dst := src.Clone()
-	for i := 0; i < len(dst.Receipts); i++ {
-		for j := 0; j < len(dst.Receipts[i].Logs); j++ {
-			if dst.Receipts[i].Logs[j] != nil {
-				if dst.Receipts[i].Logs[j].Ty == types.TyLogErr { // 为了匹配界面显示
+	receipts := types.CloneReceipts(src.Receipts)
+	for i := 0; i < len(receipts); i++ {
+		for j := 0; j < len(receipts[i].Logs); j++ {
+			if receipts[i].Logs[j] != nil {
+				if receipts[i].Logs[j].Ty == types.TyLogErr { // 为了匹配界面显示
 					continue
 				}
-				dst.Receipts[i].Logs[j].Log = nil
+				receipts[i].Logs[j].Log = nil
 			}
 		}
 	}
-	return dst.Receipts
+	return receipts
 }
 
 // ReduceLocalDB 实时精简localdb

--- a/executor/execenv.go
+++ b/executor/execenv.go
@@ -431,6 +431,10 @@ func (e *executor) loadFlag(key []byte) (int64, error) {
 
 func (e *executor) execFee(tx *types.Transaction, index int) (*types.Receipt, error) {
 	feelog := &types.Receipt{Ty: types.ExecPack}
+	// 非平行连情况下,手续费为0,直接返回
+	if !e.cfg.IsPara() && e.cfg.GetMinTxFeeRate() == 0 {
+		return feelog, nil
+	}
 	execer := string(tx.Execer)
 	ex := e.loadDriver(tx, index)
 	//执行器名称 和  pubkey 相同，费用从内置的执行器中扣除,但是checkTx 中要过
@@ -442,7 +446,7 @@ func (e *executor) execFee(tx *types.Transaction, index int) (*types.Receipt, er
 		}
 	}
 	var err error
-	//公链不允许手续费为0
+	//平行链不收取手续费
 	if !e.cfg.IsPara() && e.cfg.GetMinTxFeeRate() > 0 && !ex.IsFree() {
 		feelog, err = e.processFee(tx)
 		if err != nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -68,8 +68,8 @@ func New(cfg *typ.Chain33Config) *Executor {
 	exec.pluginEnable["stat"] = mcfg.EnableStat
 	exec.pluginEnable["mvcc"] = mcfg.EnableMVCC
 	exec.pluginEnable["addrindex"] = !mcfg.DisableAddrIndex
-	exec.pluginEnable["txindex"] = true
-	exec.pluginEnable["fee"] = true
+	exec.pluginEnable["txindex"] = !mcfg.DisableTxIndex
+	exec.pluginEnable["fee"] = !mcfg.DisableFeeIndex
 	exec.pluginEnable[addrFeeIndex] = mcfg.EnableAddrFeeIndex
 	exec.noneDriverPool = &sync.Pool{
 		New: func() interface{} {

--- a/executor/plugin_fee.go
+++ b/executor/plugin_fee.go
@@ -15,7 +15,7 @@ type feePlugin struct {
 }
 
 func (p *feePlugin) CheckEnable(executor *executor, enable bool) (kvs []*types.KeyValue, ok bool, err error) {
-	return nil, true, nil
+	return nil, enable, nil
 }
 
 func (p *feePlugin) ExecLocal(executor *executor, data *types.BlockDetail) ([]*types.KeyValue, error) {

--- a/executor/plugin_txindex.go
+++ b/executor/plugin_txindex.go
@@ -20,7 +20,7 @@ type txindexPlugin struct {
 }
 
 func (p *txindexPlugin) CheckEnable(executor *executor, enable bool) (kvs []*types.KeyValue, ok bool, err error) {
-	return nil, true, nil
+	return nil, enable, nil
 }
 
 func (p *txindexPlugin) ExecLocal(executor *executor, data *types.BlockDetail) (kvs []*types.KeyValue, err error) {

--- a/system/consensus/solo/solo.go
+++ b/system/consensus/solo/solo.go
@@ -121,7 +121,7 @@ func (client *Client) CreateBlock() {
 
 		// 为方便测试，设定基准测试模式，每个块交易数保持恒定，为配置的最大交易数
 		if len(txs) == 0 || (client.subcfg.BenchMode && len(txs) < maxTxNum) {
-			log.Debug("======SoloWaitMoreTxs======", "currTxNum", len(txs))
+			log.Info("======SoloWaitMoreTxs======", "currTxNum", len(txs))
 			issleep = true
 			continue
 		}

--- a/system/consensus/solo/solo_test.go
+++ b/system/consensus/solo/solo_test.go
@@ -161,7 +161,11 @@ func BenchmarkSoloNewBlock(b *testing.B) {
 	}
 	cfg := testnode.GetDefaultConfig()
 	cfg.GetModuleConfig().Exec.DisableAddrIndex = true
+	cfg.GetModuleConfig().Exec.DisableFeeIndex = true
+	cfg.GetModuleConfig().Exec.DisableTxIndex = true
 	cfg.GetModuleConfig().Mempool.DisableExecCheck = true
+	cfg.GetModuleConfig().Mempool.MinTxFeeRate = 0
+	cfg.SetMinFee(0)
 	cfg.GetModuleConfig().RPC.GrpcBindAddr = "localhost:8802"
 	cfg.GetModuleConfig().Crypto.EnableTypes = []string{secp256k1.Name, none.Name}
 	subcfg := cfg.GetSubConfig()

--- a/system/consensus/solo/solo_test.go
+++ b/system/consensus/solo/solo_test.go
@@ -163,6 +163,7 @@ func BenchmarkSoloNewBlock(b *testing.B) {
 	cfg.GetModuleConfig().Exec.DisableAddrIndex = true
 	cfg.GetModuleConfig().Exec.DisableFeeIndex = true
 	cfg.GetModuleConfig().Exec.DisableTxIndex = true
+	cfg.GetModuleConfig().Exec.DisableTxDupCheck = true
 	cfg.GetModuleConfig().Mempool.DisableExecCheck = true
 	cfg.GetModuleConfig().Mempool.MinTxFeeRate = 0
 	cfg.SetMinFee(0)

--- a/system/consensus/solo/solo_test.go
+++ b/system/consensus/solo/solo_test.go
@@ -191,13 +191,13 @@ func BenchmarkSoloNewBlock(b *testing.B) {
 			//gcli := types.NewChain33Client(conn)
 			pub := mock33.GetGenesisKey().PubKey().Bytes()
 			for {
-				txHeight := atomic.LoadInt64(&height)+types.LowAllowPackHeight/2
+				txHeight := atomic.LoadInt64(&height) + types.LowAllowPackHeight/2
 				//tx := util.CreateNoneTxWithTxHeight(cfg, mock33.GetGenesisKey(), txHeight)
 				//测试去签名情况
 				tx := util.CreateNoneTxWithTxHeight(cfg, nil, txHeight)
 				tx.Signature = &types.Signature{
-					Ty: none.ID,
-					Pubkey:pub,
+					Ty:     none.ID,
+					Pubkey: pub,
 				}
 				//_, err := gcli.SendTransaction(context.Background(), tx)
 				_, err := mock33.GetAPI().SendTx(tx)

--- a/system/consensus/solo/solo_test.go
+++ b/system/consensus/solo/solo_test.go
@@ -184,17 +184,18 @@ func BenchmarkSoloNewBlock(b *testing.B) {
 				panic(err.Error())
 			}
 			defer conn.Close()
-			gcli := types.NewChain33Client(conn)
-			//pub := mock33.GetGenesisKey().PubKey().Bytes()
+			//gcli := types.NewChain33Client(conn)
+			pub := mock33.GetGenesisKey().PubKey().Bytes()
 			for {
-				tx := util.CreateNoneTxWithTxHeight(cfg, mock33.GetGenesisKey(), atomic.LoadInt64(&height)+types.LowAllowPackHeight/2)
+				//tx := util.CreateNoneTxWithTxHeight(cfg, mock33.GetGenesisKey(), atomic.LoadInt64(&height)+types.LowAllowPackHeight/2)
 				//测试去签名情况
-				//tx := util.CreateNoneTxWithTxHeight(cfg, nil, 0)
-				//tx.Signature = &types.Signature{
-				//	Ty: none.ID,
-				//	Pubkey:pub,
-				//}
-				_, err := gcli.SendTransaction(context.Background(), tx)
+				tx := util.CreateNoneTxWithTxHeight(cfg, nil, 0)
+				tx.Signature = &types.Signature{
+					Ty: none.ID,
+					Pubkey:pub,
+				}
+				//_, err := gcli.SendTransaction(context.Background(), tx)
+				_, err := mock33.GetAPI().SendTx(tx)
 				if err != nil {
 					if strings.Contains(err.Error(), "ErrChannelClosed") {
 						return

--- a/system/consensus/solo/solo_test.go
+++ b/system/consensus/solo/solo_test.go
@@ -187,9 +187,10 @@ func BenchmarkSoloNewBlock(b *testing.B) {
 			//gcli := types.NewChain33Client(conn)
 			pub := mock33.GetGenesisKey().PubKey().Bytes()
 			for {
-				//tx := util.CreateNoneTxWithTxHeight(cfg, mock33.GetGenesisKey(), atomic.LoadInt64(&height)+types.LowAllowPackHeight/2)
+				txHeight := atomic.LoadInt64(&height)+types.LowAllowPackHeight/2
+				//tx := util.CreateNoneTxWithTxHeight(cfg, mock33.GetGenesisKey(), txHeight)
 				//测试去签名情况
-				tx := util.CreateNoneTxWithTxHeight(cfg, nil, 0)
+				tx := util.CreateNoneTxWithTxHeight(cfg, nil, txHeight)
 				tx.Signature = &types.Signature{
 					Ty: none.ID,
 					Pubkey:pub,

--- a/system/mempool/accountindex.go
+++ b/system/mempool/accountindex.go
@@ -53,10 +53,10 @@ func (cache *AccountTxIndex) GetAccTxs(addrs *types.ReqAddrs) *types.Transaction
 }
 
 //Remove 根据交易哈希删除对应账户的对应交易
-func (cache *AccountTxIndex) Remove(tx *types.Transaction) {
+func (cache *AccountTxIndex) Remove(tx *types.Transaction, txHash string) {
 	addr := tx.From()
 	if lm, ok := cache.accMap[addr]; ok {
-		lm.Remove(string(tx.Hash()))
+		lm.Remove(txHash)
 		if lm.Size() == 0 {
 			delete(cache.accMap, addr)
 		}
@@ -64,7 +64,7 @@ func (cache *AccountTxIndex) Remove(tx *types.Transaction) {
 }
 
 // Push push transaction to AccountTxIndex
-func (cache *AccountTxIndex) Push(tx *types.Transaction) error {
+func (cache *AccountTxIndex) Push(tx *types.Transaction, txHash string) error {
 	addr := tx.From()
 	_, ok := cache.accMap[addr]
 	if !ok {
@@ -73,7 +73,7 @@ func (cache *AccountTxIndex) Push(tx *types.Transaction) error {
 	if cache.accMap[addr].Size() >= cache.maxperaccount {
 		return types.ErrManyTx
 	}
-	cache.accMap[addr].Push(string(tx.Hash()), tx)
+	cache.accMap[addr].Push(txHash, tx)
 	return nil
 }
 

--- a/system/mempool/cache.go
+++ b/system/mempool/cache.go
@@ -66,10 +66,10 @@ func (cache *txCache) Remove(hash string) {
 	if err != nil {
 		mlog.Error("Remove", "cache Remove err", err)
 	}
-	cache.AccountTxIndex.Remove(tx)
-	cache.LastTxCache.Remove(tx)
+	cache.AccountTxIndex.Remove(tx, hash)
+	cache.LastTxCache.Remove(hash)
 	cache.totalFee -= tx.Fee
-	cache.SHashTxCache.Remove(tx)
+	cache.SHashTxCache.Remove(hash)
 }
 
 //Exist 是否存在
@@ -114,17 +114,18 @@ func (cache *txCache) Push(tx *types.Transaction) error {
 		return types.ErrManyTx
 	}
 	item := &Item{Value: tx, Priority: tx.Fee, EnterTime: types.Now().Unix()}
+	txHash := tx.Hash()
 	err := cache.qcache.Push(item)
 	if err != nil {
 		return err
 	}
-	err = cache.AccountTxIndex.Push(tx)
+	err = cache.AccountTxIndex.Push(tx, string(txHash))
 	if err != nil {
 		return err
 	}
-	cache.LastTxCache.Push(tx)
+	cache.LastTxCache.Push(tx, string(txHash))
 	cache.totalFee += tx.Fee
-	cache.SHashTxCache.Push(tx)
+	cache.SHashTxCache.Push(tx, txHash)
 	return nil
 }
 

--- a/system/mempool/lasttx.go
+++ b/system/mempool/lasttx.go
@@ -38,7 +38,7 @@ func (cache *LastTxCache) Push(tx *types.Transaction, txHash string) {
 	if cache.l.Size() >= cache.max {
 		v := cache.l.GetTop()
 		if v != nil {
-			cache.Remove(txHash)
+			cache.Remove(string(v.(*types.Transaction).Hash()))
 		}
 	}
 	cache.l.Push(txHash, tx)

--- a/system/mempool/lasttx.go
+++ b/system/mempool/lasttx.go
@@ -29,17 +29,17 @@ func (cache *LastTxCache) GetLatestTx() (txs []*types.Transaction) {
 }
 
 //Remove remove tx of last cache
-func (cache *LastTxCache) Remove(tx *types.Transaction) {
-	cache.l.Remove(string(tx.Hash()))
+func (cache *LastTxCache) Remove(txHash string) {
+	cache.l.Remove(txHash)
 }
 
 //Push tx into LastTxCache
-func (cache *LastTxCache) Push(tx *types.Transaction) {
+func (cache *LastTxCache) Push(tx *types.Transaction, txHash string) {
 	if cache.l.Size() >= cache.max {
 		v := cache.l.GetTop()
 		if v != nil {
-			cache.Remove(v.(*types.Transaction))
+			cache.Remove(txHash)
 		}
 	}
-	cache.l.Push(string(tx.Hash()), tx)
+	cache.l.Push(txHash, tx)
 }

--- a/system/mempool/shorthashtx.go
+++ b/system/mempool/shorthashtx.go
@@ -34,15 +34,14 @@ func (cache *SHashTxCache) GetSHashTxCache(sHash string) *types.Transaction {
 }
 
 //Remove remove tx of SHashTxCache
-func (cache *SHashTxCache) Remove(tx *types.Transaction) {
-	txhash := tx.Hash()
-	cache.l.Remove(types.CalcTxShortHash(txhash))
+func (cache *SHashTxCache) Remove(txHash string) {
+	cache.l.Remove(types.CalcTxShortHash(types.Str2Bytes(txHash)))
 	//shashlog.Debug("SHashTxCache:Remove", "shash", types.CalcTxShortHash(txhash), "txhash", common.ToHex(txhash))
 }
 
 //Push tx into SHashTxCache
-func (cache *SHashTxCache) Push(tx *types.Transaction) {
-	shash := types.CalcTxShortHash(tx.Hash())
+func (cache *SHashTxCache) Push(tx *types.Transaction, txHash []byte) {
+	shash := types.CalcTxShortHash(txHash)
 
 	if cache.Exist(shash) {
 		shashlog.Error("SHashTxCache:Push:Exist", "oldhash", common.ToHex(cache.GetSHashTxCache(shash).Hash()), "newhash", common.ToHex(tx.Hash()))

--- a/types/bench_test.go
+++ b/types/bench_test.go
@@ -138,3 +138,26 @@ func Test_ProtoOneOfReflect(t *testing.T) {
 	des = tx.ProtoReflect().Descriptor()
 	require.Equal(t, 0, des.Oneofs().Len())
 }
+
+func BenchmarkProtoReset(b *testing.B) {
+	_, priv := util.Genaddress()
+	cfg := types.NewChain33Config(types.GetDefaultCfgstring())
+	tx := util.CreateNoneTx(cfg, priv)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tx.Reset()
+	}
+}
+
+func BenchmarkTxHash(b *testing.B) {
+
+	_, priv := util.Genaddress()
+	cfg := types.NewChain33Config(types.GetDefaultCfgstring())
+	tx := util.CreateNoneTx(cfg, priv)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tx.Hash()
+	}
+}

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -283,6 +283,7 @@ type Exec struct {
 	EnableAddrFeeIndex bool `json:"enableAddrFeeIndex,omitempty"`
 	DisableTxIndex     bool `json:"disableTxIndex,omitempty"`
 	DisableFeeIndex    bool `json:"disableFeeIndex,omitempty"`
+	DisableTxDupCheck  bool `json:"disableTxDupCheck,omitempty"`
 }
 
 // Pprof 配置

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -281,8 +281,8 @@ type Exec struct {
 	// 是否保存token交易信息
 	SaveTokenTxList    bool `json:"saveTokenTxList,omitempty"`
 	EnableAddrFeeIndex bool `json:"enableAddrFeeIndex,omitempty"`
-	DisableTxIndex bool     `json:"disableTxIndex,omitempty"`
-	DisableFeeIndex bool    `json:"disableFeeIndex,omitempty"`
+	DisableTxIndex     bool `json:"disableTxIndex,omitempty"`
+	DisableFeeIndex    bool `json:"disableFeeIndex,omitempty"`
 }
 
 // Pprof 配置

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -281,6 +281,8 @@ type Exec struct {
 	// 是否保存token交易信息
 	SaveTokenTxList    bool `json:"saveTokenTxList,omitempty"`
 	EnableAddrFeeIndex bool `json:"enableAddrFeeIndex,omitempty"`
+	DisableTxIndex bool     `json:"disableTxIndex,omitempty"`
+	DisableFeeIndex bool    `json:"disableFeeIndex,omitempty"`
 }
 
 // Pprof 配置

--- a/types/executor.go
+++ b/types/executor.go
@@ -534,7 +534,8 @@ func (base *ExecTypeBase) decodePayloadValue(tx *Transaction) (string, reflect.V
 	}
 	action, err := base.child.DecodePayload(tx)
 	if err != nil || action == nil {
-		tlog.Error("DecodePayload", "err", err, "exec", string(tx.Execer))
+		// 目前存证交易会解析失败, 这个错误不会影响
+		tlog.Debug("DecodePayload", "err", err, "exec", string(tx.Execer))
 		return "", nilValue, err
 	}
 	name, ty, val, err := GetActionValue(action, base.child.GetFuncMap())

--- a/types/types.go
+++ b/types/types.go
@@ -202,13 +202,26 @@ func GetRealExecName(execer []byte) []byte {
 	return execer
 }
 
-//Encode  protobuf V2(golang/protobuf 1.4.0+)
+// EncodeWithBuffer encode with input buffer
+func EncodeWithBuffer(data proto.Message, buf *proto.Buffer) []byte {
+	return encodeProto(data, buf)
+}
+
+//Encode encode msg
+func Encode(data proto.Message) []byte {
+	return encodeProto(data, nil)
+}
+
+// protobuf V2(golang/protobuf 1.4.0+)
 // 版本默认Marshal接口不保证序列化结果一致性, 需要主动设置相关标志
 // 即使设置了deterministic标志, protobuf官方也不保证后续版本升级以及跨语言的序列化结果一致
 // 即该标志只能保证当前版本具备一致性
-func Encode(data proto.Message) []byte {
-	var b [0]byte
-	buf := proto.NewBuffer(b[:])
+func encodeProto(data proto.Message, buf *proto.Buffer) []byte {
+
+	if buf == nil {
+		var b [0]byte
+		buf = proto.NewBuffer(b[:])
+	}
 	// 设置确定性编码
 	buf.SetDeterministic(true)
 	err := buf.Marshal(data)
@@ -532,7 +545,7 @@ func (b *BlockDetail) Clone() *BlockDetail {
 	}
 	return &BlockDetail{
 		Block:          b.Block.Clone(),
-		Receipts:       cloneReceipts(b.Receipts),
+		Receipts:       CloneReceipts(b.Receipts),
 		KV:             cloneKVList(b.KV),
 		PrevStatusHash: b.PrevStatusHash,
 	}
@@ -598,7 +611,7 @@ func (b *BlockBody) Clone() *BlockBody {
 	}
 	return &BlockBody{
 		Txs:        cloneTxs(b.Txs),
-		Receipts:   cloneReceipts(b.Receipts),
+		Receipts:   CloneReceipts(b.Receipts),
 		MainHash:   b.MainHash,
 		MainHeight: b.MainHeight,
 		Hash:       b.Hash,
@@ -606,8 +619,8 @@ func (b *BlockBody) Clone() *BlockBody {
 	}
 }
 
-//cloneReceipts 浅拷贝交易回报
-func cloneReceipts(b []*ReceiptData) []*ReceiptData {
+//CloneReceipts 浅拷贝交易回报
+func CloneReceipts(b []*ReceiptData) []*ReceiptData {
 	if b == nil {
 		return nil
 	}

--- a/util/exec.go
+++ b/util/exec.go
@@ -157,6 +157,9 @@ func CheckTxDup(client queue.Client, txs []*types.TransactionCache, height int64
 	var checkHashList types.TxHashList
 	types.AssertConfig(client)
 	cfg := client.GetConfig()
+	if cfg.GetModuleConfig().Exec.DisableTxDupCheck {
+		return txs, nil
+	}
 	if cfg.IsFork(height, "ForkCheckTxDup") {
 		txs = DelDupTx(txs)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -328,7 +328,7 @@ func PreExecBlock(client queue.Client, prevStateRoot []byte, block *types.Block,
 	go func() {
 		beg := types.Now()
 		defer func() {
-			ulog.Info("PreExecBlock", "height", block.GetHeight(), "CheckTxDup", types.Since(beg))
+			ulog.Debug("PreExecBlock", "height", block.GetHeight(), "CheckTxDup", types.Since(beg))
 		}()
 		//check tx Duplicate
 		var err error

--- a/util/util.go
+++ b/util/util.go
@@ -318,7 +318,7 @@ func PreExecBlock(client queue.Client, prevStateRoot []byte, block *types.Block,
 			}
 		}
 		signOK := types.VerifySignature(config, block, unverifiedTxs)
-		ulog.Debug("PreExecBlock", "height", block.GetHeight(), "checkCount", len(unverifiedTxs), "CheckSign", types.Since(beg))
+		ulog.Info("PreExecBlock", "height", block.GetHeight(), "checkCount", len(unverifiedTxs), "CheckSign", types.Since(beg))
 		if !signOK {
 			return nil, nil, types.ErrSign
 		}
@@ -328,7 +328,7 @@ func PreExecBlock(client queue.Client, prevStateRoot []byte, block *types.Block,
 	go func() {
 		beg := types.Now()
 		defer func() {
-			ulog.Debug("PreExecBlock", "height", block.GetHeight(), "CheckTxDup", types.Since(beg))
+			ulog.Info("PreExecBlock", "height", block.GetHeight(), "CheckTxDup", types.Since(beg))
 		}()
 		//check tx Duplicate
 		var err error
@@ -350,7 +350,7 @@ func PreExecBlock(client queue.Client, prevStateRoot []byte, block *types.Block,
 	beg = types.Now()
 	//对区块的正确性保持乐观，交易查重和执行并行处理，提高效率
 	receipts, err := ExecTx(client, prevStateRoot, block)
-	ulog.Debug("PreExecBlock", "height", block.GetHeight(), "ExecTx", types.Since(beg))
+	ulog.Info("PreExecBlock", "height", block.GetHeight(), "ExecTx", types.Since(beg))
 	beg = types.Now()
 
 	//检查交易查重结果
@@ -363,7 +363,7 @@ func PreExecBlock(client queue.Client, prevStateRoot []byte, block *types.Block,
 		block.Txs = types.CacheToTxs(cacheTxs)
 		receipts, err = ExecTx(client, prevStateRoot, block)
 	}
-	ulog.Debug("PreExecBlock", "height", block.GetHeight(), "WaitDupCheck", types.Since(beg))
+	ulog.Info("PreExecBlock", "height", block.GetHeight(), "WaitDupCheck", types.Since(beg))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/wallet/wallet_proc.go
+++ b/wallet/wallet_proc.go
@@ -1116,7 +1116,7 @@ func (wallet *Wallet) buildAndStoreWalletTxDetail(param *buildStoreWalletTxDetai
 		txdetail.ActionName = txdetail.Tx.ActionName()
 		txdetail.Amount, Err = param.tx.Amount()
 		if Err != nil {
-			walletlog.Error("buildAndStoreWalletTxDetail Amount err", "Height", param.block.Block.Height, "index", param.index)
+			walletlog.Debug("buildAndStoreWalletTxDetail Amount err", "Height", param.block.Block.Height, "index", param.index)
 		}
 		txdetail.Fromaddr = param.senderRecver
 		//txdetail.Spendrecv = param.utxos


### PR DESCRIPTION
### 本地执行性能优化
8核16g, 5w执行并发

#### 配置调整
- 支持相关索引开关配置, 可在性能测试模式下关闭
- 支持关闭交易查重

#### 交易哈希缓存优化, fix #899  
直接实现交易哈希缓存,涉及跨模块,比较困难, 主要通过以下几个方面缓解交易哈希计算带来的gc,cpu计算等问题

- 计算哈希时使用的交易对象,采用内存池复用
- probuf编码接口支持输入复用buffer参数, 对于交易结构的buffer使用内存池
- mempool相关接口复用交易哈希计算, 减少重复计算问题


#### 交易执行优化

优化细节执行流程,提高效率
