### PR TITLE
docs: remove codecov badge that is no longer updating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,6 @@ jobs:
         run: |
           sudo sysctl -w net.core.rmem_max=2500000
           make coverage
-      - name: cover report
-        if: success()
-        run: bash <(curl -s https://codecov.io/bash)
 
   build-with-latest-stable-go:
     strategy:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/6874
 [![pipeline status](https://github.com/33cn/chain33/actions/workflows/build.yml/badge.svg)](https://github.com/33cn/chain33/actions/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/33cn/chain33)](https://goreportcard.com/report/github.com/33cn/chain33)
  [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/33cn/chain33?svg=true&branch=master&passingText=Windows%20-%20OK&failingText=Windows%20-%20failed&pendingText=Windows%20-%20pending)](https://ci.appveyor.com/project/33cn/chain33)
-[![codecov](https://codecov.io/gh/33cn/chain33/branch/master/graph/badge.svg)](https://codecov.io/gh/33cn/chain33) [![Join the chat at https://gitter.im/33cn/Lobby](https://badges.gitter.im/33cn/Lobby.svg)](https://gitter.im/33cn/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/33cn/Lobby](https://badges.gitter.im/33cn/Lobby.svg)](https://gitter.im/33cn/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 # Chain33 区块链开发框架

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/6874
 [![pipeline status](https://github.com/33cn/chain33/actions/workflows/build.yml/badge.svg)](https://github.com/33cn/chain33/actions/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/33cn/chain33)](https://goreportcard.com/report/github.com/33cn/chain33)
  [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/33cn/chain33?svg=true&branch=master&passingText=Windows%20-%20OK&failingText=Windows%20-%20failed&pendingText=Windows%20-%20pending)](https://ci.appveyor.com/project/33cn/chain33)
+[![code coverage](https://img.shields.io/badge/coverage-48%25-orange)](https://github.com/33cn/chain33/actions/workflows/build.yml)
 [![Join the chat at https://gitter.im/33cn/Lobby](https://badges.gitter.im/33cn/Lobby.svg)](https://gitter.im/33cn/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 


### PR DESCRIPTION
## Summary
- Remove codecov badge (stopped updating — uploads fail with "Rate limit reached")
- Replace with shields.io static coverage badge showing 48%
- Remove broken `cover report` step from `build.yml` CI workflow

The codecov upload has been failing consistently with rate limit errors. This PR:
1. Removes the broken CI step that tried to upload to codecov
2. Replaces the badge with a static shields.io badge linked to the CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)