### PR TITLE
add sign and send txs in file

### DIFF
--- a/.github/workflows/automake.yml
+++ b/.github/workflows/automake.yml
@@ -35,7 +35,7 @@ jobs:
           branch: master
           extra_plugins: |
             conventional-changelog/conventional-changelog-jshint
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog
             @semantic-release/git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,18 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
+#      - uses: actions/setup-node@v3
+#        with:
+#          node-version: 14
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
           branch: master
           extra_plugins: |
-            conventional-changelog/conventional-changelog-jshint
-            semantic-release-replace-plugin
-            @semantic-release/exec
+            conventional-changelog/conventional-changelog-jshint@4
+            semantic-release-replace-plugin@1.2.7
+            @semantic-release/exec@6
             @semantic-release/changelog@6
             @semantic-release/git@10
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         id: semantic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           branch: master
           extra_plugins: |
             conventional-changelog/conventional-changelog-jshint
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog@6
             @semantic-release/git@10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,14 @@ jobs:
         uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:
+          semantic_version: 18
           branch: master
           extra_plugins: |
             conventional-changelog/conventional-changelog-jshint
             @google/semantic-release-replace-plugin
             @semantic-release/exec
-            @semantic-release/changelog
-            @semantic-release/git
+            @semantic-release/changelog@6
+            @semantic-release/git@10
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:
-          semantic_version: 18
           branch: master
           extra_plugins: |
             conventional-changelog/conventional-changelog-jshint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,16 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-#      - uses: actions/setup-node@v3
-#        with:
-#          node-version: 14
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
           branch: master
           extra_plugins: |
-            conventional-changelog/conventional-changelog-jshint@4
+            conventional-changelog/conventional-changelog-jshint
             semantic-release-replace-plugin@1.2.7
             @semantic-release/exec@6
             @semantic-release/changelog@6

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -13,7 +13,7 @@
       }
     ],
     [
-        "@google/semantic-release-replace-plugin",
+        "semantic-release-replace-plugin",
       {
         "replacements": [
           {

--- a/system/dapp/commands/wallet.go
+++ b/system/dapp/commands/wallet.go
@@ -496,7 +496,7 @@ func signTxsInFile(req *types.ReqSignRawTx, in, out, rpc string) {
 		ctx := jsonclient.NewRPCCtx(rpc, "Chain33.SignRawTx", req, &signTx)
 		_, err := ctx.RunResult()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("signRawTx err, line:%d, err:%s", line, err.Error()))
+			fmt.Fprintf(os.Stderr, "signRawTx err, line:%d, err:%s \n", line, err.Error())
 			continue
 		}
 		signTxs = append(signTxs, signTx)
@@ -521,7 +521,7 @@ func writeLines(filename string, lines []string) error {
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("writeLines open file err: %s", err.Error()))
+		fmt.Fprintf(os.Stderr, "writeLines open file err: %s \n", err.Error())
 		return err
 	}
 	defer file.Close()
@@ -540,7 +540,7 @@ func readLines(file string) []string {
 	var lines []string
 	readFile, err := os.Open(file)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("readLines open file err:%s", err.Error()))
+		fmt.Fprintf(os.Stderr, "readLines open file err:%s \n", err.Error())
 		return nil
 	}
 	defer readFile.Close()
@@ -672,7 +672,7 @@ func sendTxsInFile(req *rpctypes.RawParm, in, out, rpc string) {
 		ctx := jsonclient.NewRPCCtx(rpc, "Chain33.SendTransaction", req, &hash)
 		_, err := ctx.RunResult()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("Error sendTx, line:%d, err:%s", line, err.Error()))
+			fmt.Fprintf(os.Stderr, "Error sendTx, line:%d, err:%s \n", line, err.Error())
 			continue
 		}
 		hashes = append(hashes, hash)

--- a/system/dapp/commands/wallet.go
+++ b/system/dapp/commands/wallet.go
@@ -5,6 +5,7 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"math/big"
@@ -319,7 +320,7 @@ func SignRawTxCmd() *cobra.Command {
 }
 
 func addSignRawTxFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("data", "d", "", "raw transaction data")
+	cmd.Flags().StringP("data", "d", "", "raw transaction hex data or data file")
 	cmd.MarkFlagRequired("data")
 
 	cmd.Flags().Int32P("index", "i", 0, "transaction index to be signed")
@@ -330,6 +331,7 @@ func addSignRawTxFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("to", "t", "", "new to addr (optional)")
 	cmd.Flags().Int32P("addressType", "p", -1, "address type ID, btc(0), btcMultiSign(1), eth(2)")
 	cmd.Flags().Int32P("chainID", "c", 0, "for eth signn (optional)")
+	cmd.Flags().StringP("out", "o", "sign.out", "output file, default sign.out")
 	// A duration string is a possibly signed sequence of
 	// decimal numbers, each with optional fraction and a unit suffix,
 	// such as "300ms", "-1.5h" or "2h45m".
