### PR TITLE
fix(account): reject self-transfer across eth address case variants in ExecTransferFrozen

### DIFF
--- a/account/execaccount.go
+++ b/account/execaccount.go
@@ -184,7 +184,8 @@ func (acc *DB) ExecTransfer(from, to, execaddr string, amount int64) (*types.Rec
 
 // ExecTransferFrozen 从自己冻结的钱里面扣除，转移到别人的活动钱包里面去
 func (acc *DB) ExecTransferFrozen(from, to, execaddr string, amount int64) (*types.Receipt, error) {
-	if from == to {
+	// compare with formatted address, avoid bypass by address case variants(same as FormatAddrKey used by execAccountKey)
+	if string(address.FormatAddrKey(from)) == string(address.FormatAddrKey(to)) {
 		return nil, types.ErrSendSameToRecv
 	}
 	if !acc.CheckAmount(amount) {

--- a/account/execaccount_frozen_test.go
+++ b/account/execaccount_frozen_test.go
@@ -40,9 +40,9 @@ func TestExecTransferFrozenRejectSelfTransferCaseVariant(t *testing.T) {
 	acc := newTestCoinsDB(t)
 	execaddr := address.ExecAddress("ticket")
 
-	originBalance := int64(100 * types.DefaultCoinPrecision)
-	originFrozen := int64(20 * types.DefaultCoinPrecision)
-	amount := int64(10 * types.DefaultCoinPrecision)
+	originBalance := 100 * types.DefaultCoinPrecision
+	originFrozen := 20 * types.DefaultCoinPrecision
+	amount := 10 * types.DefaultCoinPrecision
 	acc.SaveExecAccount(execaddr, &types.Account{
 		Addr: testEthAddrLower, Balance: originBalance, Frozen: originFrozen,
 	})
@@ -63,9 +63,9 @@ func TestExecTransferFrozenNormal(t *testing.T) {
 
 	addrFrom := "14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
 	addrTo := "12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv"
-	originBalance := int64(100 * types.DefaultCoinPrecision)
-	originFrozen := int64(20 * types.DefaultCoinPrecision)
-	amount := int64(10 * types.DefaultCoinPrecision)
+	originBalance := 100 * types.DefaultCoinPrecision
+	originFrozen := 20 * types.DefaultCoinPrecision
+	amount := 10 * types.DefaultCoinPrecision
 	acc.SaveExecAccount(execaddr, &types.Account{
 		Addr: addrFrom, Balance: originBalance, Frozen: originFrozen,
 	})

--- a/account/execaccount_frozen_test.go
+++ b/account/execaccount_frozen_test.go
@@ -22,7 +22,7 @@ const (
 	testEthAddrLower = "0x111111111111111111111111111111111111111a"
 )
 
-func newTestCoinsDB(t *testing.T) *DB {
+func newFrozenTestCoinsDB(t *testing.T) *DB {
 	cfg := types.NewChain33Config(types.GetDefaultCfgstring())
 	acc := NewCoinsAccount(cfg)
 	memdb, err := db.NewGoMemDB("gomemdb", "exec-frozen", 128)
@@ -37,7 +37,7 @@ func newTestCoinsDB(t *testing.T) *DB {
 // by the to record (Balance increased) under the same normalized DB key,
 // duplicating frozen funds.
 func TestExecTransferFrozenRejectSelfTransferCaseVariant(t *testing.T) {
-	acc := newTestCoinsDB(t)
+	acc := newFrozenTestCoinsDB(t)
 	execaddr := address.ExecAddress("ticket")
 
 	originBalance := 100 * types.DefaultCoinPrecision
@@ -58,7 +58,7 @@ func TestExecTransferFrozenRejectSelfTransferCaseVariant(t *testing.T) {
 
 // ExecTransferFrozen between two different addresses must still work normally.
 func TestExecTransferFrozenNormal(t *testing.T) {
-	acc := newTestCoinsDB(t)
+	acc := newFrozenTestCoinsDB(t)
 	execaddr := address.ExecAddress("ticket")
 
 	addrFrom := "14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"

--- a/account/execaccount_frozen_test.go
+++ b/account/execaccount_frozen_test.go
@@ -1,0 +1,82 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package account
+
+import (
+	"testing"
+
+	"github.com/33cn/chain33/common/address"
+	"github.com/33cn/chain33/common/db"
+	_ "github.com/33cn/chain33/system/address" //init address drivers (btc/eth)
+	"github.com/33cn/chain33/types"
+	"github.com/stretchr/testify/require"
+)
+
+// same eth address in two string forms, only letter case differs.
+// address.FormatAddrKey normalizes eth addresses to lower case as the DB key,
+// so both forms point to the same account record in the state db.
+const (
+	testEthAddrMixed = "0x111111111111111111111111111111111111111A"
+	testEthAddrLower = "0x111111111111111111111111111111111111111a"
+)
+
+func newTestCoinsDB(t *testing.T) *DB {
+	cfg := types.NewChain33Config(types.GetDefaultCfgstring())
+	acc := NewCoinsAccount(cfg)
+	memdb, err := db.NewGoMemDB("gomemdb", "exec-frozen", 128)
+	require.NoError(t, err)
+	acc.SetDB(memdb)
+	return acc
+}
+
+// ExecTransferFrozen must reject self-transfer even when from/to are the same
+// address in different letter cases. Before the fix, the raw string comparison
+// from == to was bypassed: the from record (Frozen decreased) was overwritten
+// by the to record (Balance increased) under the same normalized DB key,
+// duplicating frozen funds.
+func TestExecTransferFrozenRejectSelfTransferCaseVariant(t *testing.T) {
+	acc := newTestCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	originBalance := int64(100 * types.DefaultCoinPrecision)
+	originFrozen := int64(20 * types.DefaultCoinPrecision)
+	amount := int64(10 * types.DefaultCoinPrecision)
+	acc.SaveExecAccount(execaddr, &types.Account{
+		Addr: testEthAddrLower, Balance: originBalance, Frozen: originFrozen,
+	})
+
+	_, err := acc.ExecTransferFrozen(testEthAddrMixed, testEthAddrLower, execaddr, amount)
+	require.Equal(t, types.ErrSendSameToRecv, err,
+		"self-transfer across address case variants must be rejected")
+
+	final := acc.LoadExecAccount(testEthAddrLower, execaddr)
+	require.Equal(t, originBalance, final.Balance, "Balance must be unchanged")
+	require.Equal(t, originFrozen, final.Frozen, "Frozen must be unchanged")
+}
+
+// ExecTransferFrozen between two different addresses must still work normally.
+func TestExecTransferFrozenNormal(t *testing.T) {
+	acc := newTestCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	addrFrom := "14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
+	addrTo := "12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv"
+	originBalance := int64(100 * types.DefaultCoinPrecision)
+	originFrozen := int64(20 * types.DefaultCoinPrecision)
+	amount := int64(10 * types.DefaultCoinPrecision)
+	acc.SaveExecAccount(execaddr, &types.Account{
+		Addr: addrFrom, Balance: originBalance, Frozen: originFrozen,
+	})
+
+	_, err := acc.ExecTransferFrozen(addrFrom, addrTo, execaddr, amount)
+	require.NoError(t, err)
+
+	from := acc.LoadExecAccount(addrFrom, execaddr)
+	require.Equal(t, originBalance, from.Balance)
+	require.Equal(t, originFrozen-amount, from.Frozen)
+	to := acc.LoadExecAccount(addrTo, execaddr)
+	require.Equal(t, amount, to.Balance)
+	require.Equal(t, int64(0), to.Frozen)
+}


### PR DESCRIPTION
## Problem

`account/execaccount.go:187` — `ExecTransferFrozen` checked for self-transfer with a raw string comparison:

```go
if from == to {
    return nil, types.ErrSendSameToRecv
}
```

However, account records are stored under a **normalized** key: `execAccountKey` (`account/execaccount.go:57-64`) routes every address through `address.FormatAddrKey`, which lower-cases eth addresses (see `common/address/util.go`). So the same eth address written in two letter-case forms (e.g. `0x1111...111A` vs `0x1111...111a`) passes the `from == to` check while pointing to the same account record in the state db.

## Root cause

When the check is bypassed, `ExecTransferFrozen` loads the same underlying account twice, subtracts `amount` from `accFrom.Frozen` and adds it to `accTo.Balance`, then saves both records under the **same** key. The second save (to-side: Frozen untouched, Balance increased) overwrites the first (from-side: Frozen decreased). Net effect: **Frozen is never reduced while Balance increases — frozen funds are duplicated (minted).**

## Fix

Compare the addresses with `address.FormatAddrKey` — the exact normalization used by `execAccountKey` — instead of raw string equality. Non-eth addresses are unaffected (`FormatAddrKey` passes them through unchanged).

## Tests

New regression tests in `account/execaccount_frozen_test.go`:

- `TestExecTransferFrozenRejectSelfTransferCaseVariant`: seeds an exec account, attempts `ExecTransferFrozen` with the same eth address in mixed-case and lower-case forms; asserts the call is rejected with `types.ErrSendSameToRecv` and that both `Balance` and `Frozen` are unchanged (previously the call succeeded and `Balance` grew by `amount` while `Frozen` stayed put).
- `TestExecTransferFrozenNormal`: a normal `ExecTransferFrozen` between two distinct addresses still works (Frozen of sender decreases, Balance of receiver increases).

```
go build ./account/...        # ok
go test ./account/...         # ok  (all existing + new tests pass)
```

Note: `go build ./...` on the whole repo fails in the third-party `avalanchego` module (`slices.SortFunc` generics vs Go 1.24); verified this failure also exists on unmodified `origin/master` and is unrelated to this change.