### PR TITLE
fix(wallet/ethrpc): regressions from 'fix 20 bugs' commit (CBC 64-byte keys, ethrpc whitelist '*')

### DIFF
--- a/rpc/ethrpc/rpc.go
+++ b/rpc/ethrpc/rpc.go
@@ -251,7 +251,8 @@ func (h *httpServer) checkIPWhitelist(addr string) bool {
 		return true
 	}
 	whitelist := h.cfg.GetModuleConfig().RPC.Whitelist
-	if len(whitelist) == 0 {
+	// "*" means allow all IPs, consistent with rpc.InitIPWhitelist
+	if len(whitelist) == 0 || (len(whitelist) == 1 && whitelist[0] == "*") {
 		return true
 	}
 	ipv4 := ip.To4()

--- a/rpc/ethrpc/rpc_whitelist_test.go
+++ b/rpc/ethrpc/rpc_whitelist_test.go
@@ -1,0 +1,50 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ethrpc
+
+import (
+	"testing"
+
+	ctypes "github.com/33cn/chain33/types"
+)
+
+func newTestHTTPServer(whitelist string) *httpServer {
+	cfgstring := `Title="local"
+TestNet=true
+
+[mempool]
+minTxFeeRate=100000
+
+[wallet]
+minFee=100000
+
+[rpc]
+whitelist=` + whitelist
+	return &httpServer{cfg: ctypes.NewChain33Config(cfgstring)}
+}
+
+func TestCheckIPWhitelist(t *testing.T) {
+	cases := []struct {
+		name      string
+		whitelist string
+		addr      string
+		want      bool
+	}{
+		{"star allows all", "[\"*\"]", "172.18.0.1", true},
+		{"0000 allows all", "[\"0.0.0.0\"]", "172.18.0.1", true},
+		{"exact match", "[\"172.18.0.1\"]", "172.18.0.1", true},
+		{"other denied", "[\"192.168.1.1\"]", "172.18.0.1", false},
+		{"empty allows all", "[]", "172.18.0.1", true},
+		{"loopback always allowed", "[]", "127.0.0.1", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := newTestHTTPServer(c.whitelist)
+			if got := h.checkIPWhitelist(c.addr); got != c.want {
+				t.Errorf("checkIPWhitelist(%q) = %v, want %v", c.addr, got, c.want)
+			}
+		})
+	}
+}

--- a/types/fork.go
+++ b/types/fork.go
@@ -146,7 +146,7 @@ func (f *Forks) RegisterSystemFork() {
 	f.setFork("ForkCheckEthTxSort", 0)
 	f.setFork("ForkProxyExec", 0)
 	f.setFork("ForkMaxTxFeeV1", 0)
-	f.setFork("ForkParaFee", MaxHeight)
+	f.setFork("ForkParaFee", -1)
 	f.SetFork(ForkAccountBlacklist, MaxHeight)
 
 }
@@ -155,7 +155,6 @@ func (f *Forks) setLocalFork() {
 	f.SetAllFork(0)
 	f.ReplaceFork("ForkBlockHash", 1)
 	f.ReplaceFork("ForkRootHash", 1)
-	f.ReplaceFork("ForkParaFee", MaxHeight)
 }
 
 // paraName not used currently
@@ -163,7 +162,6 @@ func (f *Forks) setForkForParaZero() {
 	f.SetAllFork(0)
 	f.ReplaceFork("ForkBlockHash", 1)
 	f.ReplaceFork("ForkRootHash", 1)
-	f.ReplaceFork("ForkParaFee", MaxHeight)
 }
 
 // IsFork 是否系统 fork高度

--- a/types/fork.go
+++ b/types/fork.go
@@ -146,7 +146,7 @@ func (f *Forks) RegisterSystemFork() {
 	f.setFork("ForkCheckEthTxSort", 0)
 	f.setFork("ForkProxyExec", 0)
 	f.setFork("ForkMaxTxFeeV1", 0)
-	f.setFork("ForkParaFee", -1)
+	f.setFork("ForkParaFee", MaxHeight)
 	f.SetFork(ForkAccountBlacklist, MaxHeight)
 
 }
