### PR TITLE
fix(account): add safeAdd overflow protection to exec account balance additions

### DIFF
--- a/account/execaccount.go
+++ b/account/execaccount.go
@@ -134,7 +134,11 @@ func (acc *DB) ExecActive(addr, execaddr string, amount int64) (*types.Receipt, 
 		return nil, types.ErrNoBalance
 	}
 	copyacc := types.CloneAccount(acc1)
-	acc1.Balance += amount
+	var err error
+	acc1.Balance, err = safeAdd(acc1.Balance, amount)
+	if err != nil {
+		return nil, err
+	}
 	acc1.Frozen -= amount
 	receiptBalance := &types.ReceiptExecAccountTransfer{
 		ExecAddr: execaddr,
@@ -270,7 +274,11 @@ func (acc *DB) execDepositFrozen(addr, execaddr string, amount int64) (*types.Re
 	}
 	acc1 := acc.LoadExecAccount(addr, execaddr)
 	copyacc := types.CloneAccount(acc1)
-	acc1.Frozen += amount
+	var err error
+	acc1.Frozen, err = safeAdd(acc1.Frozen, amount)
+	if err != nil {
+		return nil, err
+	}
 	receiptBalance := &types.ReceiptExecAccountTransfer{
 		ExecAddr: execaddr,
 		Prev:     copyacc,
@@ -291,7 +299,11 @@ func (acc *DB) ExecDeposit(addr, execaddr string, amount int64) (*types.Receipt,
 	}
 	acc1 := acc.LoadExecAccount(addr, execaddr)
 	copyacc := types.CloneAccount(acc1)
-	acc1.Balance += amount
+	var err error
+	acc1.Balance, err = safeAdd(acc1.Balance, amount)
+	if err != nil {
+		return nil, err
+	}
 	receiptBalance := &types.ReceiptExecAccountTransfer{
 		ExecAddr: execaddr,
 		Prev:     copyacc,

--- a/account/execaccount_safeadd_test.go
+++ b/account/execaccount_safeadd_test.go
@@ -1,0 +1,111 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package account
+
+import (
+	"math"
+	"testing"
+
+	"github.com/33cn/chain33/common/address"
+	"github.com/33cn/chain33/common/db"
+	"github.com/33cn/chain33/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newExecSafeAddCoinsDB(t *testing.T) *DB {
+	cfg := types.NewChain33Config(types.GetDefaultCfgstring())
+	acc := NewCoinsAccount(cfg)
+	memdb, err := db.NewGoMemDB("gomemdb", "exec-safeadd", 128)
+	require.NoError(t, err)
+	acc.SetDB(memdb)
+	return acc
+}
+
+// Regression test: exec account balance additions must go through safeAdd,
+// same as depositBalance/Mint on the main ledger. An overflowing ExecDeposit
+// must be rejected and leave the balance untouched instead of wrapping to
+// negative.
+func TestExecDepositOverflowRejected(t *testing.T) {
+	acc := newExecSafeAddCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	// seed an exec account balance close to the int64 limit
+	seed := int64(math.MaxInt64 - 5e15)
+	acc.SaveExecAccount(execaddr, &types.Account{Addr: addr1, Balance: seed})
+
+	amount := int64(1e16) // passes CheckAmount (< MaxCoin*1e8 = 1e17)
+	_, err := acc.ExecDeposit(addr1, execaddr, amount)
+	require.Equal(t, types.ErrAmount, err, "overflowing exec deposit must be rejected")
+	require.Equal(t, seed, acc.LoadExecAccount(addr1, execaddr).Balance,
+		"balance must be unchanged after rejected overflow deposit")
+}
+
+// ExecActive moves frozen coins back to balance; the balance addition must
+// also be overflow protected.
+func TestExecActiveOverflowRejected(t *testing.T) {
+	acc := newExecSafeAddCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	seed := int64(math.MaxInt64 - 5e15)
+	frozen := int64(1e16)
+	acc.SaveExecAccount(execaddr, &types.Account{Addr: addr1, Balance: seed, Frozen: frozen})
+
+	_, err := acc.ExecActive(addr1, execaddr, frozen)
+	require.Equal(t, types.ErrAmount, err, "overflowing exec active must be rejected")
+	final := acc.LoadExecAccount(addr1, execaddr)
+	require.Equal(t, seed, final.Balance)
+	require.Equal(t, frozen, final.Frozen)
+}
+
+// execDepositFrozen adds to the frozen balance; it must be overflow protected
+// as well.
+func TestExecDepositFrozenOverflowRejected(t *testing.T) {
+	acc := newExecSafeAddCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	seed := int64(math.MaxInt64 - 5e15)
+	acc.SaveExecAccount(execaddr, &types.Account{Addr: addr1, Frozen: seed})
+
+	amount := int64(1e16)
+	_, err := acc.execDepositFrozen(addr1, execaddr, amount)
+	require.Equal(t, types.ErrAmount, err, "overflowing exec deposit frozen must be rejected")
+	require.Equal(t, seed, acc.LoadExecAccount(addr1, execaddr).Frozen)
+}
+
+// The MaxTokenBalance cap inside safeAdd must not break normal deposit,
+// frozen/active cycles (checkBalance moves coins between frozen and active).
+func TestExecAccountNormalPathsWithSafeAdd(t *testing.T) {
+	acc := newExecSafeAddCoinsDB(t)
+	execaddr := address.ExecAddress("ticket")
+
+	// max single amount allowed by CheckAmount is just below 1e17
+	amount := int64(1e16)
+
+	// deposit up to exactly MaxTokenBalance is allowed
+	acc.SaveExecAccount(execaddr, &types.Account{Addr: addr1, Balance: types.MaxTokenBalance - amount})
+	_, err := acc.ExecDeposit(addr1, execaddr, amount)
+	require.NoError(t, err)
+	require.Equal(t, types.MaxTokenBalance, acc.LoadExecAccount(addr1, execaddr).Balance)
+
+	// freeze, then activate back at the cap: total stays at MaxTokenBalance
+	_, err = acc.ExecFrozen(addr1, execaddr, amount)
+	require.NoError(t, err)
+	_, err = acc.ExecActive(addr1, execaddr, amount)
+	require.NoError(t, err)
+	final := acc.LoadExecAccount(addr1, execaddr)
+	require.Equal(t, types.MaxTokenBalance, final.Balance)
+	require.Equal(t, int64(0), final.Frozen)
+
+	// execDepositFrozen up to MaxTokenBalance frozen is allowed
+	acc.SaveExecAccount(execaddr, &types.Account{Addr: addr2, Frozen: types.MaxTokenBalance - amount})
+	_, err = acc.execDepositFrozen(addr2, execaddr, amount)
+	require.NoError(t, err)
+	require.Equal(t, types.MaxTokenBalance, acc.LoadExecAccount(addr2, execaddr).Frozen)
+
+	// any further deposit beyond MaxTokenBalance is rejected
+	_, err = acc.ExecDeposit(addr1, execaddr, 1)
+	require.Equal(t, types.ErrAmount, err)
+	require.Equal(t, types.MaxTokenBalance, acc.LoadExecAccount(addr1, execaddr).Balance)
+}


### PR DESCRIPTION
## Problem

Exec account balance additions did not use the `safeAdd` guard, unlike the main ledger:

- `ExecDeposit` (`account/execaccount.go:294`): `acc1.Balance += amount`
- `ExecActive` (`account/execaccount.go:137`): `acc1.Balance += amount`
- `execDepositFrozen` (`account/execaccount.go:273`): `acc1.Frozen += amount`

## Root Cause

On the main ledger, both `depositBalance` (`account/account.go:165`) and `Mint` (`account/account.go:467`) add amounts via `safeAdd` (`account/genesis.go:12-17`), which rejects int64 overflow and enforces the `types.MaxTokenBalance` cap. The exec account paths added amounts directly. When an exec account balance is close to the int64 limit (e.g. a bridge-style dapp accumulating ledgered deposits from an external chain), a deposit overflows and the balance wraps to a negative value, breaking ledger consistency.

## Fix

Route all three additions through `safeAdd`, returning `types.ErrAmount` on overflow, consistent with the main ledger. The change is minimal and touches only the three affected functions.

The freeze/active cycle used by `checkBalance` is not affected: it only moves already-issued coins between `Balance` and `Frozen`, so the sum can never exceed `MaxTokenBalance` (verified by a dedicated test exercising the boundary).

## Tests

New regression tests in `account/execaccount_safeadd_test.go`:

- `TestExecDepositOverflowRejected`: overflowing `ExecDeposit` returns `types.ErrAmount`, balance unchanged
- `TestExecActiveOverflowRejected`: overflowing `ExecActive` rejected, balance and frozen unchanged
- `TestExecDepositFrozenOverflowRejected`: overflowing `execDepositFrozen` rejected, frozen unchanged
- `TestExecAccountNormalPathsWithSafeAdd`: normal deposit up to exactly `MaxTokenBalance`, freeze/active cycle at the cap, and `execDepositFrozen` at the cap all still succeed; a deposit beyond the cap is rejected

Verification: `go build ./...` (account and related packages; the only build errors come from the pre-existing `avalanchego` dependency/toolchain mismatch, unrelated to this change), `go test ./account/...` all pass.