### PR TITLE
fix(ethrpc): reject value overflowing uint64 in EstimateGas

### DIFF
--- a/rpc/ethrpc/eth/eth.go
+++ b/rpc/ethrpc/eth/eth.go
@@ -530,9 +530,11 @@ func (e *ethHandler) EstimateGas(callMsg *types.CallMsg) (hexutil.Uint64, error)
 
 	var amount uint64
 	if callMsg.Value != nil && callMsg.Value.ToInt() != nil {
-		ethUnit := big.NewInt(1e18)
-		bigAmount := new(big.Int).Div(callMsg.Value.ToInt(), ethUnit.Div(ethUnit, big.NewInt(1).SetInt64(e.cfg.GetCoinPrecision())))
-		amount = bigAmount.Uint64()
+		var err error
+		amount, err = ethValue2CoinsAmount(callMsg.Value.ToInt(), e.cfg.GetCoinPrecision())
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	action := &ctypes.EVMContractAction4Chain33{Amount: amount, GasLimit: 0, GasPrice: 0, Note: "", ContractAddr: callMsg.To}
@@ -628,6 +630,21 @@ func (e *ethHandler) EstimateGas(callMsg *types.CallMsg) (hexutil.Uint64, error)
 	log.Info("EstimateGas", "evmNeedGas:", bigGas, "properFee:", fee, "realFee:", realFee, "finalFee:", finalFee, "tx.size", tx.Size())
 	return hexutil.Uint64(finalFee), err
 
+}
+
+// ethValue2CoinsAmount 把 eth 的 wei 金额按链精度换算为 coins 金额并做 uint64 截断保护。
+// 精度换算后的金额超出 uint64 范围时, 直接返回错误而不是像修复前那样静默截断,
+// 使模拟执行收到与用户意图完全无关的金额。与 AssembleChain33Tx 对同一换算的
+// IsInt64 守卫保持一致。
+func ethValue2CoinsAmount(ethValue *big.Int, coinPrecision int64) (uint64, error) {
+	ethUnit := big.NewInt(1e18)
+	bigAmount := new(big.Int).Div(ethValue, ethUnit.Div(ethUnit, big.NewInt(1).SetInt64(coinPrecision)))
+	if !bigAmount.IsUint64() {
+		log.Error("ethValue2CoinsAmount", "value exceeds uint64 range after precision conversion",
+			"ethValue", ethValue.String(), "converted", bigAmount.String())
+		return 0, errors.New("invalid value: exceeds uint64 range")
+	}
+	return bigAmount.Uint64(), nil
 }
 
 // GasPrice  eth_gasPrice default 10 gwei

--- a/rpc/ethrpc/eth/eth_test.go
+++ b/rpc/ethrpc/eth/eth_test.go
@@ -199,6 +199,29 @@ func TestEthHandler_EstimateGas(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+// TestEthValue2CoinsAmount 精度换算后的金额超出 uint64 范围时,
+// 不能再像修复前那样静默截断, 而应返回错误。
+func TestEthValue2CoinsAmount(t *testing.T) {
+	// 正常值: 1 ETH = 1e18 wei, 精度 1e8 时换算为 1e8 coins
+	oneEth := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	amount, err := ethValue2CoinsAmount(oneEth, 1e8)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(1e8), amount)
+
+	// 超 uint64: 2^64 * 1e10 wei, 除以 1e10 后仍为 2^64 > uint64 max
+	overflow := new(big.Int).Lsh(big.NewInt(1), 64)
+	overflow.Mul(overflow, big.NewInt(1e10))
+	_, err = ethValue2CoinsAmount(overflow, 1e8)
+	assert.NotNil(t, err, "超出 uint64 范围的 value 应返回错误, 而非截断")
+
+	// 恰好 uint64 max 边界: 应允许
+	atMax := new(big.Int).SetUint64(^uint64(0))
+	atMax.Mul(atMax, big.NewInt(1e10))
+	amount, err = ethValue2CoinsAmount(atMax, 1e8)
+	assert.Nil(t, err)
+	assert.Equal(t, ^uint64(0), amount)
+}
+
 func TestEthHandler_GetTransactionCount(t *testing.T) {
 	qapi.On("Query", mock.Anything).Return("0x12", nil)
 	addr := "0xd83b69c56834e85e023b1738e69bfa2f0dd52905"


### PR DESCRIPTION
## 问题

`eth_estimateGas` 把调用方传入的 wei 金额按链精度换算成 coins 后,直接 `big.Int.Uint64()` 落进 `EVMContractAction4Chain33.Amount`,**无范围检查**:

```go
bigAmount := new(big.Int).Div(callMsg.Value.ToInt(), ...)
amount = bigAmount.Uint64()   // ← 超 uint64 时静默截断为低 64 位
```

`value` 是调用方可控输入。换算后超出 uint64 范围时,`Uint64()` 返回低 64 位截断值,使 gas 估算基于一个与用户意图完全无关的金额。

这是 `cbeb5f831`(为 `AssembleChain33Tx` 的同一换算加 `IsInt64` 守卫)的**姊妹调用点,漏修**。

## 改动

把换算逻辑抽成 `ethValue2CoinsAmount`,镜像 `AssembleChain33Tx` 的守卫(`IsUint64`),超范围直接返回错误而非截断。抽成独立函数后可直接单元测试,无需注册 evm 执行器。

## 测试

`TestEthValue2CoinsAmount` 覆盖:
- 正常值:1 ETH → 1e8 coins
- 超 uint64:返回错误,而非截断(禁用守卫时测试 FAIL,守卫恢复时 PASS,已验证测试有效)
- uint64 max 边界:允许

`go test ./rpc/ethrpc/...` 全绿,`go test -race ./rpc/ethrpc/eth/` 通过,gofmt 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)