@@ -155,6 +155,7 @@ func (f *Forks) setLocalFork() {
 	f.SetAllFork(0)
 	f.ReplaceFork("ForkBlockHash", 1)
 	f.ReplaceFork("ForkRootHash", 1)
+	f.ReplaceFork("ForkParaFee", MaxHeight)
 }
 
 // paraName not used currently
@@ -162,6 +163,7 @@ func (f *Forks) setForkForParaZero() {
 	f.SetAllFork(0)
 	f.ReplaceFork("ForkBlockHash", 1)
 	f.ReplaceFork("ForkRootHash", 1)
+	f.ReplaceFork("ForkParaFee", MaxHeight)
 }
 
 // IsFork 是否系统 fork高度

--- a/types/fork.go
+++ b/types/fork.go
@@ -206,6 +206,11 @@ func (c *Chain33Config) GetFork(fork string) int64 {
 	return c.forks.GetFork(fork)
 }
 
+// SetFork 设置系统fork高度，主要用于测试
+func (c *Chain33Config) SetFork(fork string, height int64) {
+	c.forks.SetFork(fork, height)
+}
+
 // HasFork 是否有系统fork
 func (c *Chain33Config) HasFork(fork string) bool {
 	return c.forks.HasFork(fork)

--- a/wallet/common/common_test.go
+++ b/wallet/common/common_test.go
@@ -7,6 +7,7 @@ package common
 import (
 	"bytes"
 	"crypto/aes"
+	"crypto/cipher"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,62 @@ func TestCBCEncryptDecryptRoundTrip(t *testing.T) {
 		decrypted := CBCDecrypterPrivkey(password, encrypted)
 		assert.Equal(t, privkey, decrypted, "round trip failed at iteration %d", i)
 	}
+}
+
+// TestCBCEncryptDecryptPrivkey64 覆盖 ed25519 私钥（64 字节）的加解密往返。
+// 回归：CBCDecrypterPrivkey 对随机 IV 新格式仅接受 32 字节明文，64 字节私钥会被
+// 误判为旧格式并用 key[:16] 当 IV 解密，导致 privacy 等钱包的密钥损坏。
+func TestCBCEncryptDecryptPrivkey64(t *testing.T) {
+	password := []byte("test-password-12345678901234567890")
+	privkey := make([]byte, 64)
+	for i := range privkey {
+		privkey[i] = byte(i)
+	}
+
+	encrypted := CBCEncrypterPrivkey(password, privkey)
+	assert.NotNil(t, encrypted)
+	assert.Equal(t, aes.BlockSize+len(privkey), len(encrypted))
+
+	decrypted := CBCDecrypterPrivkey(password, encrypted)
+	assert.Equal(t, privkey, decrypted)
+}
+
+// legacyEncrypt 复现引入随机 IV 之前的旧格式：固定 IV = key[:16]，密文不前置 IV。
+func legacyEncrypt(password []byte, plain []byte) []byte {
+	key := make([]byte, 32)
+	if len(password) > 32 {
+		key = password[0:32]
+	} else {
+		copy(key, password)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil
+	}
+	iv := key[:block.BlockSize()]
+	encrypted := make([]byte, len(plain))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(encrypted, plain)
+	return encrypted
+}
+
+// TestCBCDecryptLegacyFormat 验证旧格式（固定 IV、密文不前置 IV）仍能正确解密，
+// 保证旧钱包持久化数据向后兼容。
+func TestCBCDecryptLegacyFormat(t *testing.T) {
+	password := []byte("test-password-12345678901234567890")
+
+	legacy32 := make([]byte, 32)
+	for i := range legacy32 {
+		legacy32[i] = byte(255 - i)
+	}
+	dec32 := CBCDecrypterPrivkey(password, legacyEncrypt(password, legacy32))
+	assert.Equal(t, legacy32, dec32)
+
+	legacy64 := make([]byte, 64)
+	for i := range legacy64 {
+		legacy64[i] = byte(i + 1)
+	}
+	dec64 := CBCDecrypterPrivkey(password, legacyEncrypt(password, legacy64))
+	assert.Equal(t, legacy64, dec64)
 }
 
 func TestCBCEncryptWrongDecrypt(t *testing.T) {

--- a/wallet/common/crypto.go
+++ b/wallet/common/crypto.go
@@ -52,14 +52,19 @@ func CBCDecrypterPrivkey(password []byte, privkey []byte) []byte {
 
 	blockSize := block.BlockSize()
 
-	// New format: IV(16) + ciphertext
+	// New format (since the IV-randomization fix): IV(16) + ciphertext,
+	// produced by CBCEncrypterPrivkey. Wallet private keys are 32 bytes
+	// (secp256k1) or 64 bytes (ed25519), so a new-format blob is 48 or 80
+	// bytes. A legacy blob of the same total length would decode to a
+	// plaintext 16 bytes longer, which is never a valid key size, so the
+	// plaintext length disambiguates the two formats.
 	if len(privkey) > blockSize && len(privkey)%blockSize == 0 {
-		iv := privkey[:blockSize]
-		ciphertext := privkey[blockSize:]
-		decrypted := make([]byte, len(ciphertext))
-		cipher.NewCBCDecrypter(block, iv).CryptBlocks(decrypted, ciphertext)
-		// Validate: if decryption looks valid, return it
-		if len(decrypted) == 32 {
+		plainLen := len(privkey) - blockSize
+		if plainLen == 32 || plainLen == 64 {
+			iv := privkey[:blockSize]
+			ciphertext := privkey[blockSize:]
+			decrypted := make([]byte, len(ciphertext))
+			cipher.NewCBCDecrypter(block, iv).CryptBlocks(decrypted, ciphertext)
 			return decrypted
 		}
 	}


### PR DESCRIPTION
## 描述

修复 commit `7198f44b3`（fix: address 20 bugs）引入的两个回归。

Closes #1369

## 修复 1：`CBCDecrypterPrivkey` 不支持 64 字节密钥

随机 IV 新格式（`IV(16)+ciphertext`）判据写死 `len(decrypted) == 32`，64 字节 ed25519 私钥（privacy 钱包 ViewPrivKey/SpendPrivKey）解密损坏 → 钱包无法恢复 onetime 密钥 → UTXO 归属检测失败 → privacy autotest 全挂。

**改动**：新格式按明文长度 `32/64` 字节判定（钱包私钥仅这两种长度），旧格式（固定 IV）通过明文长度区分，兼容旧钱包持久化数据。

## 修复 2：eth rpc `checkIPWhitelist` 不认 `*`

主 rpc 的 `InitIPWhitelist` 明确把 `whitelist=["*"]` 视为允许所有 IP，但新增的 eth rpc `checkIPWhitelist` 只认 `"0.0.0.0"` 或精确 IP。用常见的 `whitelist=["*"]` 配置时，非 loopback 客户端（如 CI 中主机 curl 容器 eth RPC 端口）全被拒 → `eth_getContractorAddress` 返回 403 "IP not authorized" → evm autotest 挂。

**改动**：`checkIPWhitelist` 对 `["*"]` 放行，与主 rpc 一致。

## 测试

- `wallet/common`：`TestCBCEncryptDecryptPrivkey64`（64 字节往返）、`TestCBCDecryptLegacyFormat`（旧格式兼容）
- `rpc/ethrpc`：`TestCheckIPWhitelist`（`*`/`0.0.0.0`/精确匹配/拒绝/空/loopback）

```bash
go test ./wallet/common/... ./rpc/ethrpc/...
```

全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
