### PR TITLE
fix(ci): exclude gg18 integration test from coverage to stop flaky timeouts

### DIFF
--- a/build/tools/coverage.sh
+++ b/build/tools/coverage.sh
@@ -5,7 +5,8 @@ set -e -o pipefail
 
 COVERAGE_DIR="${COVERAGE_DIR:-build/coverage}"
 PKG_LIST=$(go list ./... | grep -v "vendor" | grep -v "mock" | grep -v "mocks" \
-    | grep -v "cmd" | grep -v "types" | grep -v "nat" | grep -vE "pbft|snowman")
+    | grep -v "cmd" | grep -v "types" | grep -v "nat" | grep -vE "pbft|snowman" \
+    | grep -v "tss/gg18")
 
 # Create the coverage files directory
 mkdir -p "$COVERAGE_DIR"


### PR DESCRIPTION
## 问题

coverage job 周期性 flaky 失败:`TestGG18_4Node` 报 `timeout waiting for 4 peers, role node1`。

失败的 job(PR #1378 上):https://github.com/33cn/chain33/actions/runs/32441470936/job/96652865361 —— 而该 PR 只改了一个 GenesisInit 金额校验,与 gg18 毫无关系。同一 PR 的另一个 run 里 coverage 又通过了,确认是 flaky。

## 根因

`system/crypto/tss/gg18/gg18_integration_test.go` 是**全树唯一没有 `//go:build integration` 标签**的集成测试(其余 10 个 `*_integration_test.go` 都有标签)。因此它会被普通 `go test` 跑到,包括 `coverage.sh` 的 `-covermode=count` 插桩。

gg18 测试启动 4 个 DHT P2P 子进程。coverage 插桩让节点发现从正常约 30s 膨胀到超过 `waitPeerIDs` 的 150s 兜底超时(失败耗时 154.43s,刚好越过),于是 flaky 超时。

## 修复

从 `coverage.sh` 的包列表排除 `tss/gg18`。

理由:
- gg18 已有专门的 `test-gg18-integration` job(`go test -race -v -run ^TestGG18_4Node$`)完整覆盖,coverage 里再跑一遍纯属多余
- gg18 测试 fork 子进程,子进程的覆盖率本来就不会被收集,coverage 价值为零
- 排除后 coverage 不再 flaky

## 遗留(未在本 PR 处理)

根本问题是 `gg18_integration_test.go` 缺 build tag,违反了项目的集成测试规范。彻底修复需要:
1. 给它加 `//go:build integration`
2. `test-gg18-integration` job 加 `-tags integration`

第 2 步涉及改 `.github/workflows/build.yml`(项目规定改 CI 配置需确认),故本 PR 只做不碰 workflow 的最小修复。若认可,可后续补 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)