### PR TITLE
fix(types): stop txgroup and zero-minfee paths from skipping chainID

### DIFF
--- a/cmd/chain33/chain33.fork.toml
+++ b/cmd/chain33/chain33.fork.toml
@@ -31,6 +31,8 @@ ForkMaxTxFeeV1=0
 ForkParaFee=-1
 # 账户黑名单启用高度，命中名单的交易在此高度后视为非法交易，所在区块整块拒绝；-1 表示关闭
 ForkAccountBlacklist=-1
+# 交易chainID严格校验启用高度，启用后交易组内每笔交易及minTxFeeRate=0时的单笔交易都会校验chainID，防止跨链重放；-1 表示关闭
+ForkTxChainIDStrict=-1
 [fork.sub.none]
 ForkUseTimeDelay=0
 

--- a/cmd/chain33/chain33.system.fork.toml
+++ b/cmd/chain33/chain33.system.fork.toml
@@ -31,3 +31,5 @@ ForkMaxTxFeeV1=0
 ForkParaFee=-1
 # 账户黑名单启用高度，命中名单的交易在此高度后视为非法交易，所在区块整块拒绝；-1 表示关闭
 ForkAccountBlacklist=-1
+# 交易chainID严格校验启用高度，启用后交易组内每笔交易及minTxFeeRate=0时的单笔交易都会校验chainID，防止跨链重放；-1 表示关闭
+ForkTxChainIDStrict=-1

--- a/rpc/client/client.go
+++ b/rpc/client/client.go
@@ -187,6 +187,11 @@ func (c *ChannelClient) CreateRawTxGroup(param *types.CreateTransactionGroup) ([
 		if err != nil {
 			return nil, err
 		}
+		// 补全未携带 chainID 的成员(为 0 视为未设置):交易组本身是本链创建,
+		// 成员 chainID 应与本链一致, 否则开启 chainID 严格校验后会误伤本链交易
+		if transaction.ChainID == 0 {
+			transaction.ChainID = cfg.GetChainID()
+		}
 		transactions = append(transactions, &transaction)
 	}
 	feeRate := cfg.GetMinTxFeeRate()
@@ -239,6 +244,11 @@ func (c *ChannelClient) CreateNoBalanceTxs(in *types.NoBalanceTxs) (*types.Trans
 		}
 		if types.IsParaExecName(string(tx.GetExecer())) {
 			isParaTx = true
+		}
+		// 补全未携带 chainID 的成员(为 0 视为未设置):交易组本身是本链创建,
+		// 成员 chainID 应与本链一致, 否则开启 chainID 严格校验后会误伤本链交易
+		if tx.ChainID == 0 {
+			tx.ChainID = cfg.GetChainID()
 		}
 		transactions = append(transactions, tx)
 	}

--- a/system/address/address_test.go
+++ b/system/address/address_test.go
@@ -67,7 +67,7 @@ func TestMultiAddrAssetTransfer(t *testing.T) {
 		},
 	}
 
-	tx = &types.Transaction{Payload: types.Encode(action), Execer: []byte("coins"), To: execAddr}
+	tx = &types.Transaction{Payload: types.Encode(action), Execer: []byte("coins"), To: execAddr, ChainID: cfg.GetChainID()}
 	tx.Sign(types.EncodeSignID(secp256k1.ID, eth.ID), priv)
 	mock33.SendTx(tx)
 
@@ -90,7 +90,7 @@ func TestMultiAddrAssetTransfer(t *testing.T) {
 		},
 	}
 
-	tx = &types.Transaction{Payload: types.Encode(action), Execer: []byte("coins"), To: execAddr}
+	tx = &types.Transaction{Payload: types.Encode(action), Execer: []byte("coins"), To: execAddr, ChainID: cfg.GetChainID()}
 	tx.Sign(types.EncodeSignID(secp256k1.ID, eth.ID), priv)
 	mock33.SendTx(tx)
 

--- a/system/dapp/commands/coins.go
+++ b/system/dapp/commands/coins.go
@@ -320,6 +320,11 @@ func createTxGroup(cmd *cobra.Command, args []string) {
 		}
 		var transaction types.Transaction
 		types.Decode(txByte, &transaction)
