### PR TITLE
fix(account): reject self-transfer across eth address case variants in ExecTransfer

### DIFF
--- a/account/exec_selftransfer_test.go
+++ b/account/exec_selftransfer_test.go
@@ -1,0 +1,83 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package account
+
+import (
+	"testing"
+
+	"github.com/33cn/chain33/common/address"
+	"github.com/33cn/chain33/common/db"
+	_ "github.com/33cn/chain33/system/address" //init address drivers (btc/eth)
+	"github.com/33cn/chain33/types"
+	"github.com/stretchr/testify/require"
+)
+
+// 同一 eth 地址的两种字符串表示（仅大小写不同）。
+// address.FormatAddrKey 对 eth 地址统一转小写后作为 DB key，
+// 因此二者指向状态库中的同一条账户记录。
+const (
+	ethAddrMixed = "0x111111111111111111111111111111111111111A"
+	ethAddrLower = "0x111111111111111111111111111111111111111a"
+)
+
+func newTestCoinsDB(t *testing.T) *DB {
+	cfg := types.NewChain33Config(types.GetDefaultCfgstring())
+	acc := NewCoinsAccount(cfg)
+	memdb, err := db.NewGoMemDB("gomemdb", "self-transfer-test", 128)
+	require.NoError(t, err)
+	acc.SetDB(memdb)
+	return acc
+}
+
+// 前置条件：两个不同字符串的 eth 地址格式化后指向同一个 DB key。
+func TestEthAddrCaseVariantsSameKey(t *testing.T) {
+	require.NotEqual(t, ethAddrMixed, ethAddrLower)
+	require.True(t, address.IsEthAddress(ethAddrMixed))
+	require.True(t, address.IsEthAddress(ethAddrLower))
+	require.Equal(t, address.FormatAddrKey(ethAddrMixed), address.FormatAddrKey(ethAddrLower))
+}
+
+// 回归测试：ExecTransfer 自我转账检查必须比较归一化后的地址。
+// 传入同一 eth 地址的两种大小写形式，原始字符串比较不相等，
+// 但存储层经 FormatAddrKey 归一化后指向同一账户记录，
+// 若不拦截会导致先扣款记录被加款记录覆盖，余额凭空增加（造币）。
+// 修复后该转账必须被拒绝且余额不变。
+func TestExecTransferSelfTransferCaseVariantRejected(t *testing.T) {
+	acc := newTestCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	// 播种：该 eth 地址在执行器账户中有 100 coins
+	origin := int64(100 * types.DefaultCoinPrecision)
+	amount := int64(10 * types.DefaultCoinPrecision)
+	acc.SaveExecAccount(execaddr, &types.Account{Addr: ethAddrLower, Balance: origin})
+
+	// from 与 to 是同一地址的不同大小写形式，必须被识别为自我转账
+	_, err := acc.ExecTransfer(ethAddrMixed, ethAddrLower, execaddr, amount)
+	require.Equal(t, types.ErrSendSameToRecv, err)
+
+	// 两个方向的大小写组合都必须被拒绝
+	_, err = acc.ExecTransfer(ethAddrLower, ethAddrMixed, execaddr, amount)
+	require.Equal(t, types.ErrSendSameToRecv, err)
+
+	// 余额不变，未发生造币
+	require.Equal(t, origin, acc.LoadExecAccount(ethAddrLower, execaddr).Balance)
+	require.Equal(t, origin, acc.LoadExecAccount(ethAddrMixed, execaddr).Balance)
+}
+
+// 回归测试：修复不影响正常（不同地址）的 ExecTransfer。
+func TestExecTransferNormalNotAffected(t *testing.T) {
+	acc := newTestCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	origin := int64(100 * types.DefaultCoinPrecision)
+	amount := int64(10 * types.DefaultCoinPrecision)
+	acc.SaveExecAccount(execaddr, &types.Account{Addr: addr1, Balance: origin})
+
+	receipt, err := acc.ExecTransfer(addr1, addr2, execaddr, amount)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	require.Equal(t, origin-amount, acc.LoadExecAccount(addr1, execaddr).Balance)
+	require.Equal(t, amount, acc.LoadExecAccount(addr2, execaddr).Balance)
+}

