### PR TITLE
fix(ethrpc): guard nil deref and empty-slice index in eth handlers

### DIFF
--- a/rpc/ethrpc/eth/eth.go
+++ b/rpc/ethrpc/eth/eth.go
@@ -76,6 +76,9 @@ func (e *ethHandler) GetBalance(address string, tag *string) (hexutil.Big, error
 	if err != nil {
 		return balance, err
 	}
+	if len(accounts) == 0 {
+		return balance, errors.New("account not found")
+	}
 	//转换成精度为18
 	bn := new(big.Int).SetInt64(accounts[0].GetBalance())
 	bn = bn.Mul(bn, new(big.Int).Div(big.NewInt(1e18), big.NewInt(e.cfg.GetCoinPrecision())))
@@ -123,6 +126,9 @@ func (e *ethHandler) GetBlockByNumber(in string, full bool) (*types.Block, error
 	if err != nil {
 		log.Error("GetBlockByNumber", "err", err)
 		return nil, err
+	}
+	if len(details.GetItems()) == 0 {
+		return nil, errors.New("block not found")
 	}
 
 	fullblock := details.GetItems()[0]
@@ -226,6 +232,9 @@ func (e *ethHandler) GetBlockTransactionCountByNumber(blockNum *hexutil.Big) (he
 	if err != nil {
 		return 0, err
 	}
+	if len(blockdetails.GetItems()) == 0 {
+		return 0, errors.New("block not found")
+	}
 	return hexutil.Uint64(len(blockdetails.GetItems()[0].GetBlock().GetTxs())), nil
 
 }
@@ -243,6 +252,9 @@ func (e *ethHandler) GetBlockTransactionCountByHash(hash common.Hash) (hexutil.U
 	if err != nil {
 		log.Error("GetBlockByNumber", "err", err)
 		return 0, err
+	}
+	if len(blockdetails.GetItems()) == 0 {
+		return 0, errors.New("block not found")
 	}
 
 	return hexutil.Uint64(len(blockdetails.GetItems()[0].GetBlock().GetTxs())), nil
@@ -504,9 +516,16 @@ func (e *ethHandler) GetTransactionCount(address, tag string) (hexutil.Uint64, e
 		Nonce string `json:"nonce,omitempty"`
 	}
 	err = json.Unmarshal(result, &nonce)
-	bigNonce, _ := new(big.Int).SetString(nonce.Nonce, 10)
+	if err != nil {
+		return 0, err
+	}
+	// SetString 失败(空串/非十进制/hex 前缀)会返回 nil, 直接 Uint64() 会 nil deref。
+	bigNonce, ok := new(big.Int).SetString(nonce.Nonce, 10)
+	if !ok {
+		return 0, errors.New("invalid nonce: " + nonce.Nonce)
+	}
 
-	return hexutil.Uint64(bigNonce.Uint64()), err
+	return hexutil.Uint64(bigNonce.Uint64()), nil
 }
 
 // EstimateGas 获取gas
@@ -616,7 +635,11 @@ func (e *ethHandler) EstimateGas(callMsg *types.CallMsg) (hexutil.Uint64, error)
 		return 0, err
 	}
 
-	bigGas, _ := new(big.Int).SetString(gas.Gas, 10)
+	// SetString 失败(空串/非十进制)会返回 nil, 直接 Uint64() 会 nil deref。
+	bigGas, ok := new(big.Int).SetString(gas.Gas, 10)
+	if !ok {
+		return 0, errors.New("invalid gas: " + gas.Gas)
+	}
 
 	var finalFee = realFee
 	if bigGas.Uint64() > uint64(realFee) {

--- a/rpc/ethrpc/eth/eth_test.go
+++ b/rpc/ethrpc/eth/eth_test.go
@@ -473,3 +473,35 @@ func TestEthHandler_SendRawTransaction(t *testing.T) {
 	_, err = ethCli.SendRawTransaction(metamaskRawTx)
 	assert.NotNil(t, err)
 }
+
+// 以下测试回归空结果导致的下标越界 panic:
+// 修复前 GetItems()[0] 在空结果时直接 panic。
+// (GetBalance 的 accounts[0] 修复因 mock 链过深、已有 TestEthHandler_GetBalance
+// 覆盖其正常路径, 此处不重复测试空结果。)
+
+func TestEthHandler_GetBlockByNumberEmptyResult(t *testing.T) {
+	old := qapi
+	qapi = &clientMocks.QueueProtocolAPI{}
+	defer func() { qapi = old }()
+	ethCli.cli.Init(q.Client(), qapi)
+
+	qapi.On("GetBlocks", mock.Anything).Return(&ctypes.BlockDetails{}, nil)
+	_, err := ethCli.GetBlockByNumber("0x1", true)
+	assert.NotNil(t, err, "空区块结果应返回错误, 而非下标越界 panic")
+}
+
+func TestEthHandler_GetBlockTransactionCountEmptyResult(t *testing.T) {
+	old := qapi
+	qapi = &clientMocks.QueueProtocolAPI{}
+	defer func() { qapi = old }()
+	ethCli.cli.Init(q.Client(), qapi)
+
+	qapi.On("GetBlocks", mock.Anything).Return(&ctypes.BlockDetails{}, nil)
+	_, err := ethCli.GetBlockTransactionCountByNumber((*hexutil.Big)(big.NewInt(1)))
+	assert.NotNil(t, err, "空区块结果应返回错误")
+
+	qapi.On("GetBlockByHashes", mock.Anything).Return(&ctypes.BlockDetails{}, nil)
+	var hash = "0x660f78e492bf2630ecd4d8fdf09ec64f0e141bdfeb7636ed4992b31dd81338bd"
+	_, err = ethCli.GetBlockTransactionCountByHash(common.HexToHash(hash))
+	assert.NotNil(t, err, "空区块结果应返回错误")
+}


### PR DESCRIPTION
## 问题

两处 `SetString` 丢弃 ok 返回值,失败时返回的 nil `*big.Int` 被直接解引用:

- `GetTransactionCount` / `eth_sendRawTransaction`:`nonce.Nonce` 字段
- `EstimateGas`:`gas.Gas` 字段

evm 执行器返回空串或非十进制值(地址无 nonce 记录、gas 回退/为空)时,`SetString(base=10)` 失败返回 nil,随后 `.Uint64()` / `.Int64()` panic。均可通过 eth RPC 触发。

另四处对结果切片无长度检查就取 `[0]`:

- `GetBalance`:`accounts[0]`
- `GetBlockByNumber`:`details.GetItems()[0]`
- `GetBlockTransactionCountByNumber`:`GetItems()[0]`
- `GetBlockTransactionCountByHash`:`GetItems()[0]`

空结果(区块/账户不存在)时 index out of range panic。

## 严重度说明

panic 不会打崩节点:ethrpc 走 go-ethereum 的 rpc 层,`service.go` 有 recover,会转成 JSON-RPC error 响应。但 panic 仍是缺陷 —— 应返回干净的 `"block not found"` / `"invalid nonce"` 错误而非触发 recover。

## 改动

- 两处 `SetString` 检查 ok,失败返回明确错误
- 四处 `[0]` 前加 `len(...) == 0` 检查,返回 `"not found"` 类错误

## 测试

`TestEthHandler_GetBlockByNumberEmptyResult`、`TestEthHandler_GetBlockTransactionCountEmptyResult` 覆盖区块空结果路径。禁用保护后测试复现 `index out of range [0] with length 0` panic,恢复后通过 —— 已验证测试有效。

`GetBalance` 空结果路径的 mock 链较深,已有 `TestEthHandler_GetBalance` 覆盖其正常路径,未重复测试。

`go test ./rpc/ethrpc/...` 全绿,`-race` 通过,gofmt/vet 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)