### PR TITLE
Add pubsub tracer

### DIFF
--- a/system/p2p/dht/extension/pubsub.go
+++ b/system/p2p/dht/extension/pubsub.go
@@ -110,7 +110,7 @@ func setPubSubParameters(psConf *p2ptypes.PubSubConfig) {
 func NewPubSub(ctx context.Context, host host.Host, psConf *p2ptypes.PubSubConfig) (*PubSub, error) {
 	p := &PubSub{
 		topics: make(TopicMap),
-		pt:     newPubsubTracer(ctx),
+		pt:     newPubsubTracer(ctx, host),
 	}
 	setPubSubParameters(psConf)
 

--- a/system/p2p/dht/extension/trace.go
+++ b/system/p2p/dht/extension/trace.go
@@ -1,0 +1,102 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package extension
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/protocol"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+//  pubsubTracer pubsub 系统内部事件跟踪器
+type pubsubTracer struct {
+	blankTracer
+	subLock     sync.RWMutex
+	msgLock     sync.Mutex
+	subscribers map[string]SubCallBack
+	pendMsgList list.List
+}
+
+func newPubsubTracer(ctx context.Context) *pubsubTracer {
+	pt := &pubsubTracer{}
+	pt.subscribers = make(map[string]SubCallBack)
+	go pt.handlePendMsg(ctx)
+	return pt
+}
+
+var _ pubsub.RawTracer = (*pubsubTracer)(nil)
+
+func (pt *pubsubTracer) handlePendMsg(ctx context.Context) {
+
+	ticker := time.NewTicker(time.Millisecond * 100)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			msgs := pt.copyPendMsg()
+			for _, msg := range msgs {
+				cb := pt.getSubCallBack(*msg.Topic)
+				cb(*msg.Topic, msg)
+			}
+		}
+
+	}
+}
+
+func (pt *pubsubTracer) addSubscriber(topic string, cb SubCallBack) {
+	pt.subLock.Lock()
+	pt.subscribers[topic] = cb
+	pt.subLock.Unlock()
+}
+
+func (pt *pubsubTracer) getSubCallBack(topic string) SubCallBack {
+	pt.subLock.RLock()
+	defer pt.subLock.RUnlock()
+	return pt.subscribers[topic]
+}
+
+func (pt *pubsubTracer) copyPendMsg() []*pubsub.Message {
+	pt.msgLock.Lock()
+	defer pt.msgLock.Unlock()
+	if pt.pendMsgList.Len() <= 0 {
+		return nil
+	}
+	msgs := make([]*pubsub.Message, 0, pt.pendMsgList.Len())
+	for it := pt.pendMsgList.Front(); it != nil; it = it.Next() {
+		msgs = append(msgs, it.Value.(*pubsub.Message))
+	}
+	pt.pendMsgList.Init()
+	return msgs
+}
+
+// 监听subscribe数据丢弃事件, 实现重发机制
+func (pt *pubsubTracer) UndeliverableMessage(msg *pubsub.Message) {
+	pt.msgLock.Lock()
+	defer pt.msgLock.Unlock()
+	pt.pendMsgList.PushBack(msg)
+}
+
+type blankTracer struct{}
+
+func (*blankTracer) UndeliverableMessage(msg *pubsub.Message)         {}
+func (*blankTracer) DeliverMessage(msg *pubsub.Message)               {}
+func (*blankTracer) RejectMessage(msg *pubsub.Message, reason string) {}
+func (*blankTracer) ValidateMessage(msg *pubsub.Message)              {}
+func (*blankTracer) AddPeer(p peer.ID, proto protocol.ID)             {}
+func (*blankTracer) RemovePeer(p peer.ID)                             {}
+func (*blankTracer) Join(topic string)                                {}
+func (*blankTracer) Leave(topic string)                               {}
+func (*blankTracer) Graft(p peer.ID, topic string)                    {}
+func (*blankTracer) Prune(p peer.ID, topic string)                    {}
+func (*blankTracer) DuplicateMessage(msg *pubsub.Message)             {}
+func (*blankTracer) RecvRPC(rpc *pubsub.RPC)                          {}
+func (*blankTracer) SendRPC(rpc *pubsub.RPC, p peer.ID)               {}
+func (*blankTracer) DropRPC(rpc *pubsub.RPC, p peer.ID)               {}
+func (*blankTracer) ThrottlePeer(p peer.ID)                           {}

--- a/system/p2p/dht/extension/trace_test.go
+++ b/system/p2p/dht/extension/trace_test.go
@@ -1,0 +1,64 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package extension
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	blankhost "github.com/libp2p/go-libp2p-blankhost"
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/stretchr/testify/require"
+)
+
+type mockHost struct {
+	blankhost.BlankHost
+}
+
+func (h *mockHost) ID() peer.ID {
+	return "testid"
+}
+
+func Test_trace(t *testing.T) {
+
+	topic := "testtopic"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pt := newPubsubTracer(ctx, &mockHost{})
+	msgNum := 1000
+	msgChan := make(chan SubMsg, msgNum)
+	testDone := make(chan struct{})
+
+	pt.addSubscriber(topic, func(tp string, msg SubMsg) {
+		msgChan <- msg
+	})
+
+	go func() {
+		for i := 0; i < msgNum; i++ {
+			msg := <-msgChan
+			require.Equal(t, topic, *msg.Topic)
+			id := peer.ID(fmt.Sprintf("id%d", i))
+			require.Equal(t, id, msg.ReceivedFrom)
+		}
+		testDone <- struct{}{}
+	}()
+	go func() {
+		for i := 0; i < msgNum; i++ {
+			msg := &pubsub.Message{Message: &pubsub_pb.Message{}}
+			msg.Topic = &topic
+			msg.ReceivedFrom = peer.ID(fmt.Sprintf("id%d", i))
+			pt.UndeliverableMessage(msg)
+		}
+	}()
+
+	select {
+	case <-testDone:
+	case <-time.After(time.Second * 5):
+		t.Error("test trace timeout")
+	}
+}

--- a/system/p2p/dht/protocol/broadcast/pubsub.go
+++ b/system/p2p/dht/protocol/broadcast/pubsub.go
@@ -115,10 +115,6 @@ func (p *pubSub) handleSubMsg(in chan net.SubMsg) {
 			if !ok {
 				return
 			}
-			// reject receive broadcast from self
-			if data.ReceivedFrom == p.Host.ID() {
-				break
-			}
 			topic := *data.Topic
 			msg = p.newMsg(topic)
 			err = p.decodeMsg(data.Data, &buf, msg)


### PR DESCRIPTION

dht pubsub 消息事件跟踪器实现, 主要是对底层sub丢弃的消息进行缓存, 进行二次分发