### PR TITLE
fix(ci): switch semantic-release preset from jshint to angular

### DIFF
--- a/.github/workflows/automake.yml
+++ b/.github/workflows/automake.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           branch: master
           extra_plugins: |
-            conventional-changelog/conventional-changelog-jshint
             semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           branch: master
           extra_plugins: |
-            conventional-changelog/conventional-changelog-jshint
             semantic-release-replace-plugin@1.2.7
             @semantic-release/exec@6
             @semantic-release/changelog@6

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -3,13 +3,13 @@
     [
         "@semantic-release/commit-analyzer",
       {
-        "preset": "jshint"
+        "preset": "angular"
       }
     ],
     [
         "@semantic-release/release-notes-generator",
       {
-        "preset": "jshint"
+        "preset": "angular"
       }
     ],
     [


### PR DESCRIPTION
## 问题

token 修复合入 master 后,语义发布在 `analyzeCommits` 阶段崩溃(之前被 token 错误掩盖):

```
TypeError: Cannot read properties of undefined (reading 'parser')
    at load-parser-config.js:33:28
```

## 根因

`.releaserc.yml` 里 `preset: "jshint"`,而 workflow 的 `extra_plugins` 写的是 GitHub 简写 `conventional-changelog/conventional-changelog-jshint`。该简写现已解析到 2016 年的归档 v0.1.0(CommonJS、回调式 API,返回 `{parserOpts, writerOpts}`),与 modern `@semantic-release/commit-analyzer` v13(期望 ESM、返回 `{parser, writer, whatBump}`)不兼容,导致 `loadedConfig` 为 `undefined`,访问 `.parser` 崩溃。

此外,仓库的提交一直是 Angular 约定(`type(scope): subject`,如 `fix(ci): ...` / `feat: ...`),CHANGELOG 也是 `### Features` / `### Bug Fixes` 的 Angular 风格;而 `jshint` 预设的 header 格式是 `[[Type]] description`,根本匹配不到这些提交。即使修好加载,也会解析不到任何可发布提交。

## 修复

1. `.releaserc.yml`:commit-analyzer 与 release-notes-generator 的 `preset` 从 `jshint` 改为 `angular`(commit-analyzer 内置,无需 extra plugin)。
2. `release.yml` / `automake.yml`:移除已损坏的 `extra_plugins` 条目 `conventional-changelog/conventional-changelog-jshint`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)