### PR TITLE
平行链可以开启收取手续费

### DIFF
--- a/cmd/chain33/chain33.fork.toml
+++ b/cmd/chain33/chain33.fork.toml
@@ -28,6 +28,7 @@ ForkEthAddressFormat=0
 ForkCheckEthTxSort=0
 ForkProxyExec=0
 ForkMaxTxFeeV1=0
+ForkParaFee=-1
 [fork.sub.none]
 ForkUseTimeDelay=0
 

--- a/cmd/chain33/chain33.system.fork.toml
+++ b/cmd/chain33/chain33.system.fork.toml
@@ -28,3 +28,4 @@ ForkEthAddressFormat=0
 ForkCheckEthTxSort=0
 ForkProxyExec=0
 ForkMaxTxFeeV1=0
+ForkParaFee=-1

--- a/executor/execenv.go
+++ b/executor/execenv.go
@@ -455,8 +455,7 @@ func (e *executor) execFee(tx *types.Transaction, index int) (*types.Receipt, er
 	}
 	var err error
 	//主网需要收手续费, 平行链开启收费则收取手续费
-	needFee := !e.cfg.IsPara() || e.cfg.IsFork(e.height, "ForkParaFee")
-	if needFee && e.cfg.GetMinTxFeeRate() > 0 && !ex.IsFree() {
+	if (!e.cfg.IsPara() || e.cfg.IsFork(e.height, "ForkParaFee")) && e.cfg.GetMinTxFeeRate() > 0 && !ex.IsFree() {
 		feelog, err = e.processFee(tx)
 		if err != nil {
 			return nil, err

--- a/executor/execenv.go
+++ b/executor/execenv.go
@@ -455,8 +455,7 @@ func (e *executor) execFee(tx *types.Transaction, index int) (*types.Receipt, er
 	}
 	var err error
 	//主网需要收手续费, 平行链开启收费则收取手续费
-	needParaFee := e.cfg.IsFork(e.height, "ForkParaFee")
-	needFee := !e.cfg.IsPara() || needParaFee
+	needFee := !e.cfg.IsPara() || e.cfg.IsFork(e.height, "ForkParaFee")
 	if needFee && e.cfg.GetMinTxFeeRate() > 0 && !ex.IsFree() {
 		feelog, err = e.processFee(tx)
 		if err != nil {

--- a/executor/execenv.go
+++ b/executor/execenv.go
@@ -454,8 +454,10 @@ func (e *executor) execFee(tx *types.Transaction, index int) (*types.Receipt, er
 		}
 	}
 	var err error
-	//平行链不收取手续费
-	if !e.cfg.IsPara() && e.cfg.GetMinTxFeeRate() > 0 && !ex.IsFree() {
+	//主网需要收手续费, 平行链开启收费则收取手续费
+	needParaFee := e.cfg.IsFork(e.height, "ForkParaFee")
+	needFee := !e.cfg.IsPara() || needParaFee
+	if needFee && e.cfg.GetMinTxFeeRate() > 0 && !ex.IsFree() {
 		feelog, err = e.processFee(tx)
 		if err != nil {
 			return nil, err

--- a/executor/execenv_test.go
+++ b/executor/execenv_test.go
@@ -18,6 +18,9 @@ import (
 
 	"strings"
 
+	"github.com/33cn/chain33/client"
+	"github.com/33cn/chain33/queue"
+	"github.com/33cn/chain33/store"
 	_ "github.com/33cn/chain33/system"
 	"github.com/33cn/chain33/types"
 	"github.com/33cn/chain33/util"
@@ -161,4 +164,129 @@ func TestProxyExec(t *testing.T) {
 
 	//与原始交易对比
 	assert.Equal(t, coinsTx.Hash(), testTx.Hash())
+}
+
+// feeTestApp 用于execFee测试
+type feeTestApp struct {
+	*drivers.DriverBase
+	driverName string
+}
+
+func newFeeTestApp() drivers.Driver {
+	app := &feeTestApp{DriverBase: &drivers.DriverBase{}, driverName: "feetest"}
+	app.SetChild(app)
+	return app
+}
+
+func (app *feeTestApp) GetDriverName() string {
+	return app.driverName
+}
+
+func newFeeTestFreeApp() drivers.Driver {
+	app := &feeTestApp{DriverBase: &drivers.DriverBase{}, driverName: "feetestfree"}
+	app.SetChild(app)
+	app.SetIsFree(true)
+	return app
+}
+
+func TestExecFee(t *testing.T) {
+	// 注册测试驱动
+	defaultCfg := types.NewChain33Config(types.GetDefaultCfgstring())
+	drivers.Register(defaultCfg, "feetest", newFeeTestApp, 0)
+	drivers.Register(defaultCfg, "feetestfree", newFeeTestFreeApp, 0)
+
+	cases := []struct {
+		title        string
+		paraTitle    string // 空表示非平行链
+		height       int64
+		forkHeight   int64
+		minTxFeeRate int64
+		execer       string
+		expectFee    bool // 是否期望调用 processFee
+	}{
+		{
+			title:        "平行链, 高度在ForkParaFee之前, 不收费",
+			paraTitle:    "user.p.tname.",
+			height:       5,
+			forkHeight:   10,
+			minTxFeeRate: 100,
+			execer:       "feetest",
+			expectFee:    false,
+		},
+		{
+			title:        "平行链, 高度在ForkParaFee之后, feeRate>0, !IsFree, 收费",
+			paraTitle:    "user.p.tname.",
+			height:       15,
+			forkHeight:   10,
+			minTxFeeRate: 100,
+			execer:       "feetest",
+			expectFee:    true,
+		},
+		{
+			title:        "平行链, 高度在ForkParaFee之后, feeRate==0, 不收费",
+			paraTitle:    "user.p.tname.",
+			height:       15,
+			forkHeight:   10,
+			minTxFeeRate: 0,
+			execer:       "feetest",
+			expectFee:    false,
+		},
+		{
+			title:        "平行链, 高度在ForkParaFee之后, feeRate>0, IsFree, 不收费",
+			paraTitle:    "user.p.tname.",
+			height:       15,
+			forkHeight:   10,
+			minTxFeeRate: 100,
+			execer:       "feetestfree",
+			expectFee:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			cfgstring := types.GetDefaultCfgstring()
+			// 将默认local标题替换为目标标题, 确保needSetForkZero()正确初始化para fork
+			cfgstring = strings.Replace(cfgstring, `Title="local"`, `Title="`+tc.paraTitle+`"`, 1)
+			cfg := types.NewChain33Config(cfgstring)
+			// needSetForkZero() 已将 ForkParaFee 置0, 覆盖为目标值
+			forks, _ := cfg.GetForks()
+			forks["ForkParaFee"] = tc.forkHeight
+			cfg.SetMinFee(tc.minTxFeeRate)
+
+			q := queue.New("channel")
+			q.SetConfig(cfg)
+			st := store.New(cfg)
+			st.SetQueueClient(q.Client())
+			defer st.Close()
+
+			exec := New(cfg)
+			exec.client = q.Client()
+			exec.qclient, _ = client.New(exec.client, nil)
+
+			priv := util.TestPrivkeyList[0]
+			tx := util.CreateTxWithExecer(cfg, priv, tc.execer)
+			// 不手动设置Fee, FormatTxExt会根据minTxFeeRate计算
+
+			ctx := &executorCtx{
+				height:     tc.height,
+				blocktime:  time.Now().Unix(),
+				difficulty: 1,
+			}
+			execute := newExecutor(ctx, exec, nil, []*types.Transaction{tx}, nil)
+
+			receipt, err := execute.execFee(tx, 0)
+			if tc.expectFee {
+				// processFee被调用, 因账户余额为0而返回ErrNoBalance
+				assert.Equal(t, types.ErrNoBalance, err)
+				assert.Nil(t, receipt)
+			} else {
+				assert.Nil(t, err)
+				if receipt == nil {
+					t.Fatal("receipt must not be nil when no error")
+				}
+				assert.Equal(t, int32(types.ExecPack), receipt.Ty)
+				assert.Equal(t, 0, len(receipt.KV))
+			}
+		})
+	}
 }

--- a/types/fork.go
+++ b/types/fork.go
@@ -146,6 +146,7 @@ func (f *Forks) RegisterSystemFork() {
 	f.setFork("ForkCheckEthTxSort", 0)
 	f.setFork("ForkProxyExec", 0)
 	f.setFork("ForkMaxTxFeeV1", 0)
+	f.SetFork("ForkParaFee", -1)
 
 }
 

--- a/types/fork.go
+++ b/types/fork.go
@@ -146,7 +146,7 @@ func (f *Forks) RegisterSystemFork() {
 	f.setFork("ForkCheckEthTxSort", 0)
 	f.setFork("ForkProxyExec", 0)
 	f.setFork("ForkMaxTxFeeV1", 0)
-	f.SetFork("ForkParaFee", -1)
+	f.setFork("ForkParaFee", -1)
 
 }
 

--- a/types/testdata/chain33.toml
+++ b/types/testdata/chain33.toml
@@ -157,7 +157,6 @@ ForkStateDBSet=-1
 ForkMaxTxFeeV1=30839600
 ForkMaxTxFeeV2=30939600
 ForkParaFee=-1
-
 [fork.sub.manage]
 Enable=120000
 ForkV11ManageExec= 400000

--- a/types/testdata/chain33.toml
+++ b/types/testdata/chain33.toml
@@ -156,6 +156,8 @@ ForkV24TxGroupPara= 806578
 ForkStateDBSet=-1
 ForkMaxTxFeeV1=30839600
 ForkMaxTxFeeV2=30939600
+ForkParaFee=-1
+
 [fork.sub.manage]
 Enable=120000
 ForkV11ManageExec= 400000


### PR DESCRIPTION
平行链可以开启收取手续费 #1330

## Upgrade Notes / 升级风险说明

1. **MinTxFeeRate 需要同步配置**：启用该 fork 需要平行链 `Mempool.MinTxFeeRate > 0` 才真正生效，否则是 no-op。
2. **客户端/钱包兼容性**：升级到 fork 高度后，旧客户端发送的 `tx.Fee=0` 交易会开始失败，SDK 和钱包需要同步更新。
3. **余额检查**：平行链 `processFee` 走 `coins` 扣 `tx.From()` 余额，rollup 场景下需要确认平行链 coins 状态里发送方有足够余额，否则可能出现大量交易因扣费失败被回退。