### PR TITLE
refactor(tss): add session timeout support and fix nil config handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ system/store/mavl/1.png
 system/store/mavl/cpu.pprof
 system/store/mavl/mavl.test
 build/CHANGELOG.md
+.claude*

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -173,7 +173,7 @@ func (q *queue) Close() {
 			default:
 			}
 			close(ch.done)
-			q.chanSubs[topic] = &chanSub{isClose: 1}
+			q.chanSubs[topic] = &chanSub{isClose: 1, done: ch.done}
 		}
 	}
 	q.mu.Unlock()
@@ -220,7 +220,7 @@ func (q *queue) closeTopic(topic string) {
 		}
 	}
 	close(sub.done)
-	q.chanSubs[topic] = &chanSub{isClose: 1}
+	q.chanSubs[topic] = &chanSub{isClose: 1, done: sub.done}
 }
 
 func (q *queue) send(msg *Message, timeout time.Duration) (err error) {

--- a/system/crypto/tss/gg18/api.go
+++ b/system/crypto/tss/gg18/api.go
@@ -23,6 +23,7 @@ type config struct {
 	timeout time.Duration
 }
 
+// Option sets configuration options for TSS operations.
 type Option func(*config)
 
 // WithTimeout set timeout

--- a/system/crypto/tss/gg18/api.go
+++ b/system/crypto/tss/gg18/api.go
@@ -3,6 +3,7 @@ package gg18
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/33cn/chain33/system/crypto/tss"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -14,12 +15,38 @@ import (
 	"github.com/getamis/alice/crypto/tss/ecdsa/gg18/signer"
 )
 
