### PR TITLE
push重新开始后更新数据库状态

### DIFF
--- a/blockchain/push.go
+++ b/blockchain/push.go
@@ -393,7 +393,12 @@ func (push *Push) addSubscriber(subscribe *types.PushSubscribeReq) error {
 			return types.ErrNotAllowModifyPush
 		}
 		//使用保存在数据库中的push配置，而不是最新的配置信息
-		return push.check2ResumePush(subscribeInDB)
+		if err := push.check2ResumePush(subscribeInDB); nil != err {
+			return err
+		}
+
+		//当前可能是notActive的情况，重新激活后，则直接将其状态设置为active
+		return push.setActive(subscribe)
 	}
 
 	push.mu.Lock()
@@ -469,6 +474,27 @@ func (push *Push) persisAndStart(subscribe *types.PushSubscribeReq) error {
 	}
 
 	return push.store.SetSync(key, types.Encode(pushWithStatus))
+}
+
+func (push *Push) setActive(subscribe *types.PushSubscribeReq) error {
+	key := calcPushKey(subscribe.Name)
+	value, err := push.store.GetKey(key)
+	if nil != err {
+		return err
+	}
+	var pushWithStatus types.PushWithStatus
+	err = types.Decode(value, &pushWithStatus)
+	if err != nil {
+		return err
+	}
+	//如果本身就是active状态，则不进行状态的更新
+	if pushWithStatus.Status == subscribeStatusActive {
+		return nil
+	}
+
+	pushWithStatus.Status = subscribeStatusActive
+	storeLog.Info("setActive", "key", string(key), "subscribe", subscribe)
+	return push.store.SetSync(key, types.Encode(&pushWithStatus))
 }
 
 func (push *Push) check2ResumePush(subscribe *types.PushSubscribeReq) error {

--- a/blockchain/push.go
+++ b/blockchain/push.go
@@ -338,12 +338,14 @@ func (push *Push) init() {
 			chainlog.Error("Push init", "Failed to decode subscribe due to err:", err)
 			return
 		} //过滤掉grpc的推送
+		chainlog.Info("Push init", "Push Name", pushWithStatus.Push.Name, "pushWithStatus.Status", pushWithStatus.Status)
 		if pushWithStatus.Status == subscribeStatusActive {
 			subscribes = append(subscribes, pushWithStatus.Push)
 		}
 
 	}
 	for _, subscribe := range subscribes {
+		chainlog.Info("Push init", "Going to add Task to Push for Name", subscribe.Name)
 		push.addTask(subscribe)
 	}
 }

--- a/blockchain/push_test.go
+++ b/blockchain/push_test.go
@@ -1136,6 +1136,13 @@ func Test_ReactivePush(t *testing.T) {
 	require.Equal(t, atomic.LoadInt32(&pushNotify.status), notRunning)
 	lastSeq, _ = chain.ProcGetLastPushSeq(subscribe.Name)
 
+	///////////////check status/////////////////////////////////
+	key := calcPushKey(subscribe.Name)
+	value, _ := chain.push.store.GetKey(key)
+	var pushWithStatus types.PushWithStatus
+	_ = types.Decode(value, &pushWithStatus)
+	assert.Equal(t, pushWithStatus.Status, subscribeStatusNotActive)
+
 	//重新激活
 	chain.push.postService = ps
 	err = chain.push.addSubscriber(subscribe)
@@ -1147,6 +1154,12 @@ func Test_ReactivePush(t *testing.T) {
 	require.Equal(t, atomic.LoadInt32(&pushNotify.status), running)
 	lastSeqAfter, _ := chain.ProcGetLastPushSeq(subscribe.Name)
 	require.Greater(t, lastSeqAfter, lastSeq)
+
+	///////////////check status/////////////////////////////////
+	key = calcPushKey(subscribe.Name)
+	value, _ = chain.push.store.GetKey(key)
+	_ = types.Decode(value, &pushWithStatus)
+	assert.Equal(t, pushWithStatus.Status, subscribeStatusActive)
 
 	mock33.Close()
 }


### PR DESCRIPTION
目前推送３次失败后，会将该订阅的状态设置为inactive；
如果订阅重新激活，没有将其状态修改为active，
此时如果chain33重启，就不会自动推送，
所以需要在重新激活时，将状态修改为acvite(如果是非active的话)