### PR TITLE
fix(cli): exit non-zero on RPC failure so scripts can detect errors

### DIFF
--- a/rpc/jsonclient/rpc_ctx.go
+++ b/rpc/jsonclient/rpc_ctx.go
@@ -76,12 +76,12 @@ func (c *RPCCtx) Run() {
 	result, err := c.RunResult()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	}
 	data, err := json.MarshalIndent(result, "", "    ")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	}
 	fmt.Println(string(data))
 }
@@ -92,13 +92,13 @@ func (c *RPCCtx) RunWithoutMarshal() {
 	rpc, err := NewJSONClient(c.Addr)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	}
 
 	err = rpc.Call(c.Method, c.Params, &res)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	}
 
 	fmt.Println(res)
@@ -136,12 +136,12 @@ func (c *RPCCtx) RunExt(arg ...interface{}) {
 	result, err := c.RunResultExt(arg...)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	}
 	data, err := json.MarshalIndent(result, "", "    ")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return
+		os.Exit(1)
 	}
 	fmt.Println(string(data))
 }


### PR DESCRIPTION
## 问题

`rpc/jsonclient` 的 `RPCCtx.Run()` / `RunWithoutMarshal()` / `RunExt()` 在 RPC 失败时只打印错误到 stderr 并 `return`，**退出码恒为 0**。cobra `Run:`（非 `RunE:`）handler 不检查错误，进程始终以 0 退出。

导致 shell 脚本/管道无法感知 CLI 失败——所有靠退出码判断的就绪/交易等待都会假通过。例如 plugin 的 rgbx CI 用 `chain33-cli block last_header` 判断节点就绪，节点 RPC 未监听时仍返回 0，后续查询在 RPC 未就绪时失败（已导致 rgbx CI 偶发失败：DKG timeout、restart 恢复 pending 查询）。

## 修改

`rpc_ctx.go` 三处错误路径在打印错误后 `os.Exit(1)`：

- `Run()`（2 处）
- `RunWithoutMarshal()`（2 处）
- `RunExt()`（2 处）

`RunResult()` / `RunResultExt()` 返回 error（由调用方处理）不改。

## 影响

- **成功路径**：退出码不变（0）
- **失败路径**：0 → 1，符合 Unix 惯例
- **只解析 stdout（jq）的脚本**：不受影响（错误时 stdout 仍为空）
- **错误依赖退出码 0 的脚本**：会暴露隐藏 bug（正确方向）

## 验证

- `go build ./rpc/jsonclient/ ./system/dapp/commands/` 通过
- 实测：`chain33-cli block last_header --rpc_laddr=127.0.0.1:1`（RPC refused）退出码 **1**（修复前为 0）

Co-Authored-By: Claude <noreply@anthropic.com>