### PR TITLE
fix(p2p/dht): move taskGroup.Add out of goroutines to fix data race

### DIFF
--- a/system/p2p/dht/manage/conns.go
+++ b/system/p2p/dht/manage/conns.go
@@ -99,16 +99,15 @@ func (s *ConnManager) BandTrackerByProtocol() *types.NetProtocolInfos {
 }
 
 // MonitorAllPeers monitory all peers
+// 调用方需在启动 goroutine 之前执行 wg.Add(1), 否则 Add 会与 Wait 形成 data race
 func (s *ConnManager) MonitorAllPeers(wg *sync.WaitGroup) {
+	defer wg.Done()
 	ticker1 := time.NewTicker(time.Minute)
 	defer ticker1.Stop()
 	ticker2 := time.NewTicker(time.Minute * 2)
 	defer ticker2.Stop()
 	ticker3 := time.NewTicker(time.Second * 5)
 	defer ticker3.Stop()
-
-	wg.Add(1)
-	defer wg.Done()
 
 	for {
 		select {

--- a/system/p2p/dht/p2p.go
+++ b/system/p2p/dht/p2p.go
@@ -137,12 +137,15 @@ func initP2P(p *P2P) *P2P {
 	priv := p.addrBook.GetPrivkey()
 	if priv == nil { //addrbook存储的peer key 为空
 		if p.p2pCfg.WaitPid { //p2p阻塞,直到创建钱包之后
+			p.taskGroup.Add(1)
 			p.genAirDropKey()
 		} else { //创建随机公私钥对,生成临时pid，待创建钱包之后，提换钱包生成的pid
 			p.addrBook.Randkey()
+			p.taskGroup.Add(1)
 			go p.genAirDropKey() //非阻塞模式
 		}
 	} else { //非阻塞模式
+		p.taskGroup.Add(1)
 		go p.genAirDropKey()
 	}
 
@@ -205,9 +208,13 @@ func (p *P2P) StartP2P() {
 	p.env = env
 	protocol.InitAllProtocol(env)
 	p.discovery.Start()
+	// taskGroup.Add 必须在 goroutine 启动前调用, 避免与 waitTaskDone 的 Wait 竞态
+	p.taskGroup.Add(1)
 	go p.managePeers()
+	p.taskGroup.Add(1)
 	go p.findLANPeers()
 	for i := 0; i < runtime.NumCPU(); i++ {
+		p.taskGroup.Add(1)
 		go p.handleP2PEvent()
 	}
 }
@@ -301,10 +308,11 @@ func (p *P2P) buildHostOptions(priv crypto.PrivKey, bandwidthTracker metrics.Rep
 	return options
 }
 
+// managePeers 由 StartP2P 启动, 调用方需先执行 taskGroup.Add(1)
 func (p *P2P) managePeers() {
-	go p.connManager.MonitorAllPeers(p.taskGroup)
-	p.taskGroup.Add(1)
 	defer p.taskGroup.Done()
+	p.taskGroup.Add(1)
+	go p.connManager.MonitorAllPeers(p.taskGroup)
 	for {
 		log.Debug("managePeers", "table size", p.discovery.RoutingTable().Size())
 		select {
@@ -328,7 +336,9 @@ func (p *P2P) managePeers() {
 }
 
 // 查询本局域网内是否有节点
+// 由 StartP2P 启动, 调用方需先执行 taskGroup.Add(1)
 func (p *P2P) findLANPeers() {
+	defer p.taskGroup.Done()
 	if p.subCfg.DisableFindLANPeers {
 		return
 	}
@@ -337,9 +347,6 @@ func (p *P2P) findLANPeers() {
 		log.Error("findLANPeers", "err", err.Error())
 		return
 	}
-
-	p.taskGroup.Add(1)
-	defer p.taskGroup.Done()
 
 	for {
 		select {
@@ -361,9 +368,8 @@ func (p *P2P) findLANPeers() {
 	}
 }
 
+// handleP2PEvent 由 StartP2P 启动, 调用方需先执行 taskGroup.Add(1)
 func (p *P2P) handleP2PEvent() {
-
-	p.taskGroup.Add(1)
 	defer p.taskGroup.Done()
 	for {
 		select {
@@ -418,14 +424,25 @@ func (p *P2P) waitTaskDone() {
 }
 
 // 创建空投地址
+// 注意: taskGroup.Add 必须由调用方在启动 goroutine 之前完成,
+// 否则会与 waitTaskDone 中的 Wait 形成 data race
 func (p *P2P) genAirDropKey() {
-	p.taskGroup.Add(1)
+	// 必须先归还 taskGroup 名额再 reStart:
+	// reStart -> CloseP2P -> waitTaskDone 会等待本 goroutine 的名额,
+	// 若持有名额调用会自等待 20s 超时
+	needRestart := p.doGenAirDropKey()
+	if needRestart {
+		p.reStart()
+	}
+}
+
+func (p *P2P) doGenAirDropKey() bool {
 	defer p.taskGroup.Done()
 	for { //等待钱包创建，解锁
 		select {
 		case <-p.ctx.Done():
 			log.Info("genAirDropKey", "p2p closed")
-			return
+			return false
 		case <-time.After(time.Second):
 			resp, err := p.api.ExecWalletFunc("wallet", "GetWalletStatus", &types.ReqNil{})
 			if err != nil {
@@ -450,7 +467,7 @@ func (p *P2P) genAirDropKey() {
 	msg, err := p.api.ExecWalletFunc("wallet", "NewAccountByIndex", reqIndex)
 	if err != nil {
 		log.Error("genAirDropKey", "NewAccountByIndex err", err)
-		return
+		return false
 	}
 	var walletPrivkey string
 	if reply, ok := msg.(*types.ReplyString); !ok {
@@ -467,13 +484,13 @@ func (p *P2P) genAirDropKey() {
 	walletPubkey, err := GenPubkey(walletPrivkey)
 	if err != nil {
 
-		return
+		return false
 	}
 	//如果addrbook之前保存的savePrivkey相同，则意味着节点启动之前已经创建了airdrop 空投地址
 	savePrivkey, _ := p.addrBook.GetPrivPubKey()
 	if savePrivkey == walletPrivkey { //addrbook与wallet保存了相同的空投私钥，不需要继续导入
 		log.Debug("genAirDropKey", " same privekey ,process done")
-		return
+		return false
 	}
 	if len(savePrivkey) != 2*privKeyCompressBytesLen { //非压缩私钥,兼容之前老版本的DHT非压缩私钥
 		log.Debug("len savePrivkey", len(savePrivkey))
@@ -514,7 +531,7 @@ func (p *P2P) genAirDropKey() {
 	}
 
 	p.addrBook.saveKey(walletPrivkey, walletPubkey)
-	p.reStart()
+	return true
 }
 
 func newDB(name, backend, dir string, cache int32) dbm.DB {


### PR DESCRIPTION
## 问题

CI 的 `unit-test` job 在 `Test_p2p` 报 data race（[run 31145045933](https://github.com/33cn/chain33/actions/runs/31145045933/job/92762634596)）：

```
WARNING: DATA RACE
Write at 0x00c000122c28 by goroutine 1230:
  dht.(*P2P).waitTaskDone.func1()   p2p.go:411   ← taskGroup.Wait()
Previous read at 0x00c000122c28 by goroutine 831:
  dht.(*P2P).genAirDropKey()        p2p.go:422   ← taskGroup.Add(1)
```

## 根因

`sync.WaitGroup` 要求 `Add` 与 `Wait` 之间存在 happens-before 关系。原代码把 `Add(1)` 写在 goroutine **内部**：

```go
go p.genAirDropKey()      // 启动时计数器仍为 0
// ...
func (p *P2P) genAirDropKey() {
    p.taskGroup.Add(1)    // 可能与 CloseP2P 的 Wait 并发执行
```

计数器为 0 时 `Wait` 会立即返回，此时并发的 `Add` 构成 data race。

## 改动

把 `Add(1)` 上移到 goroutine 启动之前，共 5 处：

- `genAirDropKey`
- `managePeers`
- `findLANPeers`
- `handleP2PEvent`
- `ConnManager.MonitorAllPeers`

`handleP2PEvent` 中处理异步回调的那处 `Add(1)` 保留原位 —— 外层 goroutine 已持有 +1，计数器不可能归零，是安全的。

### 顺带修复一个同源的自等待

`genAirDropKey` 持有 `taskGroup` 名额时调用 `reStart() → CloseP2P() → waitTaskDone()`，等待的正是自己占用的名额，必然走到 20s 超时。拆出 `doGenAirDropKey()` 返回是否需要重启，先归还名额再 `reStart`。

## 验证

`sync.WaitGroup` 的这个 race 在 macOS 上调度窗口很窄：**修改前的 baseline 本地跑 20 次也复现不出**，因此"修复后不复现"不足以作为证据。另写最小用例验证模式本身：

| 模式 | 结果 |
|------|------|
| 旧（`Add` 在 goroutine 内） | `WARNING: DATA RACE` |
| 新（`Add` 在启动前） | `ok` |

项目侧：

- `go test -race ./system/p2p/dht/...` — 全部通过
- `make test` — 退出码 0，81 个包通过
- `gofmt` / `go vet` 项目文件干净

未完整验证的部分：本地未安装 `golangci-lint`，`make linter` 没跑完；`go vet ./...` 的报错全部位于第三方依赖 `avalanchego`，与本次改动无关。

## 说明

该 race 在 `master` 上已存在（`system/p2p/dht/` 与 master 完全一致），并非 #1371 引入，因此本 PR 基于 master，可独立合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)