### PR TITLE
fix: gofmt formatting for types/evm_event.pb.go

### DIFF
--- a/types/evm_event.pb.go
+++ b/types/evm_event.pb.go
@@ -195,7 +195,7 @@ func (x *EVMTxAndLogs) GetLogsPerTx() *EVMLogsPerTx {
 	return nil
 }
 
-//一个块中包含的多条evm event log数据
+// 一个块中包含的多条evm event log数据
 type EVMTxLogPerBlk struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -291,7 +291,7 @@ func (x *EVMTxLogPerBlk) GetSeqNum() int64 {
 	return 0
 }
 
-//多个块中包含的多条evm event log数据
+// 多个块中包含的多条evm event log数据
 type EVMTxLogsInBlks struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
## Summary
Fix `check_fmt` CI failure caused by comment spacing in auto-generated protobuf file.

## Test Plan
- [x] `gofmt -l types/evm_event.pb.go` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)