### PR TITLE
fix(account): reject non-positive amount in GenesisInit

### DIFF
--- a/account/genesis.go
+++ b/account/genesis.go
@@ -18,6 +18,9 @@ func safeAdd(balance, amount int64) (int64, error) {
 
 // GenesisInit 生成创世地址账户收据
 func (acc *DB) GenesisInit(addr string, amount int64) (receipt *types.Receipt, err error) {
+	if !acc.CheckAmount(amount) {
+		return nil, types.ErrAmount
+	}
 	accTo := acc.LoadAccount(addr)
 	copyto := types.CloneAccount(accTo)
 	accTo.Balance, err = safeAdd(accTo.GetBalance(), amount)

--- a/account/genesis_checkamount_test.go
+++ b/account/genesis_checkamount_test.go
@@ -1,0 +1,35 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package account
+
+import (
+	"testing"
+
+	"github.com/33cn/chain33/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test: GenesisInit must validate the amount via CheckAmount and
+// reject non-positive amounts instead of initializing a negative balance.
+func TestGenesisInitNegativeAmountRejected(t *testing.T) {
+	accCoin, _ := GenerAccDb()
+
+	receipt, err := accCoin.GenesisInit(addr1, -1000)
+	require.Equal(t, types.ErrAmount, err, "negative genesis amount must be rejected")
+	require.Nil(t, receipt)
+	require.Equal(t, int64(0), accCoin.LoadAccount(addr1).Balance,
+		"account must not be created with a negative balance")
+
+	receipt, err = accCoin.GenesisInit(addr1, 0)
+	require.Equal(t, types.ErrAmount, err, "zero genesis amount must be rejected")
+	require.Nil(t, receipt)
+	require.Equal(t, int64(0), accCoin.LoadAccount(addr1).Balance)
+
+	// a valid positive genesis amount still works
+	receipt, err = accCoin.GenesisInit(addr1, 100*types.DefaultCoinPrecision)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	require.Equal(t, 100*types.DefaultCoinPrecision, accCoin.LoadAccount(addr1).Balance)
+}


### PR DESCRIPTION
## Problem

`GenesisInit` (account/genesis.go:20-34) only validated the resulting balance via `safeAdd`, which does not reject negative amounts (`balance+amount < amount` only holds when `balance < 0`). A negative genesis amount could therefore initialize an account with a **negative balance**, breaking the fundamental invariant that balances are non-negative. All other public fund entry points (`Transfer`, `Mint`, `Burn`, `ExecDeposit`, etc.) validate the amount via `CheckAmount`; `GenesisInit` was the only one missing this check.

Impact is limited to the genesis configuration stage, but it is a missing input validation on a fund entry point.

## Root cause

`safeAdd` guards against overflow and the `MaxTokenBalance` upper bound, but it is not an amount-validity check: for `balance = 0` and `amount = -1000`, `safeAdd(0, -1000)` returns `-1000` with no error, and the negative value is persisted by `SaveAccount`.

## Fix

Add `CheckAmount` validation at the entry of `GenesisInit`, consistent with every other public amount-taking method in the account package:

```go
if !acc.CheckAmount(amount) {
    return nil, types.ErrAmount
}
```

`CheckAmount` rejects `amount <= 0` (and amounts above the max token supply), so invalid genesis amounts now return `types.ErrAmount` instead of writing a negative balance. The `safeAdd` logic itself is unchanged.

## Regression test

New test `TestGenesisInitNegativeAmountRejected` (account/genesis_checkamount_test.go) reproduces the scenario:

- `GenesisInit(addr, -1000)` returns `types.ErrAmount`, no receipt, and the account balance stays 0 (account not created) — previously this succeeded with balance `-1000`.
- `GenesisInit(addr, 0)` is also rejected.
- A valid positive amount (`100 * DefaultCoinPrecision`) still initializes the account normally.

## Verification

- `go build ./account/...` — ok
- `go test ./account/...` — ok (all existing tests pass, including `TestGenesisInit` / `TestGenesisInitExec`)
- `go test ./system/dapp/coins/...` — ok (`GenesisInit`'s only caller is the coins executor genesis processing)

Note: `go build ./...` fails in the third-party `github.com/33cn/avalanchego` dependency (Go version incompatibility in `slices.SortFunc` usage) — this is pre-existing on `master` and unrelated to this change.