### PR TITLE
docs: replace broken godoc badge with pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![API Reference](
-https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
-)](https://godoc.org/github.com/33cn/chain33)
+[![Go Reference](https://pkg.go.dev/badge/github.com/33cn/chain33.svg)](https://pkg.go.dev/github.com/33cn/chain33)
 [![pipeline status](https://github.com/33cn/chain33/actions/workflows/build.yml/badge.svg)](https://github.com/33cn/chain33/actions/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/33cn/chain33)](https://goreportcard.com/report/github.com/33cn/chain33)
  [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/33cn/chain33?svg=true&branch=master&passingText=Windows%20-%20OK&failingText=Windows%20-%20failed&pendingText=Windows%20-%20pending)](https://ci.appveyor.com/project/33cn/chain33)


### PR DESCRIPTION
## Summary
- The first README badge (\"API Reference\") fails to render — it uses a stale `camo.githubusercontent.com` proxy URL whose hex payload decodes to `https://godoc.org/github.com/golang/gddo?status.svg`
- godoc.org has been retired, and the target was the wrong repo (`golang/gddo`) anyway
- Replace with the standard `pkg.go.dev` badge pointing at this repo

## Test plan
- [ ] Badge renders on GitHub master after merge
- [ ] Link goes to https://pkg.go.dev/github.com/33cn/chain33

🤖 Generated with [Claude Code](https://claude.com/claude-code)