+const (
+	defaultTimeout = 30 * time.Second
+)
+
+type config struct {
+	timeout time.Duration
+}
+
+type Option func(*config)
+
+// WithTimeout set timeout
+func WithTimeout(timeout time.Duration) Option {
+	return func(o *config) {
+		o.timeout = timeout
+	}
+}
+
+func newConfig(opts ...Option) *config {
+	cfg := &config{timeout: defaultTimeout}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
 // ProcessDKG process dkg，return DKGResult
 // sessionID 各节点同一Dkg的sessionID相同
-func ProcessDKG(peers []string, threshold, rank uint32, sessionID string) (*tss.DKGResult, error) {
+func ProcessDKG(peers []string, threshold, rank uint32, sessionID string, opts ...Option) (*tss.DKGResult, error) {
 
+	cfg := newConfig(opts...)
 	pm := tss.NewReadyPeerManager(peers, DkgProtocol, sessionID)
-	listener := tss.NewListener(DkgProtocol)
+	listener := tss.NewListener(DkgProtocol, cfg.timeout)
 	dkgCore, err := dkg.NewDKG(elliptic.Secp256k1(), pm, threshold, rank, listener)
 	if err != nil {
 		log.Error("ProcessDKG", "session", sessionID, "NewDKG err", err)
@@ -34,7 +61,7 @@ func ProcessDKG(peers []string, threshold, rank uint32, sessionID string) (*tss.
 	dkgCore.Start()
 	defer dkgCore.Stop()
 
-	if err := <-listener.Done(); err != nil {
+	if err := listener.Wait(); err != nil {
 		log.Error("ProcessDKG", "session", sessionID, "listener done err", err)
 		return nil, err
 	}
@@ -49,15 +76,16 @@ func ProcessDKG(peers []string, threshold, rank uint32, sessionID string) (*tss.
 // ProcessSign sign message
 // sessionID 各节点同一Sign的sessionID需相同
 // 门限签名peers可以是部分节点，需保证调用时各节点peers参数相同
-func ProcessSign(peers []string, msg []byte, result *tss.DKGResult, sessionID string) (*signer.Result, error) {
+func ProcessSign(peers []string, msg []byte, result *tss.DKGResult, sessionID string, opts ...Option) (*signer.Result, error) {
 
+	cfg := newConfig(opts...)
 	dkgResult, err := tss.ConvertDKGResult(peers, result)
 	if err != nil {
 		log.Error("ProcessSign", "session", sessionID, "ConvertDKGResult err", err)
 		return nil, err
 	}
 	pm := tss.NewReadyPeerManager(peers, SignProtocol, sessionID)
-	listener := tss.NewListener(SignProtocol)
+	listener := tss.NewListener(SignProtocol, cfg.timeout)
 	homo, err := paillier.NewPaillier(2048)
 	if err != nil {
 		log.Error("ProcessSign", "session", sessionID, "NewPaillier err", err)
@@ -78,7 +106,7 @@ func ProcessSign(peers []string, msg []byte, result *tss.DKGResult, sessionID st
 	signerCore.Start()
 	defer signerCore.Stop()
 
-	if err := <-listener.Done(); err != nil {
+	if err := listener.Wait(); err != nil {
 		log.Error("ProcessSign", "session", sessionID, "listener done err", err)
 		return nil, err
 	}
@@ -92,14 +120,15 @@ func ProcessSign(peers []string, msg []byte, result *tss.DKGResult, sessionID st
 
 // ProcessReshare reshare public key
 // sessionID 各节点同一Reshare的sessionID需相同
-func ProcessReshare(peers []string, result *tss.DKGResult, threshold uint32, sessionID string) (*reshare.Result, error) {
+func ProcessReshare(peers []string, result *tss.DKGResult, threshold uint32, sessionID string, opts ...Option) (*reshare.Result, error) {
+	cfg := newConfig(opts...)
 	dkgRes, err := tss.ConvertDKGResult(peers, result)
 	if err != nil {
 		log.Error("ProcessReshare", "session", sessionID, "ConvertDKGResult err", err)
 		return nil, err
 	}
 	pm := tss.NewReadyPeerManager(peers, ReshareProtocol, sessionID)
-	listener := tss.NewListener(ReshareProtocol)
+	listener := tss.NewListener(ReshareProtocol, cfg.timeout)
 	reshareCore, err := reshare.NewReshare(pm, threshold, dkgRes.PublicKey, dkgRes.Share,
 		dkgRes.Bks, listener)
 
@@ -116,7 +145,7 @@ func ProcessReshare(peers []string, result *tss.DKGResult, threshold uint32, ses
 	reshareCore.Start()
 	defer reshareCore.Stop()
 
-	if err := <-listener.Done(); err != nil {
+	if err := listener.Wait(); err != nil {
 		log.Error("ProcessReshare", "session", sessionID, "listener done err", err)
 		return nil, err
 	}

--- a/system/crypto/tss/gg18/gg18_test.go
+++ b/system/crypto/tss/gg18/gg18_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -39,4 +40,15 @@ func TestGG18ConvertPubkey(t *testing.T) {
 	println(res)
 	pub := btcec.NewPublicKey(&x, &y)
 	require.True(t, pub.IsEqual(priv.PubKey()))
+}
+
+func TestNewConfig(t *testing.T) {
+	cfg := newConfig()
+	require.Equal(t, defaultTimeout, cfg.timeout)
+
+	cfg = newConfig(WithTimeout(2 * time.Minute))
+	require.Equal(t, 2*time.Minute, cfg.timeout)
+
+	cfg = newConfig(WithTimeout(0))
+	require.Zero(t, cfg.timeout)
 }

--- a/system/crypto/tss/listener.go
+++ b/system/crypto/tss/listener.go
@@ -1,8 +1,11 @@
 package tss
 
 import (
+	"context"
 	"fmt"
+	"time"
 
+	cryptocli "github.com/33cn/chain33/common/crypto/client"
 	"github.com/getamis/alice/types"
 )
 
@@ -10,35 +13,46 @@ import (
 type Listener interface {
 	types.StateChangedListener
 
-	Done() <-chan error
+	Wait() error
 }
 
 // NewListener  new listener
-func NewListener(protocol string) Listener {
+func NewListener(protocol string, timeout time.Duration) Listener {
+	ctx := cryptocli.GetCryptoContext().Ctx
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+	if timeout > 0 {
+		ctx, _ = context.WithTimeout(ctx, timeout)
+	}
 	return &listener{
 		protocol: protocol,
 		errCh:    make(chan error, 1),
+		ctx:      ctx,
 	}
 }
 
 type listener struct {
 	protocol string
 	errCh    chan error
+	ctx      context.Context
 }
 
 func (l *listener) OnStateChanged(oldState types.MainState, newState types.MainState) {
-	if newState == types.StateFailed {
+	switch newState {
+	case types.StateFailed:
 		l.errCh <- fmt.Errorf("state %s -> %s", oldState.String(), newState.String())
-		return
-	} else if newState == types.StateDone {
+	case types.StateDone:
 		l.errCh <- nil
-		return
 	}
-
-	log.Debug("State changed", "protocol", l.protocol,
-		"old", oldState.String(), "new", newState.String())
 }
 
-func (l *listener) Done() <-chan error {
-	return l.errCh
+func (l *listener) Wait() error {
+
+	select {
+	case err := <-l.errCh:
+		return err
+	case <-l.ctx.Done():
+		return fmt.Errorf("tss listener context done: %s", l.ctx.Err())
+	}
 }

--- a/system/crypto/tss/listener.go
+++ b/system/crypto/tss/listener.go
@@ -22,13 +22,15 @@ func NewListener(protocol string, timeout time.Duration) Listener {
 	if ctx == nil {
 		ctx = context.TODO()
 	}
+	var cancel context.CancelFunc
 	if timeout > 0 {
-		ctx, _ = context.WithTimeout(ctx, timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 	}
 	return &listener{
 		protocol: protocol,
 		errCh:    make(chan error, 1),
 		ctx:      ctx,
+		cancel:   cancel,
 	}
 }
 
@@ -36,6 +38,7 @@ type listener struct {
 	protocol string
 	errCh    chan error
 	ctx      context.Context
+	cancel   context.CancelFunc
 }
 
 func (l *listener) OnStateChanged(oldState types.MainState, newState types.MainState) {
@@ -48,6 +51,11 @@ func (l *listener) OnStateChanged(oldState types.MainState, newState types.MainS
 }
 
 func (l *listener) Wait() error {
+	defer func() {
+		if l.cancel != nil {
+			l.cancel()
+		}
+	}()
 
 	select {
 	case err := <-l.errCh:

--- a/system/crypto/tss/listener_test.go
+++ b/system/crypto/tss/listener_test.go
@@ -2,46 +2,36 @@ package tss
 
 import (
 	"testing"
+	"time"
 
 	"github.com/getamis/alice/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewListener(t *testing.T) {
-	l := NewListener("/gg18/dkg")
+	l := NewListener("/gg18/dkg", time.Second)
 	require.NotNil(t, l)
-	require.NotNil(t, l.Done())
 }
 
-func TestListener_OnStateChanged_StateDone(t *testing.T) {
-	l := NewListener("/gg18/dkg")
+func TestListener_Wait_StateDone(t *testing.T) {
+	l := NewListener("/gg18/dkg", time.Second)
 	l.(*listener).OnStateChanged(types.StateInit, types.StateDone)
-	err := <-l.Done()
-	require.NoError(t, err)
+	require.NoError(t, l.Wait())
 }
 
-func TestListener_OnStateChanged_StateFailed(t *testing.T) {
-	l := NewListener("/gg18/dkg")
+func TestListener_Wait_StateFailed(t *testing.T) {
+	l := NewListener("/gg18/dkg", time.Second)
 	l.OnStateChanged(types.StateInit, types.StateFailed)
-	err := <-l.Done()
+	err := l.Wait()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Init")
 	require.Contains(t, err.Error(), "Failed")
-	l.OnStateChanged(types.StateInit, types.StateDone)
-	err = <-l.Done()
-	require.NoError(t, err)
 }
 
-func TestListener_OnStateChanged_OtherState(t *testing.T) {
-	l := NewListener("/gg18/dkg")
-	// Other state does not send to errCh; Done() would block. So we just ensure no panic.
+func TestListener_Wait_Timeout(t *testing.T) {
+	l := NewListener("/gg18/dkg", 10*time.Millisecond)
 	l.(*listener).OnStateChanged(types.StateInit, types.StateInit)
-	// Channel should be empty; select would block. Use a short timeout or leave as is.
-	doneCh := l.Done()
-	select {
-	case <-doneCh:
-		t.Fatal("unexpected value on Done() for non-terminal state")
-	default:
-		// expected: no send yet
-	}
+	err := l.Wait()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context deadline exceeded")
 }

--- a/system/crypto/tss/pm.go
+++ b/system/crypto/tss/pm.go
@@ -33,7 +33,7 @@ func NewReadyPeerManager(peers []string, protocol, sessionID string) alicetypes.
 		cli:       ctx.Client,
 		ctx:       ctx.Ctx,
 	}
-	pm.ensurePeersReady()
+	pm.waitPeersReady()
 	return pm
 }
 
@@ -81,28 +81,27 @@ func (p *peerManager) removeSelf() {
 	p.peerIDs = ids
 }
 
-// ensurePeersReady waits for peers to sync and initializes self info.
-func (p *peerManager) ensurePeersReady() {
-
-	timeout := 3 * time.Second
-	ticker := time.NewTicker(timeout)
+// waitPeersReady waits for peers to sync and initializes self info.
+func (p *peerManager) waitPeersReady() {
+	interval := 3 * time.Second
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
-		peers, err := FetchConnectedPeers(p.cli, timeout)
-		if err != nil || len(peers) == 0 {
-			log.Debug("EnsurePeersReady", "session", p.sessionID, "fetchConnectedPeers err:", err, "peers", len(peers))
-			time.Sleep(timeout)
-			continue
+		peers, err := FetchConnectedPeers(p.cli, interval)
+		if err == nil && len(peers) > 0 {
+			if p.selfID == "" && peers[len(peers)-1].Self {
+				p.selfID = peers[len(peers)-1].Name
+				p.removeSelf()
+			}
+			if p.selfID != "" && p.hasAllPeersConnected(peers) {
+				return
+			}
+			log.Debug("waitPeersReady waiting for peers to sync",
+				"session", p.sessionID, "fetchPeers", len(peers))
+		} else {
+			log.Debug("waitPeersReady",
+				"session", p.sessionID, "fetchConnectedPeers err:", err, "peers", len(peers))
 		}
-		if p.selfID == "" && peers[len(peers)-1].Self {
-			p.selfID = peers[len(peers)-1].Name
-			p.removeSelf()
-		}
-		if p.hasAllPeersConnected(peers) && p.selfID != "" {
-			return
-		}
-		log.Debug("EnsurePeersReady waiting for peers to sync", "session", p.sessionID, "fetchPeers", len(peers))
-
 		select {
 		case <-p.ctx.Done():
 			return

--- a/system/crypto/tss/tss.go
+++ b/system/crypto/tss/tss.go
@@ -29,8 +29,8 @@ func init() {
 
 // init tss service
 func initTSS(ctx cryptocli.CryptoContext) error {
-	cfg := ctx.API.GetConfig()
-	if !cfg.GetModuleConfig().Crypto.EnableTSS {
+	cryptofg := ctx.API.GetConfig().GetModuleConfig().Crypto
+	if cryptofg == nil || !cryptofg.EnableTSS {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- 为 TSS（阈值签名方案）的 DKG、Sign 和 Reshare 流程引入了基于 context 的超时机制，防止会话挂起。
- 修复了当 `Crypto` 配置为 nil 时，TSS 服务初始化发生 panic 的问题。
- 修复queue关闭时done未赋值，导致的监听nil channel死锁问题