--- a/account/exec_selftransfer_test.go
+++ b/account/exec_selftransfer_test.go
@@ -49,8 +49,8 @@ func TestExecTransferSelfTransferCaseVariantRejected(t *testing.T) {
 	execaddr := address.ExecAddress("ticket")
 
 	// 播种：该 eth 地址在执行器账户中有 100 coins
-	origin := int64(100 * types.DefaultCoinPrecision)
-	amount := int64(10 * types.DefaultCoinPrecision)
+	origin := 100 * types.DefaultCoinPrecision
+	amount := 10 * types.DefaultCoinPrecision
 	acc.SaveExecAccount(execaddr, &types.Account{Addr: ethAddrLower, Balance: origin})
 
 	// from 与 to 是同一地址的不同大小写形式，必须被识别为自我转账
@@ -71,8 +71,8 @@ func TestExecTransferNormalNotAffected(t *testing.T) {
 	acc := newTestCoinsDB(t)
 	execaddr := address.ExecAddress("ticket")
 
-	origin := int64(100 * types.DefaultCoinPrecision)
-	amount := int64(10 * types.DefaultCoinPrecision)
+	origin := 100 * types.DefaultCoinPrecision
+	amount := 10 * types.DefaultCoinPrecision
 	acc.SaveExecAccount(execaddr, &types.Account{Addr: addr1, Balance: origin})
 
 	receipt, err := acc.ExecTransfer(addr1, addr2, execaddr, amount)

--- a/account/execaccount.go
+++ b/account/execaccount.go
@@ -148,7 +148,8 @@ func (acc *DB) ExecActive(addr, execaddr string, amount int64) (*types.Receipt, 
 
 // ExecTransfer 执行转帐
 func (acc *DB) ExecTransfer(from, to, execaddr string, amount int64) (*types.Receipt, error) {
-	if from == to {
+	// 比较归一化后的地址(与存储key一致, eth地址大小写变体视为同一地址)
+	if from == to || string(address.FormatAddrKey(from)) == string(address.FormatAddrKey(to)) {
 		return nil, types.ErrSendSameToRecv
 	}
 	if !acc.CheckAmount(amount) {


### PR DESCRIPTION
## Problem

`account.DB.ExecTransfer` (account/execaccount.go:151) checked self-transfer with a raw string comparison `from == to`. However, the storage layer normalizes addresses via `address.FormatAddrKey` (which lowercases eth addresses, see #1245) when building account keys.

As a result, two case variants of the same eth address (e.g. `0x...111A` vs `0x...111a`) pass the check, yet both `LoadExecAccount`/`SaveExecAccount` resolve to the **same** storage key. The sender's debit record is saved first and then overwritten by the recipient's credit record at the same key — the net effect is the exec account balance increases by `amount`, i.e. coins are minted out of thin air.

## Root cause

The self-transfer guard compared the raw input strings instead of the normalized address identity used by the storage layer. The main ledger `Transfer` (account/account.go:127) does not have this bug: it compares `accFrom.Addr == accTo.Addr` on the loaded records, which are already normalized.

## Fix

In `ExecTransfer`, compare the normalized addresses (`string(address.FormatAddrKey(from)) == string(address.FormatAddrKey(to))`) in addition to the raw comparison, matching the identity semantics of the storage key. Minimal change, no behavior change for distinct addresses.

## Tests

New regression tests in `account/exec_selftransfer_test.go`:

- `TestEthAddrCaseVariantsSameKey`: precondition — both case variants of the eth address map to the same `FormatAddrKey` storage key.
- `TestExecTransferSelfTransferCaseVariantRejected`: self-transfer via case variants is rejected with `ErrSendSameToRecv` (both directions) and the balance is unchanged.
- `TestExecTransferNormalNotAffected`: a normal transfer between distinct addresses still works.

Verification: `go build ./account/...` and `go test ./account/...` all pass.