### PR TITLE
wallet support cointype 898

### DIFF
--- a/wallet/bipwallet/bipwallet.go
+++ b/wallet/bipwallet/bipwallet.go
@@ -29,6 +29,7 @@ const (
 	TypeFactomFactoids     uint32 = 0x80000083
 	TypeFactomEntryCredits uint32 = 0x80000084
 	TypeZcash              uint32 = 0x80000085
+	TypeAS                 uint32 = 0x80000382
 	TypeBty                uint32 = 0x80003333
 	TypeYcc                uint32 = 0x80003334
 )
@@ -40,6 +41,7 @@ var CoinName = map[uint32]string{
 	TypeBitcoin:      "BTC",
 	TypeLitecoin:     "LTC",
 	TypeZcash:        "ZEC",
+	TypeAS:           "AS",
 	TypeBty:          "BTY",
 	TypeYcc:          "YCC",
 }
@@ -51,6 +53,7 @@ var coinNameType = map[string]uint32{
 	"BTC": TypeBitcoin,
 	"LTC": TypeLitecoin,
 	"ZEC": TypeZcash,
+	"AS":  TypeAS,
 	"BTY": TypeBty,
 	"YCC": TypeYcc,
 }

--- a/wallet/bipwallet/bipwallet_test.go
+++ b/wallet/bipwallet/bipwallet_test.go
@@ -99,3 +99,18 @@ func TestSm2PrivPub(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, tpub, pub)
 }
+
+func TestGetSLIP0044CoinType(t *testing.T) {
+	var coinNameType = map[string]uint32{
+		"ETH": 0x8000003c,
+		"BTC": 0x80000000,
+		"AS":  0x80000382,
+		"BTY": 0x80003333,
+		"YCC": 0x80003334,
+	}
+
+	for k, v := range coinNameType {
+		v1 := GetSLIP0044CoinType(k)
+		assert.Equal(t, v, v1)
+	}
+}

--- a/wallet/bipwallet/transformer/btcbase/loader.go
+++ b/wallet/bipwallet/transformer/btcbase/loader.go
@@ -14,6 +14,7 @@ var coinPrefix = map[string][]byte{
 	"BCH":  {0x00},
 	"BTY":  {0x00},
 	"YCC":  {0x00},
+	"AS":   {0x00},
 	"LTC":  {0x30},
 	"ZEC":  {0x1c, 0xb8},
 	"USDT": {0x00},


### PR DESCRIPTION
close #1253 钱包支持新的cointype 898. 

Assetchain 是基于chain33 框架的新的公链