### PR TITLE
feat: add consensus-level account blacklist to block attacker addresses

### DIFF
--- a/cmd/chain33/chain33.fork.toml
+++ b/cmd/chain33/chain33.fork.toml
@@ -29,6 +29,8 @@ ForkCheckEthTxSort=0
 ForkProxyExec=0
 ForkMaxTxFeeV1=0
 ForkParaFee=-1
+# 账户黑名单启用高度，命中名单的交易在此高度后视为非法交易，所在区块整块拒绝；-1 表示关闭
+ForkAccountBlacklist=-1
 [fork.sub.none]
 ForkUseTimeDelay=0
 

--- a/cmd/chain33/chain33.system.fork.toml
+++ b/cmd/chain33/chain33.system.fork.toml
@@ -29,3 +29,5 @@ ForkCheckEthTxSort=0
 ForkProxyExec=0
 ForkMaxTxFeeV1=0
 ForkParaFee=-1
+# 账户黑名单启用高度，命中名单的交易在此高度后视为非法交易，所在区块整块拒绝；-1 表示关闭
+ForkAccountBlacklist=-1

--- a/cmd/tools/strategy/create_plugin_file_template.go
+++ b/cmd/tools/strategy/create_plugin_file_template.go
@@ -226,6 +226,8 @@ ForkChainParamV2= -1
 ForkBase58AddressCheck=1800000
 ForkTicketFundAddrV1=-1
 ForkRootHash=1
+# 账户黑名单启用高度；-1 表示关闭
+ForkAccountBlacklist=-1
 [fork.sub.coins]
 Enable=0
 [fork.sub.ticket]

--- a/executor/account_blacklist_test.go
+++ b/executor/account_blacklist_test.go
@@ -1,0 +1,88 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package executor
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/33cn/chain33/types"
+	"github.com/33cn/chain33/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockedTestAddr 是 TestPrivkeyList[1] 派生的地址，测试里注入黑名单
+const blockedTestAddr = "14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
+
+func newBlockedExecutor(t *testing.T, blockedAddrs []string) (*executor, *types.Chain33Config) {
+	t.Helper()
+	exec, _ := initEnv(types.GetDefaultCfgstring())
+	cfg := exec.client.GetConfig()
+	// local 标题下 SetAllFork(0)，ForkAccountBlacklist 从高度 0 启用
+	restore := types.SetBlockedAccountsForTest(blockedAddrs)
+	t.Cleanup(restore)
+	ctx := &executorCtx{
+		height:     1,
+		blocktime:  time.Now().Unix(),
+		difficulty: 1,
+	}
+	return newExecutor(ctx, exec, nil, nil, nil), cfg
+}
+
+func TestCheckTxBlockedAccount(t *testing.T) {
+	execute, cfg := newBlockedExecutor(t, []string{blockedTestAddr})
+	normalPriv := util.TestPrivkeyList[0]
+	blockedPriv := util.TestPrivkeyList[1]
+	normalAddr, _ := util.Genaddress()
+
+	t.Run("hit from", func(t *testing.T) {
+		tx := util.CreateCoinsTx(cfg, blockedPriv, normalAddr, 1000)
+		err := execute.checkTx(tx, 0)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, types.ErrBlockedAccount))
+	})
+
+	t.Run("hit to", func(t *testing.T) {
+		tx := util.CreateCoinsTx(cfg, normalPriv, blockedTestAddr, 1000)
+		err := execute.checkTx(tx, 0)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, types.ErrBlockedAccount))
+	})
+
+	t.Run("normal pass", func(t *testing.T) {
+		tx := util.CreateCoinsTx(cfg, normalPriv, normalAddr, 1000)
+		assert.NoError(t, execute.checkTx(tx, 0))
+	})
+}
+
+func TestCheckTxGroupBlockedAccount(t *testing.T) {
+	execute, cfg := newBlockedExecutor(t, []string{blockedTestAddr})
+	normalPriv := util.TestPrivkeyList[0]
+	addr2, priv2 := util.Genaddress()
+	addr3, priv3 := util.Genaddress()
+
+	// 组内第二笔 to 命中黑名单 -> 整组 checkTxGroup 返回 ErrBlockedAccount
+	txs := []*types.Transaction{
+		util.CreateCoinsTx(cfg, normalPriv, addr2, 1000),
+		util.CreateCoinsTx(cfg, priv2, blockedTestAddr, 1000),
+		util.CreateCoinsTx(cfg, priv3, addr3, 1000),
+	}
+	txgroup, err := types.CreateTxGroup(txs, cfg.GetMinTxFeeRate())
+	require.NoError(t, err)
+	err = execute.checkTxGroup(txgroup, 0)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBlockedAccount))
+
+	// 全部正常 -> 通过
+	txs2 := []*types.Transaction{
+		util.CreateCoinsTx(cfg, normalPriv, addr2, 1000),
+		util.CreateCoinsTx(cfg, priv2, addr3, 1000),
+	}
+	txgroup2, err := types.CreateTxGroup(txs2, cfg.GetMinTxFeeRate())
+	require.NoError(t, err)
+	assert.NoError(t, execute.checkTxGroup(txgroup2, 0))
+}

--- a/executor/execenv.go
+++ b/executor/execenv.go
@@ -169,6 +169,11 @@ func (e *executor) checkTx(tx *types.Transaction, index int) error {
 		elog.Error("checkTx execNameNotAllow", "realname", string(e.getRealExecName(tx, index)), "exec", string(tx.Execer))
 		return types.ErrExecNameNotAllow
 	}