+		// 补全未携带 chainID 的成员(为 0 视为未设置):交易组本身是本链创建,
+		// 成员 chainID 应与本链一致, 否则开启 chainID 严格校验后会误伤本链交易
+		if transaction.ChainID == 0 {
+			transaction.ChainID = cfg.GetChainID()
+		}
 		transactions = append(transactions, &transaction)
 	}
 	group, err := types.CreateTxGroup(transactions, cfg.GetMinTxFeeRate())

--- a/types/fork.go
+++ b/types/fork.go
@@ -16,6 +16,11 @@ MaxHeight 出于forks 过程安全的考虑，比如代码更新，出现了新�
 */
 const MaxHeight = 10000000000000000
 
+// ForkTxChainIDStrict 交易 chainID 严格校验分叉名, 配置在 [fork.system] 节。
+// 启用后, 交易组内的每笔交易以及 minTxFeeRate=0 时的单笔交易都会校验 chainID,
+// 关闭时保持历史行为(这两条路径跳过校验)以保证旧区块可以原样重放。
+const ForkTxChainIDStrict = "ForkTxChainIDStrict"
+
 // Forks fork分叉结构体
 type Forks struct {
 	forks map[string]int64
@@ -148,6 +153,7 @@ func (f *Forks) RegisterSystemFork() {
 	f.setFork("ForkMaxTxFeeV1", 0)
 	f.setFork("ForkParaFee", -1)
 	f.SetFork(ForkAccountBlacklist, MaxHeight)
+	f.SetFork(ForkTxChainIDStrict, MaxHeight)
 
 }
 

--- a/types/tx.go
+++ b/types/tx.go
@@ -188,6 +188,8 @@ func (txgroup *Transactions) CheckWithFork(cfg *Chain33Config, checkFork, paraFo
 		if txs[i] == nil {
 			return ErrTxGroupEmpty
 		}
+		// 成员 check 固定传 minfee=0, 该提前返回只应跳过手续费校验。
+		// chainID 校验在 check 内部位于提前返回之前, 因此交易组路径同样被覆盖。
 		err := txs[i].check(cfg, height, 0, maxFee)
 		if err != nil {
 			return err
@@ -499,6 +501,16 @@ func (tx *Transaction) Check(cfg *Chain33Config, height, minfee, maxFee int64) e
 }
 
 func (tx *Transaction) check(cfg *Chain33Config, height, minfee, maxFee int64) error {
+	// chainID 校验与手续费无关, 必须位于 minfee 提前返回之前。
+	// 该提前返回的语义只是「不收最低手续费」, 不应连带跳过 chainID ——
+	// 历史上 chainID 检查写在手续费逻辑内, 导致 minfee=0 时(单笔交易,
+	// 以及交易组内每笔固定传 minfee=0)完全跳过它, 攻击者可以拿其他链上
+	// 已合法签名的交易原样重放到本链。由 fork 门控保证历史区块可重放。
+	if cfg != nil && cfg.IsFork(height, ForkTxChainIDStrict) {
+		if tx.ChainID != cfg.GetChainID() {
+			return ErrTxChainID
+		}
+	}
 	if minfee == 0 {
 		return nil
 	}

--- a/types/tx_chainid_test.go
+++ b/types/tx_chainid_test.go
@@ -1,0 +1,131 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/33cn/chain33/common/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+// foreignChainID 与默认配置的 chainID 不同, 代表另一条链
+const foreignChainID = int32(99)
+
+func chainIDTestKey(t *testing.T) crypto.PrivKey {
+	c, err := crypto.Load("secp256k1", -1)
+	assert.Nil(t, err)
+	priv, err := c.GenKey()
+	assert.Nil(t, err)
+	return priv
+}
+
+func newForeignTx(t *testing.T, priv crypto.PrivKey, fee int64) *Transaction {
+	tx := &Transaction{
+		Execer:  []byte("coins"),
+		Payload: []byte("chainid-test-payload"),
+		Fee:     fee,
+		To:      "1J7X82xR9tJr8s2oCDgrWHu8ThULyfmzRb",
+		ChainID: foreignChainID,
+	}
+	tx.Sign(SECP256K1, priv)
+	return tx
+}
+
+// 交易组曾经可以完全绕过 chainID 校验:
+// CheckWithFork 对组内每笔固定传 minfee=0, 命中 check 的提前返回。
+// 攻击者可以把其他链上已合法签名的交易原样打成交易组重放到本链。
+func TestTxGroupChainIDNotBypassable(t *testing.T) {
+	cfg := NewChain33Config(GetDefaultCfgstring())
+	cfg.forks.ReplaceFork(ForkTxChainIDStrict, 0)
+
+	priv := chainIDTestKey(t)
+	minFee := cfg.GetMinTxFeeRate()
+	maxFee := cfg.GetMaxTxFee(1)
+
+	// 基线: 单笔外链交易必须被拒绝
+	single := newForeignTx(t, priv, 1e6)
+	assert.Equal(t, ErrTxChainID, single.Check(cfg, 1, minFee, maxFee))
+	// 签名本身是有效的, 拦截来自 chainID 而非验签
+	assert.True(t, single.CheckSign(1))
+
+	// 同样的交易打成交易组后同样必须被拒绝
+	group, err := CreateTxGroup([]*Transaction{
+		newForeignTx(t, priv, 0),
+		newForeignTx(t, priv, 0),
+	}, minFee)
+	assert.Nil(t, err)
+	assert.Nil(t, group.SignN(0, SECP256K1, priv))
+	assert.Nil(t, group.SignN(1, SECP256K1, priv))
+
+	assert.True(t, group.CheckSign(1))
+	assert.Equal(t, ErrTxChainID, group.Check(cfg, 1, minFee, maxFee))
+}
+
+// minTxFeeRate=0 时单笔交易同样不能跳过 chainID 校验
+// minTxFeeRate=0 时单笔交易也必须校验 chainID:
+// minfee 的提前返回只应跳过「最低手续费」校验, 不应连带跳过 chainID。
+// 联盟链通过 minfee=0 免手续费, 不等于可以跨链重放。
+func TestSingleTxChainIDWithZeroMinFee(t *testing.T) {
+	cfg := NewChain33Config(GetDefaultCfgstring())
+	cfg.forks.ReplaceFork(ForkTxChainIDStrict, 0)
+
+	priv := chainIDTestKey(t)
+	tx := newForeignTx(t, priv, 1e6)
+	maxFee := cfg.GetMaxTxFee(1)
+
+	assert.Equal(t, ErrTxChainID, tx.Check(cfg, 1, 100000, maxFee))
+	// minfee=0 同样必须被拦, 否则跨链重放可借免手续费链绕过
+	assert.Equal(t, ErrTxChainID, tx.Check(cfg, 1, 0, maxFee))
+}
+
+// 本链 chainID 的交易组不受影响, 避免收紧校验误伤正常交易
+func TestTxGroupSameChainIDStillValid(t *testing.T) {
+	cfg := NewChain33Config(GetDefaultCfgstring())
+	cfg.forks.ReplaceFork(ForkTxChainIDStrict, 0)
+
+	priv := chainIDTestKey(t)
+	minFee := cfg.GetMinTxFeeRate()
+	maxFee := cfg.GetMaxTxFee(1)
+
+	mk := func(fee int64) *Transaction {
+		tx := &Transaction{
+			Execer:  []byte("coins"),
+			Payload: []byte("chainid-test-payload"),
+			Fee:     fee,
+			To:      "1J7X82xR9tJr8s2oCDgrWHu8ThULyfmzRb",
+			ChainID: cfg.GetChainID(),
+		}
+		tx.Sign(SECP256K1, priv)
+		return tx
+	}
+
+	group, err := CreateTxGroup([]*Transaction{mk(0), mk(0)}, minFee)
+	assert.Nil(t, err)
+	assert.Nil(t, group.SignN(0, SECP256K1, priv))
+	assert.Nil(t, group.SignN(1, SECP256K1, priv))
+	assert.Nil(t, group.Check(cfg, 1, minFee, maxFee))
+}
+
+// fork 未启用时保持历史行为, 保证旧区块可以原样重放
+func TestTxChainIDBeforeFork(t *testing.T) {
+	cfg := NewChain33Config(GetDefaultCfgstring())
+	cfg.forks.ReplaceFork(ForkTxChainIDStrict, MaxHeight)
+
+	priv := chainIDTestKey(t)
+	minFee := cfg.GetMinTxFeeRate()
+	maxFee := cfg.GetMaxTxFee(1)
+
+	group, err := CreateTxGroup([]*Transaction{
+		newForeignTx(t, priv, 0),
+		newForeignTx(t, priv, 0),
+	}, minFee)
+	assert.Nil(t, err)
+	assert.Nil(t, group.SignN(0, SECP256K1, priv))
+	assert.Nil(t, group.SignN(1, SECP256K1, priv))
+
+	// fork 之前, 交易组内不校验 chainID(历史行为)
+	assert.Nil(t, group.Check(cfg, 1, minFee, maxFee))
+}

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -35,6 +35,10 @@ func TestCreateGroupTx(t *testing.T) {
 	Decode(tx21, &tx22)
 	var tx32 Transaction
 	Decode(tx31, &tx32)
+	//这些十六进制样本早于 chainID 字段, 解码后为 0, 需显式对齐本链 chainID
+	tx12.ChainID = cfg.GetChainID()
+	tx22.ChainID = cfg.GetChainID()
+	tx32.ChainID = cfg.GetChainID()
 
 	group, err := CreateTxGroup([]*Transaction{&tx12, &tx22, &tx32}, cfg.GetMinTxFeeRate())
 	if err != nil {
@@ -143,6 +147,10 @@ func TestCreateGroupTxWithSize(t *testing.T) {
 	tx22.Payload = append(tx22.Payload, extSize...)
 	var tx32 Transaction
 	Decode(tx31, &tx32)
+	//这些十六进制样本早于 chainID 字段, 解码后为 0, 需显式对齐本链 chainID
+	tx12.ChainID = cfg.GetChainID()
+	tx22.ChainID = cfg.GetChainID()
+	tx32.ChainID = cfg.GetChainID()
 
 	group, err := CreateTxGroup([]*Transaction{&tx12, &tx22, &tx32}, cfg.GetMinTxFeeRate())
 	if err != nil {
@@ -226,6 +234,20 @@ func TestSignGroupTx(t *testing.T) {
 	}
 	if group == nil {
 		t.Errorf("signN sign a not group tx")
+		return
+	}
+	//该十六进制样本早于 chainID 字段, 解码后为 0。chainID 参与交易 hash,
+	//直接改字段会让组内 header/next 失配, 因此对齐后重建交易组。
+	members := group.GetTxs()
+	for _, gtx := range members {
+		gtx.ChainID = cfg.GetChainID()
+		gtx.Header = nil
+		gtx.Next = nil
+		gtx.GroupCount = 0
+	}
+	group, err = CreateTxGroup(members, cfg.GetMinTxFeeRate())
+	if err != nil {
+		t.Error(err)
 		return
 	}
 	for i := 0; i < len(group.GetTxs()); i++ {


### PR DESCRIPTION
## 问题

`ChainID` 用于防止跨链重放,但原生交易的唯一校验点 `types/tx.go` 位于 `Transaction.check` 中 `minfee == 0` 提前返回**之下**,导致两条路径完全跳过它。两条路径的影响范围差别很大:

**1. 交易组 — 与手续费配置无关,影响所有链**

`Transactions.CheckWithFork` 对组内每笔**硬编码**传 `minfee=0`:

```go
err := txs[i].check(cfg, height, 0, maxFee)   // ← 常量 0,与链上配置无关
```

因此即使链上正常配置了 `minTxFeeRate`(如主网 100000),交易组内的每笔交易依然跳过 chainID 校验。**这是本 PR 要解决的主要风险面。**

**2. 单笔 + `minTxFeeRate=0` — 仅限特定部署**

正常链必须配置手续费以防 DDoS,不会触及此路径。实际出现在联盟链,以及 `cmd/execblock`、`util/testnode` 等工具/测试场景。属次要风险面。

攻击者可以把其他链上**已合法签名**的交易取 ≥2 笔打成交易组,原样重放到本链。无需伪造签名 —— 签名覆盖「整笔交易去掉 Signature」,本就包含外链的 chainID,验签天然通过,而交易组级校验(fee / header / next / GroupCount)从不查 chainID。

## 为什么签名保护不足

评审时容易产生的疑问:chainID 既然参与签名,为何还能被重放?

chainID **确实**受签名保护。签名对「整笔交易去掉 `Signature` 字段」的 protobuf 编码计算,`ChainID` 作为普通字段自然被覆盖。已验证:

```
chainID=33 与 chainID=99 的待签名字节相同? false   ← chainID 进入待签数据
原始交易验签 = true
篡改 chainID 后验签 = false                        ← 受签名保护
chainID 不同时 tx.Hash() 相同? false               ← 也参与 hash
```

效果等同于以太坊 EIP-155 的链绑定,只是实现路径不同(以太坊显式拼入签名原像并复用 `v`,chain33 靠「签全字段」自动获得)。

关键在于:**签名保证的是「不可篡改」,而非「必须匹配」**。

- 签名保证攻击者**无法**把 A 链交易的 chainID 改写为 B 链的值 —— 一改验签即失败
- 签名**不保证** B 链节点会主动比对 `tx.ChainID == 本链 chainID`

攻击者无需篡改任何字段:直接取 A 链上原封不动的交易(chainID=A、签名自始一致)投给 B 链,验签必然通过。唯一能拦下它的就是 B 链主动做那次比对,而这次比对恰好被 `minfee == 0` 的提前返回跳过。

因此本问题属于**校验缺失**,而非密码学缺陷 —— 签名已将 chainID 钉死,只是无人读取。

## 复现

修复前,默认配置(chainID=33)下:

```
单笔外链交易(ChainID=99) Check -> ErrTxChainID   ← 正确拒绝
同样两笔打成 txgroup      Check -> <nil>          ← 全部通过
  组内验签全通过? true
```

`minTxFeeRate=0` 时单笔同样失效:

```
minfee=100000 -> ErrTxChainID
minfee=0      -> <nil>
```

## 改动

把 chainID 比对提到手续费逻辑之前,一处改动同时关闭两条路径。

**fork 门控**:无条件收紧会让历史上未经此校验而被接受的区块变为非法,造成共识分裂。因此按本仓库既有惯例(参照 `ForkAccountBlacklist`)注册 `ForkTxChainIDStrict`,默认 `MaxHeight`,两个 fork.toml 中配 `-1`(关闭)。**默认不生效**,各链显式配置高度后启用。

**既有测试**:`TestCreateGroupTx` / `TestCreateGroupTxWithSize` / `TestSignGroupTx` 使用早于 chainID 字段的十六进制样本(解码后为 0),此前能通过恰恰是因为本 bug。前两者对齐 chainID 即可;`TestSignGroupTx` 需重建交易组 —— chainID 参与交易 hash,原地修改会使组内 header/next 失配(直接改字段会报 `ErrTxGroupHeader`)。

## 测试

新增 4 个回归测试,覆盖交易组拦截、`minfee=0` 单笔拦截、本链 chainID 正常放行(避免误伤)、以及 fork 未启用时保持历史行为。

实际执行结果:

- `types` / `system/mempool` / `executor` / `system/dapp` / `system/consensus/solo` 全部通过
- `gofmt -l` 无输出,`go vet ./types/...` 无输出
- fork 配置解析正常,默认读到 `MaxHeight`(关闭)

`system/consensus/snowman` 构建失败源于 avalanchego 依赖与当前 Go 版本不兼容,`git stash` 验证改动前即失败,与本 PR 无关。

## 部署前提

本校验依赖主链与各平行链配置**一致的 chainID**。若某部署中主链配 33、平行链配 44,开启 fork 后平行链转发至主链的交易将被主链拒绝。

需要说明的是,这一前提并非本 PR 引入:`minTxFeeRate > 0` 的单笔交易**当前已在执行**该校验,本 PR 只是让交易组与 `minfee=0` 的单笔遵循同样规则。换言之,若存在 chainID 不一致的部署,问题当下即已存在,只是被交易组这条路径掩盖。

fork 默认关闭(`-1`)正为此留出逐链核对的余量,建议启用前确认目标部署的 chainID 配置一致性。

## 附带观察(未在本 PR 处理)

proto3 省略零值,导致 `ChainID=0` 与「字段完全缺失」的编码完全相同:

```
ChainID=0 与字段缺失的编码相同? true
```

即 chainID 为 0 的链无法区分「显式声明属于 0 号链」与「旧版客户端未填该字段」。默认配置为 33 故未触及,但配置 `chainID=0` 的部署对旧交易等同于零防护。此问题与本次修复无关,未作改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

