### PR TITLE
dht:add maxMsgSize config for pubsub

### DIFF
--- a/system/consensus/solo/solo.go
+++ b/system/consensus/solo/solo.go
@@ -121,7 +121,7 @@ func (client *Client) CreateBlock() {
 
 		// 为方便测试，设定基准测试模式，每个块交易数保持恒定，为配置的最大交易数
 		if len(txs) == 0 || (client.subcfg.BenchMode && len(txs) < maxTxNum) {
-			if len(txs) > 100 {
+			if len(txs) > 1000 {
 				log.Info("======SoloWaitMoreTxs======", "currTxNum", len(txs))
 			}
 			issleep = true

--- a/system/p2p/dht/extension/pubsub.go
+++ b/system/p2p/dht/extension/pubsub.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/33cn/chain33/types"
+
 	"github.com/33cn/chain33/common/log/log15"
 	p2ptypes "github.com/33cn/chain33/system/p2p/dht/types"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -43,7 +45,11 @@ type SubMsg *pubsub.Message
 type SubCallBack func(topic string, msg SubMsg)
 
 func setPubSubParameters(psConf *p2ptypes.PubSubConfig) {
-
+	// mb -> byte
+	psConf.MaxMsgSize *= 1 << 20
+	if psConf.MaxMsgSize <= 0 {
+		psConf.MaxMsgSize = types.MaxBlockSize
+	}
 	if psConf.PeerOutboundQueueSize <= 0 {
 		psConf.PeerOutboundQueueSize = 128
 	}
@@ -107,7 +113,8 @@ func NewPubSub(ctx context.Context, host host.Host, psConf *p2ptypes.PubSubConfi
 	psOpts = append(psOpts, pubsub.WithFloodPublish(true),
 		pubsub.WithPeerOutboundQueueSize(psConf.PeerOutboundQueueSize),
 		pubsub.WithValidateQueueSize(psConf.ValidateQueueSize),
-		pubsub.WithPeerExchange(psConf.EnablePeerExchange))
+		pubsub.WithPeerExchange(psConf.EnablePeerExchange),
+		pubsub.WithMaxMessageSize(psConf.MaxMsgSize))
 
 	//选择使用GossipSub
 	ps, err := pubsub.NewGossipSub(ctx, host, psOpts...)

--- a/system/p2p/dht/types/types.go
+++ b/system/p2p/dht/types/types.go
@@ -110,4 +110,7 @@ type PubSubConfig struct {
 	// GossipSubHistoryLength controls the size of the message cache used for gossip.
 	// The message cache will remember messages for GossipSubHistoryLength heartbeats.
 	GossipSubHistoryLength int `json:"gossipSubHistoryLength,omitempty"`
+
+	// MaxMsgSize, max message size in pub sub(MB)
+	MaxMsgSize int `json:"maxMsgSize,omitempty"`
 }


### PR DESCRIPTION

fix #1127 

1. 适配新版pubsub库, 支持最大发布数据大小可配置, 内置的为 1MB
2. 默认最大数据大小为chain33支持的最大区块, 即20MB