### PR TITLE
Bug: 🐛version control

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "feat"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "feat"
+      include: "scope"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "feat"
+      include: "scope"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: release
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Golang env
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+        id: go
+
+      - name: checkout repo
+        uses: actions/checkout@v2
+
+      - name: compile binary
+        run: make all-arch
+
+      - name : Upload artifact bin
+        uses: actions/upload-artifact@v2
+        with:
+          name: chain33-artifact
+          path: build/*.tar
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic
+        with:
+          branch: master
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Do something when a new release published
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          echo ${{ steps.semantic.outputs.new_release_version }}
+          echo ${{ steps.semantic.outputs.new_release_major_version }}
+          echo ${{ steps.semantic.outputs.new_release_minor_version }}
+          echo ${{ steps.semantic.outputs.new_release_patch_version }}
+
+

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,17 @@
+{ "branches": ["master", "next"], 
+  "plugins": [
+      "@semantic-release/commit-analyzer", #Default 1
+      "@semantic-release/release-notes-generator", #Default 2
+      [
+        "@semantic-release/changelog",
+        { "changelogFile": "CHANGELOG.md", "changelogTitle": "changelog" },
+      ],
+      # "@semantic-release/npm", #Default 3
+      # "@semantic-release/github", #Default 4
+      [
+          "@semantic-release/github",
+          {"assets": ["build/*.tar"]}
+      ],
+      "@semantic-release/git",
+    ] 
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# golang1.12 or latest
+# golang1.15 or latest
 # 1. make help
 # 2. make dep
 # 3. make build
@@ -14,8 +14,11 @@ SIGNATORY := build/signatory-server
 MINER := build/miner_accounts
 AUTOTEST := build/autotest/autotest
 SRC_AUTOTEST := github.com/33cn/chain33/cmd/autotest
-LDFLAGS := -ldflags "-w -s"
-BUILD_FLAGS = -ldflags "-X github.com/33cn/chain33/common/version.GitCommit=`git rev-parse --short=8 HEAD`"
+LDFLAGS := -ldflags '-w -s'
+#BUILDTIME=$(shell date -u)
+#GitCommit=$(git rev-parse --short=8 HEAD)
+BUILD_FLAGS = -ldflags '-X "github.com/33cn/chain33/common/version.GitCommit=$(shell git rev-parse --short=8 HEAD)" \
+                        -X "github.com/33cn/chain33/common/version.BuildTime=[$(shell date +"%Y-%m-%d %H:%M:%S %A")]"'
 MKPATH=$(abspath $(lastword $(MAKEFILE_LIST)))
 MKDIR=$(dir $(MKPATH))
 DAPP := ""
@@ -27,7 +30,6 @@ default: build cli depends
 dep: ## Get the dependencies
 	@go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
 	@go get -u golang.org/x/tools/cmd/goimports
-	@go get -u github.com/mitchellh/gox
 	@go get -u github.com/vektra/mockery/.../
 	@go get -u mvdan.cc/sh/cmd/shfmt
 	@go get -u mvdan.cc/sh/cmd/gosh
@@ -35,25 +37,62 @@ dep: ## Get the dependencies
 	@apt install clang-format
 	@apt install shellcheck
 
-all: ## Builds for multiple platforms
-	@gox  $(LDFLAGS) $(SRC)
-	@cp cmd/chain33/chain33.toml build/
-	@cp cmd/chain33/bityuan.toml build/
-	@mv chain33* build/
+cli: ## Build cli binary
+	@go build $(BUILD_FLAGS) -v -o $(CLI) $(SRC_CLI)
 
-build: ## Build the binary file
+build:cli ## Build the binary file
 	@go build $(BUILD_FLAGS) -v -o  $(APP) $(SRC)
 	@cp cmd/chain33/chain33.toml build/
 	@cp cmd/chain33/bityuan.toml build/
 
 release: ## Build the binary file
-	@go build -v -o $(APP) $(LDFLAGS) $(SRC)
+	@go build $(BUILD_FLAGS) -v -o $(APP) $(LDFLAGS) $(SRC)
+	@go build $(BUILD_FLAGS) -v -o $(CLI) $(LDFLAGS) $(SRC_CLI)
 	@cp cmd/chain33/chain33.toml build/
 	@cp cmd/chain33/bityuan.toml build/
-	@cp cmd/chain33/chain33.para.toml build/
+#	@cp cmd/chain33/chain33.para.toml build/
 
-cli: ## Build cli binary
-	@go build -v -o $(CLI) $(SRC_CLI)
+PLATFORM_LIST = \
+	darwin-amd64 \
+	darwin-arm64 \
+	linux-amd64 \
+
+WINDOWS_ARCH_LIST = \
+	windows-amd64
+
+GOBUILD=go build $(BUILD_FLAGS) $(LDFLAGS)
+
+darwin-amd64:
+	GOARCH=amd64 GOOS=darwin $(GOBUILD) -o $(APP)-$@ $(SRC)
+	GOARCH=amd64 GOOS=darwin $(GOBUILD) -o $(CLI)-$@ $(SRC_CLI)
+	cp cmd/chain33/chain33.toml build/ && cd build && \
+	chmod +x chain33-darwin-amd64 && \
+	chmod +x chain33-cli-darwin-amd64 && \
+	tar -zcvf chain33-darwin-amd64.tar chain33-darwin-amd64 chain33-cli-darwin-amd64 chain33.toml
+
+darwin-arm64:
+	GOARCH=arm64 GOOS=darwin $(GOBUILD) -o $(APP)-$@ $(SRC)
+	GOARCH=arm64 GOOS=darwin $(GOBUILD) -o $(CLI)-$@ $(SRC_CLI)
+	cp cmd/chain33/chain33.toml build/ && cd build && \
+	chmod +x chain33-darwin-arm64 && \
+	chmod +x chain33-cli-darwin-arm64 && \
+	tar -zcvf chain33-darwin-arm64.tar chain33-darwin-arm64 chain33-cli-darwin-arm64 chain33.toml
+
+linux-amd64:
+	GOARCH=amd64 GOOS=linux $(GOBUILD) -o $(APP)-$@ $(SRC)
+	GOARCH=amd64 GOOS=linux $(GOBUILD) -o $(CLI)-$@ $(SRC_CLI)
+	cp cmd/chain33/chain33.toml build/ && cd build && \
+	chmod +x chain33-linux-amd64 && \
+	chmod +x chain33-cli-linux-amd64 && \
+	tar -zcvf chain33-linux-amd64.tar chain33-linux-amd64 chain33-cli-linux-amd64 chain33.toml
+
+windows-amd64:
+	GOARCH=amd64 GOOS=windows $(GOBUILD) -o $(APP)-$@.exe $(SRC)
+	GOARCH=amd64 GOOS=windows $(GOBUILD) -o $(CLI)-$@.exe $(SRC_CLI)
+	cp cmd/chain33/chain33.toml build/ && cd build && \
+	tar -zcvf  chain33-windows-amd64.tar chain33-windows-amd64.exe chain33-cli-windows-amd64.exe chain33.toml
+
+all-arch: $(PLATFORM_LIST) $(WINDOWS_ARCH_LIST)
 
 execblock: ## Build cli binary
 	@go build -v -o build/execblock github.com/33cn/chain33/cmd/execblock

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -18,6 +18,7 @@ var (
 	storeversion     = "1.0.0"
 	appversion       = "1.0.0"
 	GitCommit        string
+	BuildTime        string
 )
 
 //GetLocalDBKeyList 获取本地key列表

--- a/util/cli/chain33.go
+++ b/util/cli/chain33.go
@@ -67,7 +67,7 @@ var (
 func RunChain33(name, defCfg string) {
 	flag.Parse()
 	if *versionCmd {
-		fmt.Println(version.GetVersion())
+		fmt.Println(fmt.Sprintf("%s %s", version.GetVersion(), version.BuildTime))
 		return
 	}
 	if *configPath == "" {

--- a/util/cli/cli.go
+++ b/util/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/33cn/chain33/common/log"
+	"github.com/33cn/chain33/common/version"
 	"github.com/33cn/chain33/pluginmgr"
 	"github.com/33cn/chain33/rpc/jsonclient"
 	rpctypes "github.com/33cn/chain33/rpc/types"
@@ -58,8 +59,9 @@ func Run(RPCAddr, ParaName, name string) {
 	types.SetCliSysParam(chain33Cfg.GetTitle(), chain33Cfg)
 
 	rootCmd := &cobra.Command{
-		Use:   chain33Cfg.GetTitle() + "-cli",
-		Short: chain33Cfg.GetTitle() + " client tools",
+		Use:     chain33Cfg.GetTitle() + "-cli",
+		Short:   chain33Cfg.GetTitle() + " client tools",
+		Version: fmt.Sprintf("%s %s", version.GetVersion(), version.BuildTime),
 	}
 
 	closeCmd := &cobra.Command{


### PR DESCRIPTION
- 统一化chain33、chain33-cli版本，通过-v 或者 --version 选项命查看版本号，格式为：版本号-提交hash [构建日期]。**主要为了让运维或者使用人员查看版本，以及查看构建的日期，版本保持一致。**
```shell
 
./chain33-cli --version
chain33-cli version 1.65.2-945de0b0 [2021-10-14 11:30:32 Thursday]

./chain33 -v
1.65.2-945de0b0 [2021-10-14 11:30:35 Thursday]

```

- 增加**自动发布版本流程**通过GitHub action workflow完成，版本的发布取决于代码**commit提交规范**，规范如下：[**规范**](https://semantic-release.gitbook.io/semantic-release/#how-does-it-work)
![image](https://user-images.githubusercontent.com/16421423/137260379-693b71f6-2580-4e0c-a24c-f498381764bf.png)
  - **版本X.Y.Z: 分别对应主要版本、次要版本、bug修复**。
  - 默认情况下 push 或者 pull_request master分支才会触发自动发布流程，并且只有 feat 和 fix 提交才会触发版本升级，版本号按照语义化版本规则自动生成。即:
版本号按照x.y.z格式组织（git tag 会加上v前缀，如v1.0.0），提交commit时，若想发布版本，请按如下规范提交commit信息：
bug fix 发布会增加修订版本号（如 1.0.0 –> 1.0.1）
feature 发布会增加次版本号（如1.0.0 –> 1.1.0）
break change feature 发布会增加主版本号（如1.1.1 –> 2.0.0，官方建议这种不兼容的升级应该推送到 next 分支开发，之后合并到 master）

注意：第一次使用 semantic-release 发布会生成1.0.0版本，同时，semantic-release 会兼顾到旧的发布版本，如果之前有过 git tag，则会在旧的 tag 基础之上再做语义化版本控制。

- golang1.17版本构建。

- 版本发布时会产生下列行为：
  - 基于master分支构建github上的tag 与 release，自动增加版本号。
  - 获取上个版本与当前版本的git log的提交的变动信息，作为**github release说明**，同时也会追加到**CHANGELOG.md**文件里面。
  - 产生**chain33-darwin-arm64.tar、chain33-darwin-amd64.tar、chain33-linux-amd64.tar 、chain33-windows-amd64.tar作为release发布内容**。其中包括各个平台的版本cli命令i、chain33 服务、运行的配置文件。
  - 只在master分支push或者pull_request行为并且遵循一定的commit提交信息规范时才会自动构建。
  - 在github action 页面也会上传构建的内容。

- 相关semantic-release参考资料如下：
https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration
https://github.com/semantic-release/semantic-release
https://github.com/marketplace/actions/action-for-semantic-release
