### PR TITLE
fix(ci): use built-in GITHUB_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/automake.yml
+++ b/.github/workflows/automake.yml
@@ -40,7 +40,7 @@ jobs:
             @semantic-release/changelog
             @semantic-release/git
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Do something when a new release published
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             @semantic-release/changelog@6
             @semantic-release/git@10
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Do something when a new release published
         if: steps.semantic.outputs.new_release_published == 'true'


### PR DESCRIPTION
## 问题

`release.yml` / `automake.yml` 的 Semantic Release 步骤在 push 到 master 时失败:

```
ENOGHTOKEN No GitHub token specified.
EGITNOPERMISSION Cannot push to the Git repository.
```

## 根因

workflow 引用了 `secrets.GH_TOKEN`,但仓库当前 secrets 数为 **0**,该 secret 不存在(为空值)。语义发布的 `@semantic-release/git` 插件拿不到凭证,无法把版本提交/tag 推回 master。

## 修复

把两处 token 从自定义 secret 切到 GitHub 内置 token:

- `GH_TOKEN: ${{ secrets.GH_TOKEN }}` → `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`

内置 `GITHUB_TOKEN` 每次运行自动注入,且仓库已具备 `contents: write` 权限,可正常推送。

## 副作用说明

用 `GITHUB_TOKEN` 推送时 GitHub 会抑制级联 workflow —— 语义发布推上去的版本提交/tag 不会再触发 `build.yml`(原来用 PAT 时会触发)。若发布提交仍需跑一遍 `build.yml` 做 CI 校验,后续可考虑在仓库重新添加 `GH_TOKEN` PAT secret。

🤖 Generated with [Claude Code](https://claude.com/claude-code)