### PR TITLE
fix(coins): reject zero-amount transactions in CheckTx

### DIFF
--- a/system/dapp/coins/executor/coins.go
+++ b/system/dapp/coins/executor/coins.go
@@ -77,7 +77,7 @@ func (c *Coins) GetDriverName() string {
 	return driverName
 }
 
-// CheckTx check transaction amount 必须不能为负数
+// CheckTx check transaction amount 必须为正数
 func (c *Coins) CheckTx(tx *types.Transaction, index int) error {
 
 	//TODO 数额在账户操作中会做检测, 此处不需要(提升性能), 需要确认在现有链中是否有分叉
@@ -87,7 +87,7 @@ func (c *Coins) CheckTx(tx *types.Transaction, index int) error {
 		if err != nil {
 			return err
 		}
-		if amount < 0 {
+		if amount <= 0 {
 			return types.ErrAmount
 		}
 	}

--- a/system/dapp/coins/executor/coins_checktx_test.go
+++ b/system/dapp/coins/executor/coins_checktx_test.go
@@ -1,0 +1,92 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/33cn/chain33/client"
+	"github.com/33cn/chain33/common/crypto"
+	"github.com/33cn/chain33/queue"
+	dtypes "github.com/33cn/chain33/system/dapp/coins/types"
+	"github.com/33cn/chain33/types"
+	"github.com/33cn/chain33/util"
+	"github.com/stretchr/testify/require"
+)
+
+var checkTxCfg = types.NewChain33Config(types.GetDefaultCfgstring())
+
+func init() {
+	Init(driverName, checkTxCfg, nil)
+}
+
+func initCheckTxCoins(t *testing.T) *Coins {
+	q := queue.New("testcoinschecktx")
+	q.SetConfig(checkTxCfg)
+	api, err := client.New(q.Client(), nil)
+	require.Nil(t, err)
+	c := newCoins()
+	c.SetAPI(api)
+	return c.(*Coins)
+}
+
+func signCheckTx(priv crypto.PrivKey, to string, action *dtypes.CoinsAction) *types.Transaction {
+	tx := &types.Transaction{
+		Execer:  []byte("coins"),
+		Payload: types.Encode(action),
+		To:      to,
+		Fee:     int64(1e6),
+	}
+	tx.Sign(types.SECP256K1, priv)
+	return tx
+}
+
+func transferCheckTxAction(amount int64) *dtypes.CoinsAction {
+	return &dtypes.CoinsAction{
+		Ty:    dtypes.CoinsActionTransfer,
+		Value: &dtypes.CoinsAction_Transfer{Transfer: &types.AssetsTransfer{Amount: amount}},
+	}
+}
+
+// TestCheckTxZeroAmountTransfer 零金额转账必须在 CheckTx 层即被拒绝
+func TestCheckTxZeroAmountTransfer(t *testing.T) {
+	c := initCheckTxCoins(t)
+	_, priv := util.Genaddress()
+	to, _ := util.Genaddress()
+
+	tx := signCheckTx(priv, to, transferCheckTxAction(0))
+	err := c.CheckTx(tx, 0)
+	require.Equal(t, types.ErrAmount, err)
+}
+
+// TestCheckTxNegativeAmountTransfer 负金额转账仍被 CheckTx 拒绝
+func TestCheckTxNegativeAmountTransfer(t *testing.T) {
+	c := initCheckTxCoins(t)
+	_, priv := util.Genaddress()
+	to, _ := util.Genaddress()
+
+	tx := signCheckTx(priv, to, transferCheckTxAction(-1))
+	err := c.CheckTx(tx, 0)
+	require.Equal(t, types.ErrAmount, err)
+}
+
+// TestCheckTxNormalActionUnaffected 正常金额的 transfer/withdraw 不受 CheckTx 影响
+func TestCheckTxNormalActionUnaffected(t *testing.T) {
+	c := initCheckTxCoins(t)
+	_, priv := util.Genaddress()
+	to, _ := util.Genaddress()
+
+	transferTx := signCheckTx(priv, to, transferCheckTxAction(1))
+	require.Nil(t, c.CheckTx(transferTx, 0))
+
+	withdrawAction := &dtypes.CoinsAction{
+		Ty: dtypes.CoinsActionWithdraw,
+		Value: &dtypes.CoinsAction_Withdraw{
+			Withdraw: &types.AssetsWithdraw{ExecName: "ticket", Amount: 1},
+		},
+	}
+	withdrawTx := signCheckTx(priv, to, withdrawAction)
+	require.Nil(t, c.CheckTx(withdrawTx, 0))
+}


### PR DESCRIPTION
## Problem

In `system/dapp/coins/executor/coins.go` (lines 81-95), `Coins.CheckTx` only rejects transactions with `amount < 0`. Zero-amount coins transactions pass the mempool-level check and are only rejected later at the Exec layer by `account.CheckAmount`. This is a defense-in-depth gap: invalid zero-amount transactions (transfer, transferToExec, withdraw, genesis) can enter the mempool and waste resources before being discarded at execution time.

## Root Cause

The amount validation in `CheckTx` used `amount < 0` instead of `amount <= 0`, so a zero amount was treated as valid even though the Exec layer (`account.CheckAmount`) considers it invalid.

## Fix

Changed the condition in `Coins.CheckTx` from `amount < 0` to `amount <= 0`, so zero-amount transactions are rejected with `types.ErrAmount` at the earliest stage. The `DisableCheckTxAmount` sub-config logic is untouched: when enabled, the amount check is still skipped entirely. Positive-amount transactions of all action types (transfer, transferToExec, withdraw, genesis) are unaffected.

## Tests

Added `system/dapp/coins/executor/coins_checktx_test.go` with regression tests:

- `TestCheckTxZeroAmountTransfer`: zero-amount transfer is now rejected by `CheckTx` with `types.ErrAmount`.
- `TestCheckTxNegativeAmountTransfer`: negative-amount transfer is still rejected by `CheckTx`.
- `TestCheckTxNormalActionUnaffected`: positive-amount transfer and withdraw actions still pass `CheckTx`.

All tests in `./system/dapp/coins/...` pass.