### PR TITLE
Fix broadcast batchtx

### DIFF
--- a/blockchain/blocksyn.go
+++ b/blockchain/blocksyn.go
@@ -162,10 +162,6 @@ func (chain *BlockChain) SynRoutine() {
 	defer chunkRecordSynTicker.Stop()
 
 	chain.UpdatesynBlkHeight(chain.GetBlockHeight())
-	mode := chain.GetDownloadSyncStatus()
-	chain.UpdateDownloadSyncStatus(forkChainDetectMode)
-	// make sure not on fork chain when node start
-	go chain.forkChainDetection(mode)
 
 	//节点下载模式
 	go chain.DownLoadBlocks()

--- a/system/p2p/dht/protocol/broadcast/pubsub.go
+++ b/system/p2p/dht/protocol/broadcast/pubsub.go
@@ -64,6 +64,7 @@ func (p *pubSub) init() {
 		p.Pubsub.RegisterTopicValidator(psBlockTopic, p.val.validateBlock, pubsub.WithValidatorInline(true))
 		p.Pubsub.RegisterTopicValidator(psTxTopic, p.val.validateTx, pubsub.WithValidatorInline(true))
 		p.Pubsub.RegisterTopicValidator(psLtBlockTopic, p.val.validatePeer, pubsub.WithValidatorInline(true))
+		p.Pubsub.RegisterTopicValidator(psBatchTxTopic, p.val.validateBatchTx, pubsub.WithValidatorInline(true))
 	}
 
 	//使用多个协程并发处理，提高效率
@@ -118,7 +119,7 @@ func (p *pubSub) handleSubMsg(in chan net.SubMsg) {
 			}
 			topic := *data.Topic
 			// 交易在pubsub内部验证时已经发送至mempool, 此处直接忽略
-			if topic == psTxTopic {
+			if topic == psTxTopic || topic == psBatchTxTopic {
 				break
 			}
 			msg = p.newMsg(topic)

--- a/system/p2p/dht/protocol/broadcast/validate_test.go
+++ b/system/p2p/dht/protocol/broadcast/validate_test.go
@@ -169,9 +169,9 @@ func Test_validateBatchTx(t *testing.T) {
 	txs := &types.Transactions{Txs: []*types.Transaction{tx}}
 	sendBuf := make([]byte, 0)
 	msg.Data = val.encodeMsg(txs, &sendBuf)
-	mockApi := new(mocks.QueueProtocolAPI)
-	val.API = mockApi
-	mockApi.On("SendTx", mock.Anything).Return(nil, nil)
+	mockAPI := new(mocks.QueueProtocolAPI)
+	val.API = mockAPI
+	mockAPI.On("SendTx", mock.Anything).Return(nil, nil)
 	require.Equal(t, ps.ValidationAccept, val.validateBatchTx(val.Ctx, "testpid", msg))
 
 	txs.Txs = append(txs.Txs, &types.Transaction{Execer: []byte("coins2")})

--- a/system/p2p/dht/protocol/broadcast/validate_test.go
+++ b/system/p2p/dht/protocol/broadcast/validate_test.go
@@ -143,13 +143,13 @@ func Test_validateTx(t *testing.T) {
 	require.Equal(t, ps.ValidationIgnore, val.validateTx(val.Ctx, "testpid", msg))
 	val.txFilter.Remove(txHash)
 
-	mockApi := new(mocks.QueueProtocolAPI)
-	val.API = mockApi
-	mockApi.On("SendTx", mock.Anything).Return(nil, types.ErrNotSync).Once()
+	mockAPI := new(mocks.QueueProtocolAPI)
+	val.API = mockAPI
+	mockAPI.On("SendTx", mock.Anything).Return(nil, types.ErrNotSync).Once()
 	require.Equal(t, ps.ValidationIgnore, val.validateTx(val.Ctx, "testpid", msg))
 	val.txFilter.Remove(txHash)
 
-	mockApi.On("SendTx", mock.Anything).Return(nil, nil).Once()
+	mockAPI.On("SendTx", mock.Anything).Return(nil, nil).Once()
 	require.Equal(t, ps.ValidationAccept, val.validateTx(val.Ctx, "testpid", msg))
 }
 


### PR DESCRIPTION

1. 批量交易广播增加实时验证, 避免错误交易可能导致的泛洪问题

2. 移除blockchain启动时分叉检测任务, 由定时任务完成检测即可