### PR TITLE
fix(ethrpc): prevent uint64→int64 overflow in AssembleChain33Tx

### DIFF
--- a/rpc/ethrpc/eth/eth.go
+++ b/rpc/ethrpc/eth/eth.go
@@ -378,6 +378,10 @@ func (e *ethHandler) SendRawTransaction(rawData string) (hexutil.Bytes, error) {
 	}
 
 	chain33Tx := types.AssembleChain33Tx(ntx, sig, pubkey, e.cfg)
+	if chain33Tx == nil {
+		log.Error("SendRawTransaction", "AssembleChain33Tx failed")
+		return nil, errors.New("failed to assemble chain33 tx")
+	}
 	reply, err := e.cli.SendTx(chain33Tx)
 	log.Info("SendRawTransaction", "cacuHash", common.Bytes2Hex(chain33Tx.Hash()),
 		"ethHash:", ntx.Hash().String(), "exec", string(chain33Tx.Execer), "mempool reply:", common.Bytes2Hex(reply.GetMsg()), "err:", err)

--- a/rpc/ethrpc/types/tx.go
+++ b/rpc/ethrpc/types/tx.go
@@ -496,8 +496,16 @@ func AssembleChain33Tx(etx *etypes.Transaction, sig, pubkey []byte, cfg *ctypes.
 
 	if etx.Value() != nil {
 		bigAmount := precisionEth2Coins(etx.Value(), cfg.GetCoinPrecision())
+		if !bigAmount.IsInt64() {
+			log.Error("AssembleChain33Tx", "value exceeds int64 range after precision conversion",
+				"ethValue", etx.Value().String(), "converted", bigAmount.String())
+			return nil
+		}
 		amount = bigAmount.Int64()
-
+		if amount < 0 {
+			log.Error("AssembleChain33Tx", "amount overflow to negative", "amount", amount)
+			return nil
+		}
 	}
 	action := &ctypes.EVMContractAction4Chain33{
 		Amount:       uint64(amount),


### PR DESCRIPTION
Sync fix for same uint64→int64 overflow pattern in AssembleChain33Tx. Adds IsInt64() guard and nil protection.