### PR TITLE
feat: add [blacklist] toml config for account blacklist

### DIFF
--- a/cmd/chain33/chain33.toml
+++ b/cmd/chain33/chain33.toml
@@ -7,6 +7,10 @@ TxHeight=true
 ChainID=0
 AddrVer=0
 
+# 账户黑名单：命中地址禁止收发任何交易，支持base58与0x两种地址格式
+[blacklist]
+accountBlacklist=[]
+
 # crypto模块配置
 [crypto]
 enableTypes=[]    #设置启用的加密插件名称，不配置启用所有

--- a/types/account_blacklist_test.go
+++ b/types/account_blacklist_test.go
@@ -31,6 +31,33 @@ func withBlockedAccounts(t *testing.T, addrs []string) {
 	})
 }
 
+// TestChain33ConfigLoadsBlacklist 验证 toml [blacklist] 段的 accountBlacklist
+// 能在 NewChain33Config 时被读入并生效
+func TestChain33ConfigLoadsBlacklist(t *testing.T) {
+	old := blockedAccountSet
+	t.Cleanup(func() {
+		blockedAccountSet = old
+	})
+
+	cfgstring := GetDefaultCfgstring() + `
+[blacklist]
+accountBlacklist=["` + testBlockedBtcAddr + `"]
+`
+	NewChain33Config(cfgstring)
+
+	assert.True(t, IsBlockedAccount(testBlockedBtcAddr))
+	assert.False(t, IsBlockedAccount(testNormalBtcAddr))
+}
+
+// TestChain33ConfigNoBlacklistSection 验证未配置 [blacklist] 段时不影响既有名单
+func TestChain33ConfigNoBlacklistSection(t *testing.T) {
+	withBlockedAccounts(t, []string{testBlockedBtcAddr})
+
+	NewChain33Config(GetDefaultCfgstring())
+
+	assert.True(t, IsBlockedAccount(testBlockedBtcAddr), "无 [blacklist] 段不应清空已有名单")
+}
+
 func TestDryRunBlockedAccounts(t *testing.T) {
 	// 上线前填充真实名单后，此用例会逐条解析；当前为空名单应直接通过
 	for _, addr := range blockedAccounts {

--- a/types/cfg.go
+++ b/types/cfg.go
@@ -11,35 +11,36 @@ import (
 
 // Config 配置信息
 type Config struct {
-	Title            string          `json:"title,omitempty"`
-	Version          string          `json:"version,omitempty"`
-	Log              *Log            `json:"log,omitempty"`
-	Store            *Store          `json:"store,omitempty"`
-	Consensus        *Consensus      `json:"consensus,omitempty"`
-	Mempool          *Mempool        `json:"memPool,omitempty"`
-	BlockChain       *BlockChain     `json:"blockChain,omitempty"`
-	Wallet           *Wallet         `json:"wallet,omitempty"`
-	P2P              *P2P            `json:"p2p,omitempty"`
-	RPC              *RPC            `json:"rpc,omitempty"`
-	Exec             *Exec           `json:"exec,omitempty"`
-	TestNet          bool            `json:"testNet,omitempty"`
-	FixTime          bool            `json:"fixTime,omitempty"`
-	TxHeight         bool            `json:"txHeight,omitempty"`
-	Pprof            *Pprof          `json:"pprof,omitempty"`
-	Fork             *ForkList       `json:"fork,omitempty"`
-	Health           *HealthCheck    `json:"health,omitempty"`
-	CoinExec         string          `json:"coinExec,omitempty"`
-	CoinSymbol       string          `json:"coinSymbol,omitempty"`
-	CoinPrecision    int64           `json:"coinPrecision,omitempty"`
-	TokenPrecision   int64           `json:"tokenPrecision,omitempty"`
-	DisableForkCheck bool            `json:"disableForkCheck,omitempty"`
-	EnableParaFork   bool            `json:"enableParaFork,omitempty"`
-	Metrics          *Metrics        `json:"metrics,omitempty"`
-	ChainID          int32           `json:"chainID,omitempty"`
-	AddrVer          byte            `json:"addrVer,omitempty"`
-	Crypto           *crypto.Config  `json:"crypto,omitempty"`
-	NtpHosts         []string        `json:"ntpHosts,omitempty"`
-	Address          *address.Config `json:"address,omitempty"`
+	Title            string                  `json:"title,omitempty"`
+	Version          string                  `json:"version,omitempty"`
+	Log              *Log                    `json:"log,omitempty"`
+	Store            *Store                  `json:"store,omitempty"`
+	Consensus        *Consensus              `json:"consensus,omitempty"`
+	Mempool          *Mempool                `json:"memPool,omitempty"`
+	BlockChain       *BlockChain             `json:"blockChain,omitempty"`
+	Wallet           *Wallet                 `json:"wallet,omitempty"`
+	P2P              *P2P                    `json:"p2p,omitempty"`
+	RPC              *RPC                    `json:"rpc,omitempty"`
+	Exec             *Exec                   `json:"exec,omitempty"`
+	TestNet          bool                    `json:"testNet,omitempty"`
+	FixTime          bool                    `json:"fixTime,omitempty"`
+	TxHeight         bool                    `json:"txHeight,omitempty"`
+	Pprof            *Pprof                  `json:"pprof,omitempty"`
+	Fork             *ForkList               `json:"fork,omitempty"`
+	Health           *HealthCheck            `json:"health,omitempty"`
+	CoinExec         string                  `json:"coinExec,omitempty"`
+	CoinSymbol       string                  `json:"coinSymbol,omitempty"`
+	CoinPrecision    int64                   `json:"coinPrecision,omitempty"`
+	TokenPrecision   int64                   `json:"tokenPrecision,omitempty"`
+	DisableForkCheck bool                    `json:"disableForkCheck,omitempty"`
+	EnableParaFork   bool                    `json:"enableParaFork,omitempty"`
+	Metrics          *Metrics                `json:"metrics,omitempty"`
+	ChainID          int32                   `json:"chainID,omitempty"`
+	AddrVer          byte                    `json:"addrVer,omitempty"`
+	Crypto           *crypto.Config          `json:"crypto,omitempty"`
+	NtpHosts         []string                `json:"ntpHosts,omitempty"`
+	Address          *address.Config         `json:"address,omitempty"`
+	Blacklist        *AccountBlacklistConfig `json:"blacklist,omitempty"`
 }
 
 // ConfigSubModule 子模块的配置
@@ -339,6 +340,11 @@ type HealthCheck struct {
 	ListenAddr     string `json:"listenAddr,omitempty"`
 	CheckInterval  uint32 `json:"checkInterval,omitempty"`
 	UnSyncMaxTimes uint32 `json:"unSyncMaxTimes,omitempty"`
+}
+
+// AccountBlacklistConfig 账户黑名单配置
+type AccountBlacklistConfig struct {
+	AccountBlacklist []string `json:"accountBlacklist,omitempty"`
 }
 
 // Metrics 相关测量配置信息

--- a/types/config.go
+++ b/types/config.go
@@ -287,6 +287,10 @@ func (c *Chain33Config) chain33CfgInit(cfg *Config) {
 		if cfg.RPC != nil && cfg.RPC.ParaChain.MainChainGrpcAddr == "" {
 			cfg.RPC.ParaChain.MainChainGrpcAddr = "localhost:8802"
 		}
+
+		if cfg.Blacklist != nil {
+			blockedAccountSet = parseBlockedAccounts(cfg.Blacklist.AccountBlacklist)
+		}
 	}
 	if c.needSetForkZero() { //local 只用于单元测试
 		if c.isLocal() {


### PR DESCRIPTION
## Summary
- Add `AccountBlacklistConfig` struct (`accountBlacklist []string`) to `types.Config`, read at `Chain33Config` init time via `[blacklist]` toml section.
- When configured, replaces the existing `blockedAccountSet` used by `CheckTxBlockedAccount` / `CheckTxBlockedAccountImmediate` — no changes to the fork-gated check logic, call sites, or existing tests in executor/mempool/consensus.
- Absent `[blacklist]` section (nil) keeps prior hardcoded-empty-list behavior; no regression for existing configs.
- Added `[blacklist]\naccountBlacklist=[]` example section to `cmd/chain33/chain33.toml`.

## Test plan
- [x] `go test ./types/...` — new `TestChain33ConfigLoadsBlacklist` / `TestChain33ConfigNoBlacklistSection` pass, existing blacklist tests unaffected
- [x] `go test ./executor/... ./system/mempool/... ./system/consensus/...` — pass (consensus/solo included; consensus/snowman fails to build due to a pre-existing avalanchego/Go version incompatibility unrelated to this change, confirmed present on master before this branch)
- [ ] `make linter` — not run in this environment yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)