### PR TITLE
update: set libp2p new stream timeout to 3s

### DIFF
--- a/system/p2p/dht/protocol/p2pstore/handler.go
+++ b/system/p2p/dht/protocol/p2pstore/handler.go
@@ -398,7 +398,7 @@ func (p *Protocol) handleEventNotifyStoreChunk(m *queue.Message) {
 	//如果本节点是扩展路由表中距离该chunk最近的 `Percentage` 节点之一，则保存数据；否则不需要保存数据
 	extendRoutingTable := p.getExtendRoutingTable()
 	pids := extendRoutingTable.NearestPeers(genDHTID(req.ChunkHash), extendRoutingTable.Size())
-	if len(pids) > 0 && kb.Closer(pids[len(pids)*p.SubConfig.Percentage/100], p.Host.ID(), genChunkNameSpaceKey(req.ChunkHash)) {
+	if len(pids) > 0 && kb.Closer(pids[(len(pids)-1)*p.SubConfig.Percentage/100], p.Host.ID(), genChunkNameSpaceKey(req.ChunkHash)) {
 		return
 	}
 	log.Info("handleEventNotifyStoreChunk", "peers count", len(pids), "chunk hash", hex.EncodeToString(req.ChunkHash), "start", req.Start, "end", req.End)

--- a/system/p2p/dht/protocol/p2pstore/query.go
+++ b/system/p2p/dht/protocol/p2pstore/query.go
@@ -444,7 +444,7 @@ func (p *Protocol) mustFetchChunk(req *types.ChunkInfoMsg) (*types.BlockBodys, p
 
 	// 优先从已经建立连接的节点上查找数据，因为建立新的连接会耗时，且会导致网络拓扑结构发生变化
 	loop1Start := time.Now()
-	Loop1:
+Loop1:
 	for {
 		select {
 		case <-ctx.Done():
@@ -489,7 +489,7 @@ func (p *Protocol) mustFetchChunk(req *types.ChunkInfoMsg) (*types.BlockBodys, p
 
 	// 其次从未建立连接但已保存ip等信息的的节点上获取数据
 	loop2Start := time.Now()
-	Loop2:
+Loop2:
 	for {
 		select {
 		case <-ctx.Done():
@@ -559,7 +559,7 @@ func (p *Protocol) mustFetchChunk(req *types.ChunkInfoMsg) (*types.BlockBodys, p
 }
 
 func (p *Protocol) fetchChunkFromPeer(params *types.ChunkInfoMsg, pid peer.ID) (*types.BlockBodys, []peer.ID, error) {
-	ctx, cancel := context.WithTimeout(p.Ctx, time.Second * 3)
+	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*3)
 	defer cancel()
 	p.Host.ConnManager().Protect(pid, fetchChunk)
 	defer p.Host.ConnManager().Unprotect(pid, fetchChunk)

--- a/system/p2p/dht/protocol/p2pstore/refresh.go
+++ b/system/p2p/dht/protocol/p2pstore/refresh.go
@@ -42,12 +42,10 @@ func (p *Protocol) refreshLocalChunk() {
 			p.chunkInfoCacheMutex.Unlock()
 			syncNum++
 			p.chunkToSync <- msg
-			log.Info("refreshLocalChunk sync", "save num", saveNum, "sync num", syncNum, "delete num", deleteNum, "chunkHash", hex.EncodeToString(info.ChunkHash), "start", info.Start)
 
 		} else {
 			deleteNum++
 			p.chunkToDelete <- msg
-			log.Info("refreshLocalChunk delete", "save num", saveNum, "sync num", syncNum, "delete num", deleteNum, "chunkHash", hex.EncodeToString(info.ChunkHash), "start", info.Start)
 		}
 	}
 	log.Info("refreshLocalChunk", "save num", saveNum, "sync num", syncNum, "delete num", deleteNum, "time cost", time.Since(start), "exRT size", p.getExtendRoutingTable().Size())

--- a/system/p2p/dht/protocol/peer/peerinfo.go
+++ b/system/p2p/dht/protocol/peer/peerinfo.go
@@ -164,7 +164,7 @@ func (p *Protocol) detectNodeAddr() {
 }
 
 func (p *Protocol) queryPeerInfoOld(pid peer.ID) (*types.Peer, error) {
-	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*5)
+	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*3)
 	defer cancel()
 	stream, err := p.Host.NewStream(ctx, pid, peerInfoOld)
 	if err != nil {
@@ -199,7 +199,7 @@ func (p *Protocol) queryPeerInfoOld(pid peer.ID) (*types.Peer, error) {
 }
 
 func (p *Protocol) queryPeerInfo(pid peer.ID) (*types.Peer, error) {
-	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*5)
+	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*3)
 	defer cancel()
 	stream, err := p.Host.NewStream(ctx, pid, peerInfo)
 	if err != nil {
@@ -217,7 +217,7 @@ func (p *Protocol) queryPeerInfo(pid peer.ID) (*types.Peer, error) {
 }
 
 func (p *Protocol) queryVersionOld(pid peer.ID) error {
-	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*5)
+	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*3)
 	defer cancel()
 	stream, err := p.Host.NewStream(ctx, pid, peerVersionOld)
 	if err != nil {
@@ -263,7 +263,7 @@ func (p *Protocol) queryVersionOld(pid peer.ID) error {
 }
 
 func (p *Protocol) queryVersion(pid peer.ID) error {
-	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*5)
+	ctx, cancel := context.WithTimeout(p.Ctx, time.Second*3)
 	defer cancel()
 	stream, err := p.Host.NewStream(ctx, pid, peerVersion)
 	if err != nil {


### PR DESCRIPTION
libp2p stream超时控制分为两个部分，一个是建立stream（即数据流，基于节点之间的tcp连接）耗时，另一个是从stream中读写数据的耗时。
1. 节点之间建立新的tcp连接耗时为毫秒级别，基于tcp连接建立stream耗时为微妙级别，通过NewStream接口的context进行控制。节点拥堵时该耗时会变长，因此统一设置NewStream的超时为3秒，超过3秒则选择另外的节点进行通信。由于查询分片数据会与比较多的节点进行通信，所以该超时时间对获取分片数据的耗时的影响无法忽略。
2. 节点之间通过stream读写数据则根据数据量的多少有不同的耗时，通过stream.SetDeadline来进行超时控制，不同的业务逻辑应根据具体的通信数据设定合理的超时时间。