### PR TITLE
fix(coins): add missing ExecDelLocal_Genesis to rollback genesis receiver stats

### DIFF
--- a/system/dapp/coins/executor/exec_del_local.go
+++ b/system/dapp/coins/executor/exec_del_local.go
@@ -35,3 +35,12 @@ func (c *Coins) ExecDelLocal_Withdraw(withdraw *types.AssetsWithdraw, tx *types.
 	}
 	return &types.LocalDBSet{KV: []*types.KeyValue{kv}}, nil
 }
+
+// ExecDelLocal_Genesis delete genesis of local exec
+func (c *Coins) ExecDelLocal_Genesis(gen *types.AssetsGenesis, tx *types.Transaction, receipt *types.ReceiptData, index int) (*types.LocalDBSet, error) {
+	kv, err := updateAddrReciver(c.GetLocalDB(), tx.GetRealToAddr(), gen.Amount, false)
+	if err != nil {
+		return nil, err
+	}
+	return &types.LocalDBSet{KV: []*types.KeyValue{kv}}, nil
+}

--- a/system/dapp/coins/executor/exec_del_local_test.go
+++ b/system/dapp/coins/executor/exec_del_local_test.go
@@ -1,0 +1,94 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/33cn/chain33/client"
+	"github.com/33cn/chain33/common/crypto"
+	"github.com/33cn/chain33/common/db"
+	"github.com/33cn/chain33/queue"
+	dtypes "github.com/33cn/chain33/system/dapp/coins/types"
+	"github.com/33cn/chain33/types"
+	"github.com/33cn/chain33/util"
+	"github.com/stretchr/testify/require"
+)
+
+var testCfg = types.NewChain33Config(types.GetDefaultCfgstring())
+
+const testCoinUnit = int64(1e8)
+
+func init() {
+	Init(driverName, testCfg, nil)
+}
+
+func initTestCoins(t *testing.T) (string, *Coins) {
+	q := queue.New("testcoinsdellocal")
+	q.SetConfig(testCfg)
+	api, err := client.New(q.Client(), nil)
+	require.Nil(t, err)
+	dbDir, stateDB, kvDB := util.CreateTestDB()
+	c := newCoins()
+	c.SetAPI(api)
+	c.SetStateDB(stateDB)
+	c.SetLocalDB(kvDB)
+	return dbDir, c.(*Coins)
+}
+
+func closeTestCoins(t *testing.T, dbDir string, c *Coins) {
+	util.CloseTestDB(dbDir, c.GetStateDB().(db.DB))
+}
+
+func signCoinsTx(priv crypto.PrivKey, to string, action *dtypes.CoinsAction) *types.Transaction {
+	tx := &types.Transaction{
+		Execer:  []byte("coins"),
+		Payload: types.Encode(action),
+		To:      to,
+		Fee:     int64(1e6),
+	}
+	tx.Sign(types.SECP256K1, priv)
+	return tx
+}
+
+func genesisAction(amount int64) *dtypes.CoinsAction {
+	return &dtypes.CoinsAction{
+		Ty:    dtypes.CoinsActionGenesis,
+		Value: &dtypes.CoinsAction_Genesis{Genesis: &types.AssetsGenesis{Amount: amount}},
+	}
+}
+
+// TestExecDelLocalGenesis checks that ExecDelLocal of a genesis tx reverts the
+// address receiver stat (LODB-coins-Addr:*) written by ExecLocal, so rolling
+// back a block at height 0 leaves no stale local data.
+func TestExecDelLocalGenesis(t *testing.T) {
+	dbDir, c := initTestCoins(t)
+	defer closeTestCoins(t, dbDir, c)
+
+	addr, _ := util.Genaddress()
+	_, priv := util.Genaddress()
+	c.SetEnv(0, 1539918074, 1)
+
+	tx := signCoinsTx(priv, addr, genesisAction(100*testCoinUnit))
+	receiptData := &types.ReceiptData{Ty: types.ExecOk}
+
+	// ExecLocal writes the address receiver stat
+	lset, err := c.ExecLocal(tx, receiptData, 0)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(lset.KV))
+	require.Nil(t, c.GetLocalDB().Set(lset.KV[0].Key, lset.KV[0].Value))
+	recv, err := getAddrReciver(c.GetLocalDB(), addr)
+	require.Nil(t, err)
+	require.Equal(t, 100*testCoinUnit, recv)
+
+	// ExecDelLocal must produce the rollback KV, and applying it reverts the stat
+	delSet, err := c.ExecDelLocal(tx, receiptData, 0)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(delSet.KV))
+	require.Nil(t, c.GetLocalDB().Set(delSet.KV[0].Key, delSet.KV[0].Value))
+	recv, err = getAddrReciver(c.GetLocalDB(), addr)
+	require.Nil(t, err)
+	require.Equal(t, int64(0), recv)
+}


### PR DESCRIPTION
## Problem

`system/dapp/coins/executor/exec_local.go:72-78` implements `ExecLocal_Genesis`, which writes the per-address receiver stat (`LODB-coins-Addr:*`) for genesis transactions. However, `system/dapp/coins/executor/exec_del_local.go` only implements `ExecDelLocal_Transfer`, `ExecDelLocal_TransferToExec` and `ExecDelLocal_Withdraw` — there is no `ExecDelLocal_Genesis`.

When a height-0 block is disconnected (reorg or local index rebuild), the dispatcher finds no matching `ExecDelLocal_Genesis` method and returns an empty KV set, so the genesis-written receiver stat is never reverted. Local data then becomes inconsistent with chain state — a funds-accounting correctness issue.

## Root Cause

The genesis action type was handled in `execLocal` but its symmetric rollback path in `exec_del_local.go` was simply missing.

## Fix

Add `ExecDelLocal_Genesis` in `system/dapp/coins/executor/exec_del_local.go`, mirroring `ExecLocal_Genesis` with `updateAddrReciver(..., isadd=false)`, consistent in style with the other `ExecDelLocal_*` methods. Minimal change, no refactoring.

## Regression Test

New test `TestExecDelLocalGenesis` in `system/dapp/coins/executor/exec_del_local_test.go`:

1. Executes `ExecLocal` on a genesis tx and applies the KV — receiver stat becomes the genesis amount.
2. Executes `ExecDelLocal`, asserts exactly one rollback KV is produced, applies it, and asserts the receiver stat returns to 0.

Verified: the test fails without the fix (`ExecDelLocal` returns 0 KVs) and passes with it. `go build ./...` and `go test ./system/dapp/coins/...` pass.