### PR TITLE
fix(account): stop sharing key buffer in accountReadKey

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -36,7 +36,6 @@ type DB struct {
 	execAccountKeyPerfix []byte
 	execer               string
 	symbol               string
-	accountKeyBuffer     []byte
 	cfg                  *types.Chain33Config
 }
 
@@ -66,8 +65,6 @@ func NewAccountDB(cfg *types.Chain33Config, execer string, symbol string, db dbm
 func newAccountDB(cfg *types.Chain33Config, prefix string) *DB {
 	acc := &DB{cfg: cfg}
 	acc.accountKeyPerfix = []byte(prefix)
-	acc.accountKeyBuffer = make([]byte, 0, len(acc.accountKeyPerfix)+64)
-	acc.accountKeyBuffer = append(acc.accountKeyBuffer, acc.accountKeyPerfix...)
 	acc.execAccountKeyPerfix = append([]byte(prefix), []byte("exec-")...)
 	//alog.Warn("NewAccountDB", "prefix", prefix, "key1", string(acc.accountKeyPerfix), "key2", string(acc.execAccountKeyPerfix))
 	return acc
@@ -79,10 +76,14 @@ func (acc *DB) SetDB(db dbm.KV) *DB {
 	return acc
 }
 
+// accountReadKey builds the state db key for addr. A fresh slice is returned
+// on every call: reusing a shared buffer here is unsafe under concurrent
+// LoadAccount calls on the same *DB (the backing array gets overwritten while
+// another goroutine's db.Get is still reading it).
 func (acc *DB) accountReadKey(addr string) []byte {
-	acc.accountKeyBuffer = acc.accountKeyBuffer[0:len(acc.accountKeyPerfix)]
-	acc.accountKeyBuffer = append(acc.accountKeyBuffer, address.FormatAddrKey(addr)...)
-	return acc.accountKeyBuffer
+	key := make([]byte, 0, len(acc.accountKeyPerfix)+len(addr)+4)
+	key = append(key, acc.accountKeyPerfix...)
+	return append(key, address.FormatAddrKey(addr)...)
 }
 
 // LoadAccount 根据地址载入账户

--- a/account/account_readkey_race_test.go
+++ b/account/account_readkey_race_test.go
@@ -1,0 +1,65 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package account
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/33cn/chain33/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadAccountConcurrentRace hammers LoadAccount from many goroutines on a
+// single *DB. Before the fix, accountReadKey reused a shared backing array
+// (DB.accountKeyBuffer), so concurrent loads overwrote each other's key while
+// db.Get was still reading it — a data race (go test -race) and a potential
+// wrong-account read. After the fix every call builds a fresh key slice.
+func TestLoadAccountConcurrentRace(t *testing.T) {
+	acc := newTestCoinsDB(t)
+
+	const nAccounts = 8
+	addrs := make([]string, nAccounts)
+	for i := 0; i < nAccounts; i++ {
+		addrs[i] = fmt.Sprintf("%s%02d", addr1[:len(addr1)-2], i)
+		balance := int64(100+i) * types.DefaultCoinPrecision
+		acc.SaveAccount(&types.Account{Addr: addrs[i], Balance: balance})
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, nAccounts*4)
+	for g := 0; g < nAccounts*2; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			addr := addrs[g%nAccounts]
+			want := int64(100+g%nAccounts) * types.DefaultCoinPrecision
+			for i := 0; i < 200; i++ {
+				a := acc.LoadAccount(addr)
+				if a.GetBalance() != want {
+					errCh <- fmt.Errorf("addr %s: got balance %d, want %d", addr, a.GetBalance(), want)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}
+
+// TestAccountReadKeyIndependent verifies the returned key slice does not
+// change when a subsequent key is built (no shared backing array).
+func TestAccountReadKeyIndependent(t *testing.T) {
+	acc := newTestCoinsDB(t)
+	key1 := acc.accountReadKey(addr1)
+	key1Copy := append([]byte(nil), key1...)
+	_ = acc.accountReadKey(addr2)
+	require.Equal(t, key1Copy, key1, "previously returned key must not be mutated by later calls")
+	require.NotEqual(t, acc.accountReadKey(addr1), acc.accountReadKey(addr2))
+}


### PR DESCRIPTION
## Problem

`accountReadKey` (`account/account.go`) reused `DB.accountKeyBuffer` across calls:

```go
acc.accountKeyBuffer = acc.accountKeyBuffer[0:len(acc.accountKeyPerfix)]
acc.accountKeyBuffer = append(acc.accountKeyBuffer, address.FormatAddrKey(addr)...)
return acc.accountKeyBuffer
```

Two hazards:

1. **Data race**: concurrent `LoadAccount` calls on the same `*DB` overwrite the shared backing array while another goroutine's `db.Get` is still reading it. Reproduced with `go test -race` → `WARNING: DATA RACE` (before the fix).
2. **Aliasing**: a previously returned key slice is mutated by the next call, so any caller retaining the key observes it change underneath.

`execAccountKey` already allocates a fresh slice per call; `accountReadKey` was the outlier.

## Fix

- `accountReadKey` now builds a fresh slice per call (same style as `execAccountKey`).
- Removed the now-unused `accountKeyBuffer` field from `DB`.

## Tests

- `TestLoadAccountConcurrentRace`: 16 goroutines × 200 `LoadAccount` iterations over 8 seeded accounts; fails with `DATA RACE` under `-race` on the old code, clean after the fix.
- `TestAccountReadKeyIndependent`: a previously returned key must not be mutated by later calls.
- `go vet`, `gofmt -s`, `goimports` clean; full `go test ./account/` passes.