### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.github/workflows/automake.yml
+++ b/.github/workflows/automake.yml
@@ -35,7 +35,7 @@ jobs:
           branch: master
           extra_plugins: |
             conventional-changelog/conventional-changelog-jshint
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog
             @semantic-release/git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           branch: master
           extra_plugins: |
             conventional-changelog/conventional-changelog-jshint
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog
             @semantic-release/git

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -13,7 +13,7 @@
       }
     ],
     [
-        "@google/semantic-release-replace-plugin",
+        "semantic-release-replace-plugin",
       {
         "replacements": [
           {


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).