+	// 账户黑名单：命中则在扣手续费前返回 error，最终包装为 ExecErr
+	if err := types.CheckTxBlockedAccount(e.cfg, e.height, tx); err != nil {
+		elog.Error("checkTx blocked account", "txhash", common.ToHex(tx.Hash()), "height", e.height, "err", err)
+		return err
+	}
 	return nil
 }
 
@@ -193,6 +198,11 @@ func (e *executor) checkTxGroup(txgroup *types.Transactions, index int) error {
 		return types.ErrTxExpire
 	}
 	if err := txgroup.Check(e.cfg, e.height, e.cfg.GetMinTxFeeRate(), e.cfg.GetMaxTxFee(e.height)); err != nil {
+		return err
+	}
+	// 交易组不会对组内单笔再调 checkTx，必须在此整组检查黑名单
+	if err := types.CheckTxsBlockedAccount(e.cfg, e.height, txgroup.GetTxs()); err != nil {
+		elog.Error("checkTxGroup blocked account", "height", e.height, "err", err)
 		return err
 	}
 	return nil
@@ -703,7 +713,8 @@ func (e *executor) execTx(exec *Executor, tx *types.Transaction, index int) (*ty
 	err = e.checkTx(tx, index)
 	if err != nil {
 		elog.Error("execTx.checkTx ", "txhash", common.ToHex(tx.Hash()), "err", err)
-		if e.cfg.IsPara() {
+		// 黑名单命中是预期共识错误，平行链也不得 panic，需包装成 ExecErr 使区块非法
+		if e.cfg.IsPara() && !errors.Is(err, types.ErrBlockedAccount) {
 			panic(err)
 		}
 		return nil, err

--- a/system/consensus/base.go
+++ b/system/consensus/base.go
@@ -602,6 +602,12 @@ func (bc *BaseClient) AddTxsToBlock(block *types.Block, txs []*types.Transaction
 			continue
 		}
 		if txGroup == nil {
+			// 出块侧过滤黑名单交易，避免进入 PreExecBlock 后再剔除
+			if err := types.CheckTxBlockedAccount(cfg, block.Height, txs[i]); err != nil {
+				tlog.Error("AddTxsToBlock skip blocked account", "txhash", common.ToHex(txs[i].Hash()),
+					"height", block.Height, "err", err)
+				continue
+			}
 			currentCount++
 			if currentCount > maxTx {
 				return addedTx
@@ -613,6 +619,12 @@ func (bc *BaseClient) AddTxsToBlock(block *types.Block, txs []*types.Transaction
 			addedTx = append(addedTx, txs[i])
 			block.Txs = append(block.Txs, txs[i])
 		} else {
+			// 交易组任一笔命中黑名单则整组跳过
+			if err := types.CheckTxsBlockedAccount(cfg, block.Height, txGroup.GetTxs()); err != nil {
+				tlog.Error("AddTxsToBlock skip blocked tx group", "txhash", common.ToHex(txs[i].Hash()),
+					"height", block.Height, "err", err)
+				continue
+			}
 			currentCount += int64(len(txGroup.Txs))
 			if currentCount > maxTx {
 				return addedTx

--- a/system/mempool/account_blacklist_test.go
+++ b/system/mempool/account_blacklist_test.go
@@ -1,0 +1,160 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mempool
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/33cn/chain33/common"
+	"github.com/33cn/chain33/common/address"
+	"github.com/33cn/chain33/queue"
+	nty "github.com/33cn/chain33/system/dapp/none/types"
+	"github.com/33cn/chain33/types"
+	"github.com/33cn/chain33/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const blockedMempoolAddr = "14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
+
+// TestMempoolCheckTxBlockedAccount mempool 入口拦截（统一深度判定，无 fork 门控）
+func TestMempoolCheckTxBlockedAccount(t *testing.T) {
+	_, mem := initEnv(1)
+	cfg := mem.client.GetConfig()
+	restore := types.SetBlockedAccountsForTest([]string{blockedMempoolAddr})
+	defer restore()
+
+	normalPriv := util.TestPrivkeyList[0]
+	blockedPriv := util.TestPrivkeyList[1]
+	normalAddr, _ := util.Genaddress()
+
+	// 需要 header 才能走完整 checkTx
+	mem.setHeader(&types.Header{Height: 1, BlockTime: 1})
+
+	t.Run("hit from", func(t *testing.T) {
+		tx := createTx(cfg, blockedPriv, normalAddr, 1000)
+		msg := mem.checkTx(&queue.Message{Data: tx})
+		require.NotNil(t, msg.Data)
+		err, ok := msg.Data.(error)
+		require.True(t, ok, "expect error data, got %T", msg.Data)
+		assert.True(t, errors.Is(err, types.ErrBlockedAccount))
+	})
+
+	t.Run("hit to", func(t *testing.T) {
+		tx := createTx(cfg, normalPriv, blockedMempoolAddr, 1000)
+		msg := mem.checkTx(&queue.Message{Data: tx})
+		require.NotNil(t, msg.Data)
+		err, ok := msg.Data.(error)
+		require.True(t, ok, "expect error data, got %T", msg.Data)
+		assert.True(t, errors.Is(err, types.ErrBlockedAccount))
+	})
+
+	t.Run("normal pass", func(t *testing.T) {
+		tx := createTx(cfg, normalPriv, normalAddr, 1000)
+		msg := mem.checkTx(&queue.Message{Data: tx})
+		// 正常交易 Data 仍为原 tx
+		assert.Equal(t, tx, msg.Data)
+	})
+
+	// 深度判定关键用例：EVM 纯转账真实收款方藏在 Para 里，tx.To 是执行器地址。
+	// 旧的浅层 From/To 判断会漏拦，改用 CheckTxBlockedAccountImmediate 后才能覆盖。
+	t.Run("hit evm para hidden receiver", func(t *testing.T) {
+		raw, err := address.NewBtcAddress(blockedMempoolAddr)
+		require.NoError(t, err)
+		action := &types.EVMContractAction4Chain33{
+			Amount:       1,
+			GasLimit:     10000,
+			GasPrice:     1,
+			Para:         raw.Hash160[:],
+			ContractAddr: address.ExecAddress("evm"),
+		}
+		tx := &types.Transaction{
+			Execer:  []byte("evm"),
+			To:      address.ExecAddress("evm"),
+			Payload: types.Encode(action),
+			Fee:     1e6,
+			ChainID: cfg.GetChainID(),
+		}
+		tx.Sign(types.SECP256K1, normalPriv)
+
+		// 浅层判断（旧实现）看不到 Para 里的地址
+		assert.False(t, types.IsBlockedAccount(tx.From()))
+		assert.False(t, types.IsBlockedAccount(tx.To))
+		// 深度判定能拦住
+		msg := mem.checkTx(&queue.Message{Data: tx})
+		berr, ok := msg.Data.(error)
+		require.True(t, ok, "expect error data, got %T", msg.Data)
+		assert.True(t, errors.Is(berr, types.ErrBlockedAccount))
+	})
+}
+
+// createCommitDelayBlock 构造携带 CommitDelayTx 的 none 区块，内嵌延时交易 innerTx
+func createCommitDelayBlock(innerTx *types.Transaction, height int64) *types.Block {
+	action := &nty.NoneAction{
+		Ty: nty.TyCommitDelayTxAction,
+		Value: &nty.NoneAction_CommitDelayTx{CommitDelayTx: &nty.CommitDelayTx{
+			DelayTx:             common.ToHex(types.Encode(innerTx)),
+			RelativeDelayHeight: 1,
+		}},
+	}
+	blockTx := &types.Transaction{Execer: []byte(nty.NoneX), Payload: types.Encode(action)}
+	return &types.Block{Height: height, BlockTime: height, Txs: []*types.Transaction{blockTx}}
+}
+
+// TestEventAddDelayTxBlockedAccount 延时交易提交入口拦截
+func TestEventAddDelayTxBlockedAccount(t *testing.T) {
+	// delayCache 容量为 poolCacheSize/2，取 10 保证正常交易可入 cache
+	_, mem := initEnv(10)
+	restore := types.SetBlockedAccountsForTest([]string{blockedMempoolAddr})
+	defer restore()
+	cfg := mem.client.GetConfig()
+
+	normalPriv := util.TestPrivkeyList[0]
+	blockedPriv := util.TestPrivkeyList[1]
+	normalAddr, _ := util.Genaddress()
+
+	sendDelayTx := func(delayTx *types.DelayTx) *types.Reply {
+		msg := queue.NewMessage(0, "mempool", types.EventAddDelayTx, delayTx)
+		mem.eventAddDelayTx(msg)
+		resp, err := mem.client.Wait(msg)
+		require.NoError(t, err)
+		reply, ok := resp.GetData().(*types.Reply)
+		require.True(t, ok, "expect *types.Reply, got %T", resp.GetData())
+		return reply
+	}
+
+	// 命中黑名单：提交即拒，不进 delayCache
+	reply := sendDelayTx(&types.DelayTx{Tx: createTx(cfg, blockedPriv, normalAddr, 1000), EndDelayTime: 100})
+	require.False(t, reply.IsOk)
+	assert.Contains(t, string(reply.Msg), types.ErrBlockedAccount.Error())
+	assert.Equal(t, 0, len(mem.cache.delayCache.hashCache))
+
+	// 正常延时交易仍可入 cache
+	reply = sendDelayTx(&types.DelayTx{Tx: createTx(cfg, normalPriv, normalAddr, 1000), EndDelayTime: 100})
+	require.True(t, reply.IsOk, string(reply.Msg))
+	assert.Equal(t, 1, len(mem.cache.delayCache.hashCache))
+}
+
+// TestAddDelayTxBlockedAccount 区块 CommitDelayTx 入 cache 拦截
+func TestAddDelayTxBlockedAccount(t *testing.T) {
+	_, mem := initEnv(1)
+	restore := types.SetBlockedAccountsForTest([]string{blockedMempoolAddr})
+	defer restore()
+	cfg := mem.client.GetConfig()
+
+	blockedPriv := util.TestPrivkeyList[1]
+	normalAddr, _ := util.Genaddress()
+
+	cache := newDelayTxCache(10)
+
+	// 命中黑名单的内嵌延时交易不入 cache
+	mem.addDelayTx(cache, createCommitDelayBlock(createTx(cfg, blockedPriv, normalAddr, 1000), 10))
+	assert.Equal(t, 0, len(cache.hashCache))
+
+	// 正常内嵌延时交易仍可入 cache
+	mem.addDelayTx(cache, createCommitDelayBlock(createTx(cfg, util.TestPrivkeyList[0], normalAddr, 1000), 11))
+	assert.Equal(t, 1, len(cache.hashCache))
+}

--- a/system/mempool/check.go
+++ b/system/mempool/check.go
@@ -71,6 +71,13 @@ func (mem *Mempool) checkTx(msg *queue.Message) *queue.Message {
 		msg.Data = types.ErrInvalidAddress
 		return msg
 	}
+	// 账户黑名单入口拦截：不加 fork 门控，随二进制升级立即生效（本地 mempool 行为，无共识分叉风险）
+	// 走统一深度判定，覆盖 From / To / RealTo / EVM payload，避免浅层判断漏拦平行链 EVM 纯转账
+	if err := types.CheckTxBlockedAccountImmediate(tx); err != nil {
+		mlog.Error("checkTx blocked account", "txhash", common.ToHex(tx.Hash()), "err", err)
+		msg.Data = err
+		return msg
+	}
 	// 检查交易账户在mempool中是否存在过多交易
 	from := tx.From()
 	if mem.TxNumOfAccount(from) >= mem.cfg.MaxTxNumPerAccount {
@@ -123,7 +130,7 @@ func (mem *Mempool) checkTxs(msg *queue.Message) *queue.Message {
 	if txs == nil {
 		return mem.checkTx(msg)
 	}
-	//txgroup 的交易
+	//txgroup 的交易，逐笔走 checkTx（已含黑名单深度判定）
 	for i := 0; i < len(txs.Txs); i++ {
 		msgitem := mem.checkTx(&queue.Message{Data: txs.Txs[i]})
 		if msgitem.Err() != nil {

--- a/system/mempool/eventprocess.go
+++ b/system/mempool/eventprocess.go
@@ -212,6 +212,12 @@ func (mem *Mempool) addDelayTx(cache *delayTxCache, block *types.Block) {
 			continue
 		}
 
+		// 区块内嵌的延时交易，入 cache 前先过黑名单，到期不会被再次投递
+		if berr := types.CheckTxBlockedAccountImmediate(tx); berr != nil {
+			mlog.Error("addDelayTx skip blocked account", "txHash", common.ToHex(tx.Hash()), "err", berr)
+			continue
+		}
+
 		delayTx := &types.DelayTx{}
 		delayTx.Tx = tx
 		delayTx.EndDelayTime = commitInfo.GetRelativeDelayTime() + block.GetBlockTime()
@@ -329,7 +335,13 @@ func (mem *Mempool) eventAddDelayTx(msg *queue.Message) {
 
 	err := types.ErrInvalidParam
 	if delayTx, ok := msg.GetData().(*types.DelayTx); ok {
-		err = mem.cache.delayCache.addDelayTx(delayTx)
+		// 延时交易提交即拦（不经 checkTx），这里走 Immediate 深度判定
+		if berr := types.CheckTxBlockedAccountImmediate(delayTx.GetTx()); berr != nil {
+			mlog.Error("eventAddDelayTx blocked account", "txhash", common.ToHex(delayTx.GetTx().Hash()), "err", berr)
+			err = berr
+		} else {
+			err = mem.cache.delayCache.addDelayTx(delayTx)
+		}
 	}
 	replyMsg := mem.client.NewMessage("rpc", types.EventReply, nil)
 	if err != nil {

--- a/types/account_blacklist.go
+++ b/types/account_blacklist.go
@@ -1,0 +1,189 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"fmt"
+
+	"github.com/33cn/chain33/common"
+	"github.com/33cn/chain33/common/address"
+)
+
+// ForkAccountBlacklist 账户黑名单分叉名，配置在 [fork.system] 节。
+// 默认注册高度为 MaxHeight（永不启用），配置为具体高度 H 后，
+// 高度 >= H 的区块中涉及黑名单地址的交易将被共识层判为非法。
+const ForkAccountBlacklist = "ForkAccountBlacklist"
+
+// evmExecName EVM 执行器真实名，用于从 payload 中解析真实目标地址
+const evmExecName = "evm"
+
+// blockedAccounts 硬编码的攻击地址名单，命中后永久封禁（禁止收发任何交易）。
+// 支持 base58 编码的 1x 地址与 0x 开头的十六进制地址混写。
+// 注意：同一私钥派生的 base58 地址与 0x 地址 hash160 不同，是两个独立账户，
+// 如两种形态都在使用，需分别列入。
+// 上线前必须将 7.20 整数溢出攻击的地址名单填入，并逐条 dry-run 校验可解析。
+var blockedAccounts = []string{}
+
+// blockedAccountSet 黑名单原始 20 字节地址集合，由 blockedAccounts 解析生成。
+// 以原始 20 字节为 key，天然兼容 base58 与 0x 两种地址形态。
+var blockedAccountSet = parseBlockedAccounts(blockedAccounts)
+
+// SetBlockedAccountsForTest 仅供测试注入黑名单，返回恢复原集合的函数。
+// 生产代码请勿调用。
+func SetBlockedAccountsForTest(addrs []string) func() {
+	old := blockedAccountSet
+	blockedAccountSet = parseBlockedAccounts(addrs)
+	return func() {
+		blockedAccountSet = old
+	}
+}
+
+// parseBlockedAccounts 将名单统一解析为 20 字节原始地址集合。
+// 任一地址解析失败直接 panic，防止错别字地址在上线时静默漏放。
+func parseBlockedAccounts(addrs []string) map[[20]byte]struct{} {
+	set := make(map[[20]byte]struct{}, len(addrs))
+	for _, addr := range addrs {
+		raw, err := parseBlockedAccount(addr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid blocked account address %s: %v", addr, err))
+		}
+		if len(raw) != 20 {
+			panic(fmt.Sprintf("invalid blocked account address %s: raw length %d != 20", addr, len(raw)))
+		}
+		var key [20]byte
+		copy(key[:], raw)
+		set[key] = struct{}{}
+	}
+	return set
+}
+
+// parseBlockedAccount 解析单个地址：0x 十六进制地址按 hex 解码取 20 字节，
+// 其余按 base58 比特币格式地址解析取 hash160。
+func parseBlockedAccount(addr string) ([]byte, error) {
+	if address.IsEthAddress(addr) {
+		return common.FromHex(addr)
+	}
+	btcAddr, err := address.NewBtcAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+	return btcAddr.Hash160[:], nil
+}
+
+// IsBlockedAccountRaw 判断 20 字节原始地址是否命中黑名单
+func IsBlockedAccountRaw(raw []byte) bool {
+	if len(raw) != 20 || len(blockedAccountSet) == 0 {
+		return false
+	}
+	var key [20]byte
+	copy(key[:], raw)
+	_, ok := blockedAccountSet[key]
+	return ok
+}
+
+// IsBlockedAccount 判断地址（base58 或 0x 形态）是否命中黑名单。
+// 地址无法解析时视为未命中，返回 false。
+func IsBlockedAccount(addr string) bool {
+	if len(blockedAccountSet) == 0 {
+		return false
+	}
+	raw, err := parseBlockedAccount(addr)
+	if err != nil {
+		return false
+	}
+	return IsBlockedAccountRaw(raw)
+}
+
+// CheckTxBlockedAccount 共识层拦截（fork 门控 + 深度判定），
+// 供 executor.checkTx / checkTxGroup、BaseClient.AddTxsToBlock 调用。
+// ForkAccountBlacklist 高度后检查交易是否涉及黑名单地址，覆盖四个维度：
+// 发送方（tx.From）、接收方（tx.To / GetRealToAddr）、
+// EVM 合约目标地址（ContractAddr）、EVM 纯转账原始地址（20 字节 Para）。
+// 命中返回包装后的 ErrBlockedAccount，调用方可用 errors.Is 判定。
+func CheckTxBlockedAccount(cfg *Chain33Config, height int64, tx *Transaction) error {
+	if cfg == nil || !cfg.IsFork(height, ForkAccountBlacklist) {
+		return nil
+	}
+	return checkTxBlockedAccountCore(tx, height)
+}
+
+// CheckTxBlockedAccountImmediate 入口层拦截（不带 fork 门控 + 深度判定），
+// 供 mempool.checkTx / checkTxs 与延时交易 eventAddDelayTx / addDelayTx 调用。
+// mempool 是节点本地行为、不进状态计算、无共识分叉风险，随二进制升级立即生效，提前止血。
+func CheckTxBlockedAccountImmediate(tx *Transaction) error {
+	return checkTxBlockedAccountCore(tx, 0)
+}
+
+// CheckTxsBlockedAccount 交易组共识层拦截：任一笔命中返回 error，全部通过返回 nil。
+// 语义与 procExecTxList 的错误处理一致（组内任一笔 err 则整组每笔都 ExecErr）。
+func CheckTxsBlockedAccount(cfg *Chain33Config, height int64, txs []*Transaction) error {
+	for _, tx := range txs {
+		if err := CheckTxBlockedAccount(cfg, height, tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CheckTxsBlockedAccountImmediate 交易组入口层拦截（不带 fork 门控）
+func CheckTxsBlockedAccountImmediate(txs []*Transaction) error {
+	for _, tx := range txs {
+		if err := CheckTxBlockedAccountImmediate(tx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkTxBlockedAccountCore 黑名单深度判定核心逻辑，唯一实现完整四维判定。
+// logHeight 仅用于日志，不做 fork 判断；Immediate 入口传 0。
+func checkTxBlockedAccountCore(tx *Transaction, logHeight int64) error {
+	if len(blockedAccountSet) == 0 || tx == nil {
+		return nil
+	}
+	txhash := common.ToHex(tx.Hash())
+	if from := tx.From(); IsBlockedAccount(from) {
+		tlog.Error("CheckTxBlockedAccount hit", "txhash", txhash, "height", logHeight, "pos", "from", "addr", from)
+		return fmt.Errorf("%w: from %s", ErrBlockedAccount, from)
+	}
+	if to := tx.GetTo(); IsBlockedAccount(to) {
+		tlog.Error("CheckTxBlockedAccount hit", "txhash", txhash, "height", logHeight, "pos", "to", "addr", to)
+		return fmt.Errorf("%w: to %s", ErrBlockedAccount, to)
+	}
+	if realTo := tx.GetRealToAddr(); realTo != tx.GetTo() && IsBlockedAccount(realTo) {
+		tlog.Error("CheckTxBlockedAccount hit", "txhash", txhash, "height", logHeight, "pos", "realTo", "addr", realTo)
+		return fmt.Errorf("%w: real to %s", ErrBlockedAccount, realTo)
+	}
+	if err := checkEVMTxBlockedTarget(tx, logHeight, txhash); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkEVMTxBlockedTarget 解析 EVM 交易 payload 中的真实目标地址。
+// 平行链及 ETH 风格 coins 转账场景下 tx.To 可能被改写为执行器地址，
+// 真实接收方只能从 EVMContractAction4Chain33 中取得：
+// 合约调用取 ContractAddr，纯转账取 20 字节的 Para 原始地址。
+// len(Para) == 20 的判据是概率论证而非绝对安全：ABI calldata 极少恰好 20 字节，
+// 即便 isTransferNote 的备注误撞，概率约 N/2^160，可忽略。
+func checkEVMTxBlockedTarget(tx *Transaction, logHeight int64, txhash string) error {
+	if string(GetRealExecName(tx.GetExecer())) != evmExecName {
+		return nil
+	}
+	action := new(EVMContractAction4Chain33)
+	if err := Decode(tx.GetPayload(), action); err != nil {
+		return nil
+	}
+	if contractAddr := action.GetContractAddr(); contractAddr != "" && IsBlockedAccount(contractAddr) {
+		tlog.Error("CheckTxBlockedAccount hit", "txhash", txhash, "height", logHeight, "pos", "evmContractAddr", "addr", contractAddr)
+		return fmt.Errorf("%w: evm contract addr %s", ErrBlockedAccount, contractAddr)
+	}
+	if para := action.GetPara(); IsBlockedAccountRaw(para) {
+		addr := common.ToHex(para)
+		tlog.Error("CheckTxBlockedAccount hit", "txhash", txhash, "height", logHeight, "pos", "evmPara", "addr", addr)
+		return fmt.Errorf("%w: evm transfer to %s", ErrBlockedAccount, addr)
+	}
+	return nil
+}

--- a/types/account_blacklist_test.go
+++ b/types/account_blacklist_test.go
@@ -1,0 +1,259 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/33cn/chain33/common"
+	"github.com/33cn/chain33/common/address"
+	"github.com/33cn/chain33/common/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 固定测试地址（均来自仓库既有 fixture）
+const (
+	testBlockedBtcAddr = "14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
+	testBlockedEthAddr = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0"
+	testNormalBtcAddr  = "1JmFaA6unrCFYEWPGRi7uuXY1KthTJxJEP"
+)
+
+func withBlockedAccounts(t *testing.T, addrs []string) {
+	t.Helper()
+	old := blockedAccountSet
+	blockedAccountSet = parseBlockedAccounts(addrs)
+	t.Cleanup(func() {
+		blockedAccountSet = old
+	})
+}
+
+func TestDryRunBlockedAccounts(t *testing.T) {
+	// 上线前填充真实名单后，此用例会逐条解析；当前为空名单应直接通过
+	for _, addr := range blockedAccounts {
+		raw, err := parseBlockedAccount(addr)
+		require.NoError(t, err, "dry-run parse failed for %s", addr)
+		require.Len(t, raw, 20, "dry-run raw length for %s", addr)
+	}
+	// 双格式样例预校验，防止解析路径回归
+	cases := []string{testBlockedBtcAddr, testBlockedEthAddr}
+	for _, addr := range cases {
+		raw, err := parseBlockedAccount(addr)
+		require.NoError(t, err, addr)
+		require.Len(t, raw, 20, addr)
+	}
+}
+
+func TestParseBlockedAccountFormats(t *testing.T) {
+	btcRaw, err := parseBlockedAccount(testBlockedBtcAddr)
+	require.NoError(t, err)
+	require.Len(t, btcRaw, 20)
+
+	ethRaw, err := parseBlockedAccount(testBlockedEthAddr)
+	require.NoError(t, err)
+	require.Len(t, ethRaw, 20)
+
+	// eth 大小写不敏感（IsHexAddress 接受混合大小写）
+	ethLower, err := parseBlockedAccount("0x742d35cc6634c0532925a3b844bc9e7595f0beb0")
+	require.NoError(t, err)
+	assert.Equal(t, ethRaw, ethLower)
+
+	_, err = parseBlockedAccount("not-an-address")
+	assert.Error(t, err)
+
+	_, err = parseBlockedAccount("0x1234")
+	assert.Error(t, err)
+}
+
+func TestIsBlockedAccount(t *testing.T) {
+	withBlockedAccounts(t, []string{testBlockedBtcAddr, testBlockedEthAddr})
+
+	assert.True(t, IsBlockedAccount(testBlockedBtcAddr))
+	assert.True(t, IsBlockedAccount(testBlockedEthAddr))
+	assert.False(t, IsBlockedAccount(testNormalBtcAddr))
+	assert.False(t, IsBlockedAccount("not-an-address"))
+
+	btcRaw, err := parseBlockedAccount(testBlockedBtcAddr)
+	require.NoError(t, err)
+	assert.True(t, IsBlockedAccountRaw(btcRaw))
+	assert.False(t, IsBlockedAccountRaw([]byte{1, 2, 3}))
+}
+
+func TestCheckTxBlockedAccount(t *testing.T) {
+	cfg := NewChain33Config(GetDefaultCfgstring())
+	// local title 下 SetAllFork(0)，ForkAccountBlacklist 从高度 0 启用
+	withBlockedAccounts(t, []string{testBlockedBtcAddr, testBlockedEthAddr})
+
+	priv := mustLoadTestPriv(t)
+	normalTo := testNormalBtcAddr
+
+	t.Run("before fork height uses MaxHeight path", func(t *testing.T) {
+		// 构造一个未启用 fork 的 cfg：直接改 forks map
+		cfg2 := NewChain33Config(GetDefaultCfgstring())
+		cfg2.forks.SetFork(ForkAccountBlacklist, MaxHeight)
+		tx := &Transaction{Execer: []byte("coins"), To: testBlockedBtcAddr, Fee: 1e6}
+		tx.Sign(SECP256K1, priv)
+		assert.NoError(t, CheckTxBlockedAccount(cfg2, 0, tx))
+	})
+
+	// 门控差异：同一笔命中交易，Fork 入口在高度未达时放行，Immediate 入口始终拦截
+	t.Run("immediate ignores fork gate", func(t *testing.T) {
+		cfg2 := NewChain33Config(GetDefaultCfgstring())
+		cfg2.forks.SetFork(ForkAccountBlacklist, MaxHeight)
+		tx := &Transaction{Execer: []byte("coins"), To: testBlockedBtcAddr, Fee: 1e6}
+		tx.Sign(SECP256K1, priv)
+
+		assert.NoError(t, CheckTxBlockedAccount(cfg2, 0, tx), "fork 未达高度应放行")
+		err := CheckTxBlockedAccountImmediate(tx)
+		require.Error(t, err, "Immediate 不看 fork，必须拦截")
+		assert.True(t, errors.Is(err, ErrBlockedAccount))
+	})
+
+	// fork 高度边界：H-1 放行，H 拦截
+	t.Run("fork height boundary", func(t *testing.T) {
+		const forkHeight = 100
+		cfg2 := NewChain33Config(GetDefaultCfgstring())
+		cfg2.forks.SetFork(ForkAccountBlacklist, forkHeight)
+		tx := &Transaction{Execer: []byte("coins"), To: testBlockedBtcAddr, Fee: 1e6}
+		tx.Sign(SECP256K1, priv)
+
+		assert.NoError(t, CheckTxBlockedAccount(cfg2, forkHeight-1, tx))
+		err := CheckTxBlockedAccount(cfg2, forkHeight, tx)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrBlockedAccount))
+	})
+
+	t.Run("hit from", func(t *testing.T) {
+		// 用被拉黑地址对应私钥签名，命中 from 维度
+		blockedPriv := mustLoadBlockedPriv(t)
+		tx := &Transaction{Execer: []byte("coins"), To: normalTo, Fee: 1e6}
+		tx.Sign(SECP256K1, blockedPriv)
+		require.Equal(t, testBlockedBtcAddr, tx.From())
+		err := CheckTxBlockedAccount(cfg, 0, tx)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrBlockedAccount))
+	})
+
+	t.Run("hit to", func(t *testing.T) {
+		tx := &Transaction{Execer: []byte("coins"), To: testBlockedBtcAddr, Fee: 1e6}
+		tx.Sign(SECP256K1, priv)
+		err := CheckTxBlockedAccount(cfg, 0, tx)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrBlockedAccount))
+	})
+
+	t.Run("normal pass", func(t *testing.T) {
+		tx := &Transaction{Execer: []byte("coins"), To: normalTo, Fee: 1e6}
+		tx.Sign(SECP256K1, priv)
+		// from 是 priv 派生地址，不在名单；to 正常
+		assert.False(t, IsBlockedAccount(tx.From()))
+		assert.NoError(t, CheckTxBlockedAccount(cfg, 0, tx))
+	})
+
+	t.Run("hit evm contractAddr", func(t *testing.T) {
+		action := &EVMContractAction4Chain33{
+			Amount:       0,
+			GasLimit:     10000,
+			GasPrice:     1,
+			ContractAddr: testBlockedEthAddr,
+		}
+		tx := &Transaction{
+			Execer:  []byte("evm"),
+			To:      address.ExecAddress("evm"),
+			Payload: Encode(action),
+			Fee:     1e6,
+		}
+		tx.Sign(SECP256K1, priv)
+		err := CheckTxBlockedAccount(cfg, 0, tx)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrBlockedAccount))
+	})
+
+	t.Run("hit evm para 20 bytes", func(t *testing.T) {
+		raw, err := parseBlockedAccount(testBlockedEthAddr)
+		require.NoError(t, err)
+		action := &EVMContractAction4Chain33{
+			Amount:       1,
+			GasLimit:     10000,
+			GasPrice:     1,
+			Para:         raw,
+			ContractAddr: address.ExecAddress("evm"),
+		}
+		tx := &Transaction{
+			Execer:  []byte("evm"),
+			To:      address.ExecAddress("evm"),
+			Payload: Encode(action),
+			Fee:     1e6,
+		}
+		tx.Sign(SECP256K1, priv)
+		err = CheckTxBlockedAccount(cfg, 0, tx)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrBlockedAccount))
+	})
+
+	t.Run("nil cfg", func(t *testing.T) {
+		assert.NoError(t, CheckTxBlockedAccount(nil, 0, &Transaction{To: testBlockedBtcAddr}))
+	})
+}
+
+func mustLoadBlockedPriv(t *testing.T) crypto.PrivKey {
+	t.Helper()
+	// TestPrivkeyList[1]，派生地址 14KEKbYtKKQm4wMthSK9J4La4nAiidGozt（testBlockedBtcAddr）
+	cr, err := crypto.Load(GetSignName("", SECP256K1), -1)
+	require.NoError(t, err)
+	bkey, err := common.FromHex("CC38546E9E659D15E6B4893F0AB32A06D103931A8230B0BDE71459D2B27D6944")
+	require.NoError(t, err)
+	priv, err := cr.PrivKeyFromBytes(bkey)
+	require.NoError(t, err)
+	return priv
+}
+
+// TestCheckTxsBlockedAccount 交易组便利函数：任一笔命中整组 error，全通过返回 nil
+func TestCheckTxsBlockedAccount(t *testing.T) {
+	cfg := NewChain33Config(GetDefaultCfgstring())
+	withBlockedAccounts(t, []string{testBlockedBtcAddr})
+	priv := mustLoadTestPriv(t)
+
+	mkTx := func(to string) *Transaction {
+		tx := &Transaction{Execer: []byte("coins"), To: to, Fee: 1e6}
+		tx.Sign(SECP256K1, priv)
+		return tx
+	}
+
+	// 任一笔 to 命中 -> error
+	blocked := []*Transaction{mkTx(testNormalBtcAddr), mkTx(testBlockedBtcAddr)}
+	err := CheckTxsBlockedAccount(cfg, 0, blocked)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBlockedAccount))
+
+	// 全部正常 -> nil
+	ok := []*Transaction{mkTx(testNormalBtcAddr), mkTx(testNormalBtcAddr)}
+	assert.NoError(t, CheckTxsBlockedAccount(cfg, 0, ok))
+
+	// Immediate 变体同样工作
+	err = CheckTxsBlockedAccountImmediate(blocked)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBlockedAccount))
+	assert.NoError(t, CheckTxsBlockedAccountImmediate(ok))
+}
+
+func TestParseBlockedAccountsPanic(t *testing.T) {
+	assert.Panics(t, func() {
+		parseBlockedAccounts([]string{"bad-addr"})
+	})
+}
+
+func mustLoadTestPriv(t *testing.T) crypto.PrivKey {
+	t.Helper()
+	// TestPrivkeyList[0]，派生地址 12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv，不在黑名单
+	cr, err := crypto.Load(GetSignName("", SECP256K1), -1)
+	require.NoError(t, err)
+	bkey, err := common.FromHex("4257D8692EF7FE13C68B65D6A52F03933DB2FA5CE8FAF210B5B8B80C721CED01")
+	require.NoError(t, err)
+	priv, err := cr.PrivKeyFromBytes(bkey)
+	require.NoError(t, err)
+	return priv
+}

--- a/types/config_merge_test.go
+++ b/types/config_merge_test.go
@@ -218,6 +218,8 @@ ForkLocalDBAccess=1
 ForkBase58AddressCheck=1800000
 ForkTicketFundAddrV1=-1
 ForkRootHash=1
+# 账户黑名单启用高度；-1 表示关闭
+ForkAccountBlacklist=-1
 [fork.sub.coins]
 Enable=0
 

--- a/types/error.go
+++ b/types/error.go
@@ -56,6 +56,7 @@ var (
 	ErrInvalidExpire           = errors.New("ErrInvalidExpire")
 	ErrInvalidAddress          = errors.New("ErrInvalidAddress")
 	ErrNotInited               = errors.New("ErrNotInited")
+	ErrBlockedAccount          = errors.New("ErrBlockedAccount")
 
 	ErrStartBigThanEnd            = errors.New("ErrStartBigThanEnd")
 	ErrToAddrNotSameToExecAddr    = errors.New("ErrToAddrNotSameToExecAddr")

--- a/types/fork.go
+++ b/types/fork.go
@@ -147,6 +147,7 @@ func (f *Forks) RegisterSystemFork() {
 	f.setFork("ForkProxyExec", 0)
 	f.setFork("ForkMaxTxFeeV1", 0)
 	f.setFork("ForkParaFee", -1)
+	f.SetFork(ForkAccountBlacklist, MaxHeight)
 
 }
 

--- a/types/testdata/bityuan.toml
+++ b/types/testdata/bityuan.toml
@@ -176,6 +176,8 @@ ForkLocalDBAccess=1
 ForkBase58AddressCheck=1800000
 ForkTicketFundAddrV1=-1
 ForkRootHash=1
+# 账户黑名单启用高度；-1 表示关闭
+ForkAccountBlacklist=-1
 [fork.sub.coins]
 Enable=0
 

--- a/types/testdata/chain33.toml
+++ b/types/testdata/chain33.toml
@@ -157,6 +157,8 @@ ForkStateDBSet=-1
 ForkMaxTxFeeV1=30839600
 ForkMaxTxFeeV2=30939600
 ForkParaFee=-1
+# 账户黑名单启用高度；-1 表示关闭
+ForkAccountBlacklist=-1
 [fork.sub.manage]
 Enable=120000
 ForkV11ManageExec= 400000

--- a/types/testdata/guodun.toml
+++ b/types/testdata/guodun.toml
@@ -179,6 +179,8 @@ ForkEnableParaRegExec=0
 ForkCacheDriver=0
 ForkTicketFundAddrV1=-1
 ForkRootHash=1
+# 账户黑名单启用高度；-1 表示关闭
+ForkAccountBlacklist=-1
 [fork.sub.coins]
 Enable=0
 

--- a/types/testdata/local.mvertest.toml
+++ b/types/testdata/local.mvertest.toml
@@ -219,6 +219,8 @@ ForkEnableParaRegExec=0
 ForkCacheDriver=0
 ForkTicketFundAddrV1=-1
 ForkRootHash=1
+# 账户黑名单启用高度；-1 表示关闭
+ForkAccountBlacklist=-1
 [fork.sub.coins]
 Enable=0
 


### PR DESCRIPTION
Introduce a unified blacklist check in types so a hit transaction is rejected before the fee is charged, producing an ExecErr receipt. Blocks carrying such transactions are therefore invalid for peers, while honest miners simply drop the transaction and keep producing blocks.

The check covers four dimensions (From, To, RealTo and the EVM payload) because an EVM plain transfer keeps its real recipient in action.Para, which tx.To does not reveal on parallel chains.

Gating is split by whether a caller affects consensus: mempool and delay transaction entries use the Immediate variant so a binary upgrade stops the bleeding at once, whereas executor and consensus paths go through ForkAccountBlacklist to keep historical block replay intact. The fork defaults to MaxHeight and is configured per chain via [fork.system].