### PR TITLE
adjust semantic-release commit message conventions to jshint

### DIFF
--- a/.github/workflows/automake.yml
+++ b/.github/workflows/automake.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           branch: master
           extra_plugins: |
+            conventional-changelog/conventional-changelog-jshint
             @google/semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           branch: master
           extra_plugins: |
+            conventional-changelog/conventional-changelog-jshint
             @google/semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,6 +1,17 @@
 { "branches": ["master", "next"],
   "plugins": [
-    "@semantic-release/commit-analyzer", #Default 1
+    [
+        "@semantic-release/commit-analyzer",
+      {
+        "preset": "jshint"
+      }
+    ],
+    [
+        "@semantic-release/release-notes-generator",
+      {
+        "preset": "jshint"
+      }
+    ],
     "@semantic-release/release-notes-generator", #Default 2
     [
         "@google/semantic-release-replace-plugin",


### PR DESCRIPTION
**语义调整：**
改为jshint语义：https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jshint

![image](https://user-images.githubusercontent.com/16421423/137907123-9a1d70c4-a313-4bb1-895c-3784bcb7a58d.png)