@@ -420,6 +422,7 @@ func signRawTx(cmd *cobra.Command, args []string) {
 	expire, _ := cmd.Flags().GetString("expire")
 	addressType, _ := cmd.Flags().GetInt32("addressType")
 	chainID, _ := cmd.Flags().GetInt32("chainID")
+	outFile, _ := cmd.Flags().GetString("out")
 	//check tx type
 	ethTx := new(ethtypes.Transaction)
 	if ethTx.UnmarshalBinary(common.FromHex(data)) == nil {
@@ -467,8 +470,96 @@ func signRawTx(cmd *cobra.Command, args []string) {
 		AddressID: addressType,
 	}
 
-	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SignRawTx", &params, nil)
-	ctx.RunWithoutMarshal()
+	if !isFileExist(data) {
+
+		ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SignRawTx", &params, nil)
+		ctx.RunWithoutMarshal()
+		return
+	}
+
+	// data为文件
+	signTxsInFile(&params, data, outFile, rpcLaddr)
+
+}
+
+func signTxsInFile(req *types.ReqSignRawTx, in, out, rpc string) {
+
+	rawTxs := readLines(in)
+	var signTxs []string
+	var signTx string
+	for line, rawTx := range rawTxs {
+
+		if rawTx == "" {
+			continue
+		}
+		req.TxHex = rawTx
+		ctx := jsonclient.NewRPCCtx(rpc, "Chain33.SignRawTx", req, &signTx)
+		_, err := ctx.RunResult()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, fmt.Sprintf("signRawTx err, line:%d, err:%s", line, err.Error()))
+			continue
+		}
+		signTxs = append(signTxs, signTx)
+	}
+
+	err := writeLines(out, signTxs)
+	if err == nil {
+		return
+	}
+	// output to stdout if write file failed
+	for _, tx := range signTxs {
+		fmt.Println(tx)
+	}
+}
+
+func writeLines(filename string, lines []string) error {
+
+	if len(lines) <= 0 {
+		return nil
+	}
+
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("writeLines open file err: %s", err.Error()))
+		return err
+	}
+	defer file.Close()
+	datawriter := bufio.NewWriter(file)
+
+	for _, data := range lines {
+		_, _ = datawriter.WriteString(data + "\n")
+	}
+
+	datawriter.Flush()
+	return nil
+}
+
+func readLines(file string) []string {
+
+	var lines []string
+	readFile, err := os.Open(file)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("readLines open file err:%s", err.Error()))
+		return nil
+	}
+	defer readFile.Close()
+	fs := bufio.NewScanner(readFile)
+	fs.Split(bufio.ScanLines)
+
+	for fs.Scan() {
+		lines = append(lines, fs.Text())
+	}
+
+	return lines
+}
+
+func isFileExist(file string) bool {
+
+	if _, err := os.Stat(file); err == nil {
+		return true
+	}
+	return false
 }
 
 // SetFeeCmd set tx fee
@@ -521,9 +612,9 @@ func SendTxCmd() *cobra.Command {
 }
 
 func addSendTxFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("data", "d", "", "transaction content")
+	cmd.Flags().StringP("data", "d", "", "tx data or tx file")
 	cmd.MarkFlagRequired("data")
-
+	cmd.Flags().StringP("out", "o", "send.out", "output file")
 	cmd.Flags().StringP("token", "t", types.BTY, "token name. (BTY supported)")
 	cmd.Flags().BoolP("ethType", "e", false, "")
 }
@@ -533,6 +624,7 @@ func sendTx(cmd *cobra.Command, args []string) {
 	data, _ := cmd.Flags().GetString("data")
 	token, _ := cmd.Flags().GetString("token")
 	ethType, _ := cmd.Flags().GetBool("ethType")
+	outFile, _ := cmd.Flags().GetString("out")
 	if ethType {
 		c, err := rpc.DialContext(context.Background(), rpcLaddr)
 		if err != nil {
@@ -557,6 +649,36 @@ func sendTx(cmd *cobra.Command, args []string) {
 		Data:  data,
 	}
 
-	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SendTransaction", params, nil)
-	ctx.RunWithoutMarshal()
+	if !isFileExist(data) {
+		ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.SendTransaction", params, nil)
+		ctx.RunWithoutMarshal()
+		return
+	}
+
+	sendTxsInFile(&params, data, outFile, rpcLaddr)
+}
+
+func sendTxsInFile(req *rpctypes.RawParm, in, out, rpc string) {
+
+	signTxs := readLines(in)
+	var hashes []string
+	var hash string
+	for line, tx := range signTxs {
+
+		if tx == "" {
+			continue
+		}
+		req.Data = tx
+		ctx := jsonclient.NewRPCCtx(rpc, "Chain33.SendTransaction", req, &hash)
+		_, err := ctx.RunResult()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, fmt.Sprintf("Error sendTx, line:%d, err:%s", line, err.Error()))
+			continue
+		}
+		hashes = append(hashes, hash)
+	}
+
+	for _, h := range hashes {
+		fmt.Println(h)
+	}
 }


### PR DESCRIPTION
- 增加签名和发送批量交易命令（**数据在指定文件中按行排列**）

- 扩展wallet sign命令， -d指定数据文件时，执行从文件中解析数据批量签名， -o指定输出文件（默认sign.out）

- 扩展wallet send命令， -d指定数据文件时，执行从文件中解析数据批量发送